### PR TITLE
feat: chips

### DIFF
--- a/lib/controllers/interact.ts
+++ b/lib/controllers/interact.ts
@@ -12,7 +12,7 @@ class InteractController extends AbstractController {
   }
 
   async handler(req: Request<{ versionID: string }, null, { state?: State; request?: GeneralRequest }, { locale?: string }>) {
-    const { runtime, metrics, nlu, tts, dialog, asr, state: stateManager } = this.services;
+    const { runtime, metrics, nlu, tts, chips, dialog, asr, state: stateManager } = this.services;
 
     metrics.generalRequest();
 
@@ -23,7 +23,7 @@ class InteractController extends AbstractController {
     } = req;
 
     const turn = new TurnBuilder<Context>(stateManager);
-    turn.addHandlers(asr, nlu, dialog, runtime).addHandlers(tts);
+    turn.addHandlers(asr, nlu, dialog, runtime).addHandlers(tts, chips);
 
     return turn.handle({ state, request, versionID, data: { locale } });
   }

--- a/lib/services/chips/index.ts
+++ b/lib/services/chips/index.ts
@@ -1,21 +1,41 @@
+import { PrototypeModel } from '@voiceflow/api-sdk';
 import { TraceType } from '@voiceflow/general-types';
-import { TraceFrame as SpeakTrace } from '@voiceflow/general-types/build/nodes/speak';
 import _ from 'lodash';
 
 import { Context, ContextHandler } from '@/types';
 
 import { AbstractManager, injectServices } from '../utils';
+import { getChoiceChips } from './utils';
 
