### PR TITLE
feat: nlc dm

### DIFF
--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -1,4 +1,4 @@
-import { PrototypeModel, Version } from '@voiceflow/api-sdk';
+import { PrototypeModel } from '@voiceflow/api-sdk';
 import { GeneralTrace, IntentRequest, TraceType } from '@voiceflow/general-types';
 import _ from 'lodash';
 
@@ -6,18 +6,11 @@ import logger from '@/logger';
 import { Context, ContextHandler } from '@/types';
 
 import { generateVariations } from '../chips/utils';
+import { handleNLCDialog } from '../nlu/nlc';
+import { getNoneIntentRequest } from '../nlu/utils';
 import { isIntentRequest } from '../runtime/types';
 import { AbstractManager, injectServices } from '../utils';
-import {
-  dmNLCModel,
-  dmPrefix,
-  fillStringEntities,
-  getDMPrefixIntentName,
-  getIntentEntityList,
-  getNoneIntentRequest,
-  getUnfulfilledEntity,
-  VF_DM_PREFIX,
-} from './utils';
+import { dmPrefix, fillStringEntities, getDMPrefixIntentName, getIntentEntityList, getUnfulfilledEntity, VF_DM_PREFIX } from './utils';
 
 export const utils = {};
 
@@ -102,7 +95,9 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
 
       const dmPrefixedResult = await this.services.nlu.predict({
         query: `${dmPrefix(dmStateStore.intentRequest.payload.intent.name)} ${incomingRequest.payload.query}`,
+        model: version.prototype.model,
         projectID: version.projectID,
+        dmIntent: dmStateStore.intentRequest,
       });
 
       const isFallback = this.handleDMContext(dmStateStore, dmPrefixedResult, incomingRequest, version.prototype.model);

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -6,7 +6,6 @@ import logger from '@/logger';
 import { Context, ContextHandler } from '@/types';
 
 import { generateVariations } from '../chips/utils';
-import { handleNLCDialog } from '../nlu/nlc';
 import { getNoneIntentRequest } from '../nlu/utils';
 import { isIntentRequest } from '../runtime/types';
 import { AbstractManager, injectServices } from '../utils';

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -94,6 +94,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
       logger.debug('@DM - In dialog management context');
 
       const { query } = incomingRequest.payload;
