### PR TITLE
fix: nested replace (CORE-000)

### DIFF
--- a/lib/services/runtime/handlers/speak.ts
+++ b/lib/services/runtime/handlers/speak.ts
@@ -21,7 +21,7 @@ const SpeakHandler: HandlerFactory<Node> = () => ({
     const sanitizedVars = sanitizeVariables(variables.getState());
 
     if (_.isString(speak)) {
-      const output = replaceVariables(speak, sanitizedVars);
+      const output = replaceVariables(replaceVariables(speak, sanitizedVars), sanitizedVars);
 
       runtime.storage.produce((draft) => {
         draft[StorageType.OUTPUT] += output;


### PR DESCRIPTION
**Fixes or implements CORE-000**

### Brief description. What is this change?
`test = "{test_nested}"`
and if we put that into a speak block with `{test}` and have it display the value of `{test_nested}` we want it to replace twice?

so if we want to pass in a variable that contains a string with "variables" you would technically need to replace it twice. This is an edge case. I think in the future we make build this into the replaceVariables function.

Although I'm not sure if this is the base behavior, might need some further discussion. While we allow it to go into a depth of 2 here - is there an actual limit we want to enforce.