### PR TITLE
chore(deps): remove crypto dependency

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -10,7 +10,6 @@
     "source-map-support",
     "fixpack",
     "husky",
-    "lint-staged",
-    "crypto"
+    "lint-staged"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "cookie-parser": "^1.4.4",
     "core-js": "^3.4.8",
     "cors": "^2.8.5",
-    "crypto": "^1.0.1",
     "datadog-metrics": "^0.8.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2121,11 +2121,6 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
-  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
-
 current-git-branch@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/current-git-branch/-/current-git-branch-1.1.0.tgz#3730e71ee024ed27dab16d740e5b1ea4774fa49f"


### PR DESCRIPTION
### Brief description. What is this change?

This package was using the npm package `crypto` (which is a proxy, has no actual code) instead of the builtin node library