+
       try {
         const dmPrefixedResult = await this.services.nlu.predict({
           query: `${dmPrefix(dmStateStore.intentRequest.payload.intent.name)} ${query}`,
@@ -110,11 +111,14 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
         }
       } catch (err) {
         const resultNLC = handleNLCDialog(query, dmStateStore.intentRequest, version.prototype.model);
-        if (resultNLC.payload.intent.name === NONE_INTENT)
+
+        if (resultNLC.payload.intent.name === NONE_INTENT) {
           return {
             ...DialogManagement.setDMStore(context, undefined),
             request: getNoneIntentRequest(query),
           };
+        }
+
         dmStateStore.intentRequest = resultNLC;
       }
     } else {
@@ -130,6 +134,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
     // Are there any unfulfilled required entities?
     // We need to use the stored DM state here to ensure that previously fulfilled entities are also considered!
     const unfulfilledEntity = getUnfulfilledEntity(dmStateStore!.intentRequest, version.prototype.model);
+
     if (unfulfilledEntity) {
       // There are unfulfilled required entities -> return dialog management prompt
       // Assemble return string by populating the inline entity values

--- a/lib/services/dialog/utils.ts
+++ b/lib/services/dialog/utils.ts
@@ -47,18 +47,6 @@ export const getDMPrefixIntentName = (intentName: string) => {
   return `${VF_DM_PREFIX}${dmPrefix(intentName)}_${intentName}`;
 };
 
-export const NONE_INTENT = 'None';
-export const getNoneIntentRequest = (query = ''): IntentRequest => ({
-  type: RequestType.INTENT,
-  payload: {
-    query,
-    intent: {
-      name: NONE_INTENT,
-    },
-    entities: [],
-  },
-});
-
 export const getIntentEntityList = (intentName: string, model: PrototypeModel) => {
   const intentModel = model.intents.find((intent) => intent.name === intentName);
   const intentEntityIDs = intentModel?.slots?.map((entity) => entity.id);

--- a/lib/services/dialog/utils.ts
+++ b/lib/services/dialog/utils.ts
@@ -1,5 +1,5 @@
 import { PrototypeModel } from '@voiceflow/api-sdk';
-import { IntentRequest, RequestType, SLOT_REGEXP } from '@voiceflow/general-types';
+import { IntentRequest, SLOT_REGEXP } from '@voiceflow/general-types';
 import * as crypto from 'crypto';
 
 export const VF_DM_PREFIX = 'dm_';

--- a/lib/services/dialog/utils.ts
+++ b/lib/services/dialog/utils.ts
@@ -2,15 +2,12 @@ import { PrototypeModel } from '@voiceflow/api-sdk';
 import { IntentRequest, RequestType, SLOT_REGEXP } from '@voiceflow/general-types';
 import * as crypto from 'crypto';
 
-import { Context } from '@/types';
-
 export const VF_DM_PREFIX = 'dm_';
 
 export const getSlotNameByID = (id: string, model: PrototypeModel) => {
   return model.slots.find((lmEntity) => lmEntity.key === id)?.name;
 };
 
-// Find one unfulfilled entity (if exists) on the current classified intent with the DM stored state
 export const getUnfulfilledEntity = (intentRequest: IntentRequest, model: PrototypeModel) => {
   const intentModel = model.intents.find((intent) => intent.name === intentRequest.payload.intent.name);
   const extractedEntities = intentRequest.payload.entities;
@@ -50,24 +47,17 @@ export const getDMPrefixIntentName = (intentName: string) => {
   return `${VF_DM_PREFIX}${dmPrefix(intentName)}_${intentName}`;
 };
 
-export const fallbackIntent = (context: Context) => {
-  const incomingRequest = context.request as IntentRequest;
-  const intentRequest: IntentRequest = {
-    type: RequestType.INTENT,
-    payload: {
-      query: incomingRequest.payload.query,
-      intent: {
-        name: 'None',
-      },
-      entities: [],
+export const NONE_INTENT = 'None';
+export const getNoneIntentRequest = (query = ''): IntentRequest => ({
+  type: RequestType.INTENT,
+  payload: {
+    query,
+    intent: {
+      name: NONE_INTENT,
     },
-  };
-  return {
-    ...context,
-    request: intentRequest,
-    state: { ...context.state, storage: { ...context.state.storage, dm: undefined } },
-  };
-};
+    entities: [],
+  },
+});
 
 export const getIntentEntityList = (intentName: string, model: PrototypeModel) => {
   const intentModel = model.intents.find((intent) => intent.name === intentName);

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -3,27 +3,15 @@ import { IntentRequest, RequestType } from '@voiceflow/general-types';
 
 import { Context, ContextHandler } from '@/types';
 
+import { getNoneIntentRequest } from '../dialog/utils';
 import { AbstractManager, injectServices } from '../utils';
 import { handleNLCCommand } from './nlc';
 
 export const utils = {};
 
-export const EMPTY_INTENT = '_empty';
-
 @injectServices({ utils })
 class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHandler {
-  static getEmptyIntentRequest(): IntentRequest {
-    return {
-      type: RequestType.INTENT,
-      payload: {
-        query: '',
-        intent: { name: EMPTY_INTENT },
-        entities: [],
-      },
-    };
-  }
-
-  async predict({ query, model, nlcQuery = query, projectID }: { query: string; model?: PrototypeModel; nlcQuery?: string; projectID: string }) {
+  async predict({ query, model, projectID }: { query: string; model?: PrototypeModel; projectID: string }) {
     try {
       const { data } = await this.services.axios.post<IntentRequest>(`${this.config.GENERAL_SERVICE_ENDPOINT}/runtime/${projectID}/predict`, {
         query,
@@ -34,10 +22,9 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
       if (!model) {
         throw new Error('Model not found!');
       }
+      const request = await handleNLCCommand(query, model);
 
-      const request = await handleNLCCommand(nlcQuery, model);
-
-      return request || NLU.getEmptyIntentRequest();
+      return request || getNoneIntentRequest();
     }
   }
 
@@ -50,7 +37,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     if (!context.request.payload) {
       return {
         ...context,
-        request: NLU.getEmptyIntentRequest(),
+        request: getNoneIntentRequest(),
       };
     }
 

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -4,14 +4,14 @@ import { IntentRequest, RequestType } from '@voiceflow/general-types';
 import { Context, ContextHandler } from '@/types';
 
 import { AbstractManager, injectServices } from '../utils';
-import { handleNLCCommand, handleNLCDialog } from './nlc';
+import { handleNLCCommand } from './nlc';
 import { getNoneIntentRequest } from './utils';
 
 export const utils = {};
 
 @injectServices({ utils })
 class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHandler {
-  async predict({ query, model, projectID, dmIntent }: { query: string; model?: PrototypeModel; projectID: string; dmIntent?: IntentRequest }) {
+  async predict({ query, model, projectID }: { query: string; model?: PrototypeModel; projectID: string }) {
     try {
       const { data } = await this.services.axios.post<IntentRequest>(`${this.config.GENERAL_SERVICE_ENDPOINT}/runtime/${projectID}/predict`, {
         query,
@@ -21,9 +21,6 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     } catch (err) {
       if (!model) {
         throw new Error('Model not found!');
-      }
-      if (dmIntent) {
-        return handleNLCDialog(query, dmIntent, model);
       }
 
       return handleNLCCommand(query, model);

--- a/lib/services/nlu/nlc.ts
+++ b/lib/services/nlu/nlc.ts
@@ -1,10 +1,13 @@
 import { PrototypeModel } from '@voiceflow/api-sdk';
 import { utils } from '@voiceflow/common';
 import { IntentRequest, RequestType } from '@voiceflow/general-types';
-import NLC, { IIntentSlot } from '@voiceflow/natural-language-commander';
+import NLC, { IIntentFullfilment, IIntentSlot } from '@voiceflow/natural-language-commander';
+import { getRequired } from '@voiceflow/natural-language-commander/dist/lib/standardSlots';
 import _ from 'lodash';
 
 import logger from '@/logger';
+
+import { getNoneIntentRequest } from './utils';
 
 const { getUtterancesWithSlotNames } = utils.intent;
 
@@ -65,23 +68,43 @@ export const registerIntents = (nlc: NLC, { slots, intents }: PrototypeModel) =>
   });
 };
 
-export const handleNLCCommand = (query: string, model: PrototypeModel): null | IntentRequest => {
+const createNLC = (model: PrototypeModel) => {
   const nlc = new NLC();
-
   registerSlots(nlc, model);
-
   registerIntents(nlc, model);
 
-  const intent = nlc.handleCommand(query);
+  return nlc;
+};
 
-  return !intent
-    ? null
-    : {
-        type: RequestType.INTENT,
-        payload: {
-          query,
-          intent: { name: intent.intent },
-          entities: intent.slots.map(({ name, value }) => ({ name, value: value || name })),
-        },
-      };
+const nlcToIntent = (intent: IIntentFullfilment | null, query = ''): IntentRequest =>
+  (intent && {
+    type: RequestType.INTENT,
+    payload: {
+      query,
+      intent: { name: intent.intent },
+      entities: intent.slots.map(({ name, value }) => ({ name, value: value || name })),
+    },
+  }) ||
+  getNoneIntentRequest();
+
+export const handleNLCCommand = (query: string, model: PrototypeModel): IntentRequest => {
+  const nlc = createNLC(model);
+
+  return nlcToIntent(nlc.handleCommand(query));
+};
+
+export const handleNLCDialog = (query: string, dmRequest: IntentRequest, model: PrototypeModel): IntentRequest => {
+  const nlc = createNLC(model);
+
+  const intentName = dmRequest.payload.intent.name;
+  const filledEntities = dmRequest.payload.entities;
+
+  // turn the dmRequest into IIntentFullfilment
+  const fulfillment: IIntentFullfilment = {
+    intent: intentName,
+    slots: filledEntities,
+    required: getRequired(nlc.getIntent(intentName)?.slots || [], filledEntities),
+  };
+
+  return nlcToIntent(nlc.handleDialog(fulfillment, query), query);
 };

--- a/lib/services/nlu/nlc.ts
+++ b/lib/services/nlu/nlc.ts
@@ -83,10 +83,7 @@ const nlcToIntent = (intent: IIntentFullfilment | null, query = ''): IntentReque
       query,
       intent: { name: intent.intent },
       // only add entity if value is defined
-      entities: intent.slots.reduce<{ name: string; value: string }[]>((acc, { name, value }) => {
-        if (value) acc.push({ name, value });
-        return acc;
-      }, []),
+      entities: intent.slots.reduce<{ name: string; value: string }[]>((acc, { name, value }) => (value ? [...acc, { name, value }] : acc), []),
     },
   }) ||
   getNoneIntentRequest(query);

--- a/lib/services/nlu/utils.ts
+++ b/lib/services/nlu/utils.ts
@@ -1,0 +1,13 @@
+import { IntentRequest, RequestType } from '@voiceflow/general-types';
+
+export const NONE_INTENT = 'None';
+export const getNoneIntentRequest = (query = ''): IntentRequest => ({
+  type: RequestType.INTENT,
+  payload: {
+    query,
+    intent: {
+      name: NONE_INTENT,
+    },
+    entities: [],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@voiceflow/common": "^6.2.0",
     "@voiceflow/general-types": "1.16.1",
     "@voiceflow/logger": "^1.4.2",
-    "@voiceflow/natural-language-commander": "^0.5.0",
+    "@voiceflow/natural-language-commander": "^0.5.1",
     "@voiceflow/runtime": "1.17.1",
     "@voiceflow/verror": "^1.1.0",
     "axios": "^0.19.0",

--- a/tests/lib/services/dialog/index.unit.ts
+++ b/tests/lib/services/dialog/index.unit.ts
@@ -41,23 +41,6 @@ describe('dialog manager unit tests', () => {
     sinon.restore();
   });
 
-  describe('helpers', () => {
-    it('calls NLU runtime with appropriate prefix', async () => {
-      const stub = sinon.stub();
-      const services = {
-        axios: { post: stub.returns({ data: {} }) },
-      };
-      const dm = new DialogManager({ utils: { ...defaultUtils }, ...services } as any, {} as any);
-      const intentName = 'dummy_intent';
-      const queryText = 'some query text';
-
-      await dm.makeDMPrefixedInference(queryText, intentName, 'dummyID');
-
-      const correctResult = `${utils.dmPrefix(intentName)} ${queryText}`;
-      expect(stub.args[0][1].query).to.be.equal(correctResult);
-    });
-  });
-
   describe('general handler', () => {
     it('fails if version is not found', async () => {
       const services = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1116,10 +1116,10 @@
     pino "6.8.0"
     pino-http "5.3.0"
 
-"@voiceflow/natural-language-commander@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/natural-language-commander/-/natural-language-commander-0.5.0.tgz#c64a28e6c772cd22dd4b20e87746158fe7827999"
-  integrity sha512-ONZjNW5O99BITyHOS+JcO1D59yrYnDBP2L8Vm7TYJS3pTGFQPKGAtbVVlRvqVteEd9uemYlm+Wu2+LMGJpR6TA==
+"@voiceflow/natural-language-commander@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@voiceflow/natural-language-commander/-/natural-language-commander-0.5.1.tgz#507436588afa60f1bf3aeb4d6b23a7db0947fa26"
+  integrity sha512-1c4hieLldz8/vJVVfBgY13HiTSpHNEyyrJug8+VCxGU7VXs4hKyonmCBoFI1/Y9zpdVPX8njveFuBdkvBuhcMw==
   dependencies:
     "@types/lodash" "^4.14.106"
     babel-runtime "^6.9.2"


### PR DESCRIPTION
The reason why this works is because we already have dialog management built into the NLC:
https://github.com/voiceflow/natural-language-commander/blob/master/src/NaturalLanguageCommander.ts#L222

This was already being used by the FE:
https://github.com/voiceflow/creator-app/blob/master/src/pages/Prototype/PrototypeTool/Dialog.ts#L147

To test this, just go to the NLU `predict` function and make it throw an error from from the axios call every time (comment out the code, throw an error, and ignore dependencies)

turns out we had a bug in the NLC the whole time
https://github.com/voiceflow/natural-language-commander/commit/14dd8094200a519879800dc529315c46041b1f3d