-export const utils = {};
+export const utils = {
+  getChoiceChips,
+};
 
 @injectServices({ utils })
 class Chips extends AbstractManager<{ utils: typeof utils }> implements ContextHandler {
   handle = async (context: Context) => {
     if (!context.trace) context.trace = [];
 
+    let model: PrototypeModel | undefined;
+    const getModel = async () => {
+      if (!model) {
+        const { prototype } = await this.services.dataAPI.getVersion(context.versionID);
+        model = prototype?.model || { intents: [], slots: [] };
+      }
+      return model!;
+    };
+
     const trace = await Promise.all(
       context.trace.map(async (frame) => {
-        return frame;
+        if (frame.type !== TraceType.CHOICE) {
+          return frame;
+        }
+        return {
+          ...frame,
+          payload: {
+            choices: getChoiceChips(frame.payload.choices, await getModel()),
+          },
+        };
       })
     );
 

--- a/lib/services/chips/index.ts
+++ b/lib/services/chips/index.ts
@@ -1,0 +1,29 @@
+import { TraceType } from '@voiceflow/general-types';
+import { TraceFrame as SpeakTrace } from '@voiceflow/general-types/build/nodes/speak';
+import _ from 'lodash';
+
+import { Context, ContextHandler } from '@/types';
+
+import { AbstractManager, injectServices } from '../utils';
+
+export const utils = {};
+
+@injectServices({ utils })
+class Chips extends AbstractManager<{ utils: typeof utils }> implements ContextHandler {
+  handle = async (context: Context) => {
+    if (!context.trace) context.trace = [];
+
+    const trace = await Promise.all(
+      context.trace.map(async (frame) => {
+        return frame;
+      })
+    );
+
+    return {
+      ...context,
+      trace,
+    };
+  };
+}
+
+export default Chips;

--- a/lib/services/chips/utils.ts
+++ b/lib/services/chips/utils.ts
@@ -1,39 +1,75 @@
 import { PrototypeModel } from '@voiceflow/api-sdk';
-import { replaceVariables } from '@voiceflow/runtime';
 import _ from 'lodash';
 
-type Chip = { name: string };
-// eslint-disable-next-line import/prefer-default-export
+import { replaceVariables } from '../dialog/utils';
+
+type Chip = { intent?: string; name: string };
+type Utterance = { text: string; slots?: string[] };
+
+export const sampleUtterance = (utterances: Utterance[], model: PrototypeModel, index = 0) => {
+  let slotMap: Record<string, string> = {};
+  const utterance =
+    // ensure every slot in the utterance can be filled with a dummy value
+    utterances.find(({ slots = [] }) => {
+      let i = index;
+      slotMap = {};
+
+      return slots.every((utteranceSlot) => {
+        // find an random sample for each slot in the intent
+        const slot = model.slots.find(({ key }) => key === utteranceSlot);
+        const sample = slot?.inputs[i % slot.inputs.length]?.split(',')[0];
+        if (!sample) return false;
+
+        i++;
+        slotMap[slot!.name] = sample;
+
+        return true;
+      });
+    })?.text;
+
+  return utterance ? replaceVariables(utterance, slotMap).trim() : '';
+};
+
+// generate multiple chips with slot variations from provided utterances
+export const generateVariations = (utterances: Utterance[], model: PrototypeModel, variations = 3): Chip[] => {
+  const chips: Chip[] = [];
+
+  for (let i = 0; i < variations; i++) {
+    const utterance = utterances[i % utterances.length];
+    if (utterance) {
+      const name = sampleUtterance([utterance], model, i);
+
+      if (name) {
+        chips.push({ name });
+      }
+    }
+  }
+
+  return _.uniqBy(chips, (chip) => chip.name);
+};
+
 export const getChoiceChips = (rawChoices: Chip[], model: PrototypeModel): Chip[] => {
   const chips: Chip[] = [];
 
   rawChoices.forEach((choice) => {
-    const intent = model.intents.find(({ name }) => name === choice.name);
-    if (intent) {
+    const chip: Chip = { ...choice };
+
+    // use intent to generate a sample utterance
+    if (choice.intent) {
+      const intent = model.intents.find(({ name }) => name === choice.intent);
+      if (!intent) return;
+
       // order utterances by least number of slots
       const utterances = intent.inputs.sort((a, b) => (a.slots?.length || 0) - (b.slots?.length || 0));
 
       // find an utterance can have slots filled
-      let slotMap: Record<string, string> = {};
-      const utterance = utterances.find(({ slots = [] }) => {
-        slotMap = {};
-        // eslint-disable-next-line no-restricted-syntax
-        for (const utteranceSlot of slots) {
-          // find an input sample for each slot in the intent
-          const slot = model.slots.find(({ name }) => name === utteranceSlot);
-          const sampleInput = _.sample(slot?.inputs || []);
-          if (!sampleInput) return false;
+      chip.name = sampleUtterance(utterances, model);
+    }
 
-          slotMap[slot!.name] = sampleInput;
-        }
-        return true;
-      });
-
-      if (utterance) {
-        chips.push({ name: replaceVariables(utterance.text, slotMap) });
-      }
+    if (chip.name) {
+      chips.push(chip);
     }
   });
 
-  return chips;
+  return _.uniqBy(chips, (chip) => chip.name);
 };

--- a/lib/services/chips/utils.ts
+++ b/lib/services/chips/utils.ts
@@ -1,0 +1,39 @@
+import { PrototypeModel } from '@voiceflow/api-sdk';
+import { replaceVariables } from '@voiceflow/runtime';
+import _ from 'lodash';
+
+type Chip = { name: string };
+// eslint-disable-next-line import/prefer-default-export
+export const getChoiceChips = (rawChoices: Chip[], model: PrototypeModel): Chip[] => {
+  const chips: Chip[] = [];
+
+  rawChoices.forEach((choice) => {
+    const intent = model.intents.find(({ name }) => name === choice.name);
+    if (intent) {
+      // order utterances by least number of slots
+      const utterances = intent.inputs.sort((a, b) => (a.slots?.length || 0) - (b.slots?.length || 0));
+
+      // find an utterance can have slots filled
+      let slotMap: Record<string, string> = {};
+      const utterance = utterances.find(({ slots = [] }) => {
+        slotMap = {};
+        // eslint-disable-next-line no-restricted-syntax
+        for (const utteranceSlot of slots) {
+          // find an input sample for each slot in the intent
+          const slot = model.slots.find(({ name }) => name === utteranceSlot);
+          const sampleInput = _.sample(slot?.inputs || []);
+          if (!sampleInput) return false;
+
+          slotMap[slot!.name] = sampleInput;
+        }
+        return true;
+      });
+
+      if (utterance) {
+        chips.push({ name: replaceVariables(utterance.text, slotMap) });
+      }
+    }
+  });
+
+  return chips;
+};

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -2,6 +2,7 @@ import { Config } from '@/types';
 
 import { ClientMap } from '../clients';
 import ASR from './asr';
+import Chips from './chips';
 import Dialog from './dialog';
 import NLU from './nlu';
 import Runtime from './runtime';
@@ -15,6 +16,7 @@ export interface ServiceMap {
   nlu: NLU;
   dialog: Dialog;
   tts: TTS;
+  chips: Chips;
 }
 
 export interface FullServiceMap extends ClientMap, ServiceMap {}
@@ -33,6 +35,7 @@ const buildServices = (config: Config, clients: ClientMap): FullServiceMap => {
   services.nlu = new NLU(services, config);
   services.tts = new TTS(services, config);
   services.dialog = new Dialog(services, config);
+  services.chips = new Chips(services, config);
 
   return services;
 };

--- a/lib/services/runtime/handlers/interaction.ts
+++ b/lib/services/runtime/handlers/interaction.ts
@@ -27,8 +27,9 @@ export const InteractionHandler: HandlerFactory<Node, typeof utilsObj> = (utils)
       runtime.trace.addTrace<TraceFrame>({
         type: TraceType.CHOICE,
         payload: {
-          choices: node.interactions.reduce<{ name: string }[]>((acc, interaction) => {
-            if (interaction.event.type === EventType.INTENT) acc.push({ name: interaction.event.intent });
+          choices: node.interactions.reduce<{ name: string; intent?: string }[]>((acc, interaction) => {
+            const { intent } = interaction.event;
+            if (interaction.event.type === EventType.INTENT) acc.push({ intent, name: intent });
             return acc;
           }, []),
         },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@voiceflow/api-sdk": "^1.20.0",
     "@voiceflow/backend-utils": "^2.1.1",
     "@voiceflow/common": "^6.2.0",
-    "@voiceflow/general-types": "1.16.0",
+    "@voiceflow/general-types": "1.16.1",
     "@voiceflow/logger": "^1.4.2",
     "@voiceflow/natural-language-commander": "^0.5.0",
     "@voiceflow/runtime": "1.17.1",

--- a/tests/lib/controllers/interact.unit.ts
+++ b/tests/lib/controllers/interact.unit.ts
@@ -15,6 +15,7 @@ describe('interact controller unit tests', () => {
         asr: { handle: sinon.stub().resolves(output('asr')) },
         nlu: { handle: sinon.stub().resolves(output('nlu')) },
         tts: { handle: sinon.stub().resolves(output('tts')) },
+        chips: { handle: sinon.stub().resolves(output('chips')) },
         runtime: { handle: sinon.stub().resolves(output('runtime')) },
         dialog: { handle: sinon.stub().resolves(output('dialog')) },
         metrics: { generalRequest: sinon.stub() },
@@ -22,7 +23,7 @@ describe('interact controller unit tests', () => {
 
       const interactController = new Interact(services as any, null as any);
 
-      expect(await interactController.handler(req as any)).to.eql(output('tts'));
+      expect(await interactController.handler(req as any)).to.eql(output('chips'));
 
       expect(services.state.handle.args).to.eql([[context]]);
       expect(services.asr.handle.args).to.eql([[output('state')]]);
@@ -30,6 +31,7 @@ describe('interact controller unit tests', () => {
       expect(services.dialog.handle.args).to.eql([[output('nlu')]]);
       expect(services.runtime.handle.args).to.eql([[output('dialog')]]);
       expect(services.tts.handle.args).to.eql([[output('runtime')]]);
+      expect(services.chips.handle.args).to.eql([[output('tts')]]);
       expect(services.metrics.generalRequest.callCount).to.eql(1);
     });
   });

--- a/tests/lib/services/dialog/fixture.ts
+++ b/tests/lib/services/dialog/fixture.ts
@@ -66,6 +66,7 @@ export const mockDMContext: Context = {
   request: mockUnfulfilledIntentRequest,
   versionID: '5ff486b75b99f8b36505ecfd',
   trace: [],
+  data: {},
 };
 
 export const mockRegularContext: Context = {
@@ -78,6 +79,7 @@ export const mockRegularContext: Context = {
   request: mockUnfulfilledIntentRequest,
   versionID: '5ff486b75b99f8b36505ecfd',
   trace: [],
+  data: {},
 };
 
 export const mockLM = {

--- a/tests/lib/services/dialog/index.unit.ts
+++ b/tests/lib/services/dialog/index.unit.ts
@@ -166,15 +166,22 @@ describe('dialog manager unit tests', () => {
       it('returns the required entity prompt defined in the LM', async () => {
         const result = await dm.handle(mockRegularContext);
 
-        const expectedTrace = {
-          type: 'speak',
-          payload: {
-            message: 'what flavor?',
+        const expectedTrace = [
+          {
+            type: 'speak',
+            payload: {
+              message: 'what flavor?',
+            },
           },
-        };
+          {
+            type: 'choice',
+            payload: {
+              choices: [{ name: 'bbq' }, { name: 'spicy wings' }, { name: 'I want honey garlic' }],
+            },
+          },
+        ];
         expect(result.end).to.be.true;
-        expect(result.trace?.length).to.be.equal(1);
-        expect(result.trace![0]).to.be.deep.equal(expectedTrace);
+        expect(result.trace).to.eql(expectedTrace);
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1078,10 +1078,10 @@
   dependencies:
     "@voiceflow/api-sdk" "1.20.0"
 
-"@voiceflow/general-types@1.16.0":
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.16.0.tgz#14b6e7fbe766d067d635f136e97c7ad83bb40de6"
-  integrity sha512-x+7An94NuyGy7cM1LApxQvRYsI0cOge4CQQDrASyfOXavjGlpkZlFThZzHvIGQZkmKQeh/VZwxSQqBom+qxdwQ==
+"@voiceflow/general-types@1.16.1":
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.16.1.tgz#259356c5a079a6c4cc669e96638a409bacfbd703"
+  integrity sha512-/P0Htzz8JMLMNSTYatTo72EUbaskCKQjcw6vYrwTDuyLvOVk6vOz3mQhZD+wEmqghs9PuLQfpLITlkCpB4xLSQ==
   dependencies:
     "@voiceflow/api-sdk" "1.20.0"
 


### PR DESCRIPTION
so what I wanted to do here:

To show a chip for an intent, we show the utterance with the minimal number of potential slots: 
"I want pizza" over "I want a {small} pizza"

For dialog management, show up to 3 choices to fill in the slots. So if it asks "what size do you want your pizza?"
the chips you would get are "small" "medium" and "large"

this behavior used to be handled in the frontend here, but has now been enhanced:
https://github.com/voiceflow/creator-app/blob/859c14317c5a92bf258457dfe9724dd29acd1c64/src/pages/Prototype/PrototypeTool/utils/intent.ts