### PR TITLE
feat: implement NATO/APCO slot types (CORE-4839)

### DIFF
--- a/lib/controllers/interact.ts
+++ b/lib/controllers/interact.ts
@@ -20,7 +20,7 @@ class InteractController extends AbstractController {
   }
 
   async handler(req: Request<{ versionID: string }, null, { state?: State; request?: GeneralRequest; config?: Config }, { locale?: string }>) {
-    const { runtime, metrics, nlu, tts, chips, dialog, asr, state: stateManager } = this.services;
+    const { runtime, metrics, nlu, tts, chips, dialog, asr, slots, state: stateManager } = this.services;
 
     metrics.generalRequest();
     const {
@@ -32,7 +32,7 @@ class InteractController extends AbstractController {
 
     const turn = new TurnBuilder<Context>(stateManager);
 
-    turn.addHandlers(asr, nlu, dialog, runtime);
+    turn.addHandlers(asr, nlu, slots, dialog, runtime);
 
     if (_.isUndefined(config.tts) || config.tts) {
       turn.addHandlers(tts);

--- a/lib/middlewares/rateLimit.ts
+++ b/lib/middlewares/rateLimit.ts
@@ -1,6 +1,5 @@
+import VError from '@voiceflow/verror';
 import { NextFunction, Request, Response } from 'express';
-
-import log from '@/logger';
 
 import { AbstractMiddleware } from './utils';
 
@@ -11,8 +10,7 @@ class RateLimit extends AbstractMiddleware {
       (!this.config.CREATOR_APP_ORIGIN || req.headers.origin !== this.config.CREATOR_APP_ORIGIN) &&
       !req.headers.authorization
     ) {
-      // throw new VError('Auth Key Required', VError.HTTP_STATUS.UNAUTHORIZED);
-      log.info(`unauthenticated call: ${req.ip} ${req.headers.origin}`);
+      throw new VError('Auth Key Required', VError.HTTP_STATUS.UNAUTHORIZED);
     }
 
     next();

--- a/lib/middlewares/rateLimit.ts
+++ b/lib/middlewares/rateLimit.ts
@@ -1,5 +1,6 @@
-import VError from '@voiceflow/verror';
 import { NextFunction, Request, Response } from 'express';
+
+import log from '@/logger';
 
 import { AbstractMiddleware } from './utils';
 
@@ -9,8 +10,10 @@ class RateLimit extends AbstractMiddleware {
       !this.config.PROJECT_SOURCE &&
       (!this.config.CREATOR_APP_ORIGIN || req.headers.origin !== this.config.CREATOR_APP_ORIGIN) &&
       !req.headers.authorization
-    )
-      throw new VError('Auth Key Required', VError.HTTP_STATUS.UNAUTHORIZED);
+    ) {
+      // throw new VError('Auth Key Required', VError.HTTP_STATUS.UNAUTHORIZED);
+      log.info(`unauthenticated call: ${req.ip} ${req.headers.origin}`);
+    }
 
     next();
   }

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -5,6 +5,7 @@
 
 import { PrototypeModel } from '@voiceflow/api-sdk';
 import { GeneralTrace, IntentRequest, Locale, TraceType } from '@voiceflow/general-types';
+import { SpeakType } from '@voiceflow/general-types/build/nodes/speak';
 import _ from 'lodash';
 
 import logger from '@/logger';
@@ -161,6 +162,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
         type: TraceType.SPEAK,
         payload: {
           message: fillStringEntities(inputToString(_.sample(unfulfilledEntity.dialog.prompt)!), dmStateStore!.intentRequest),
+          type: SpeakType.MESSAGE,
         },
       });
 

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -7,6 +7,7 @@ import Dialog from './dialog';
 import NLU from './nlu';
 import RateLimit from './rateLimit';
 import Runtime from './runtime';
+import Slots from './slots';
 import State from './state';
 import TTS from './tts';
 
@@ -19,6 +20,7 @@ export interface ServiceMap {
   tts: TTS;
   chips: Chips;
   rateLimit: RateLimit;
+  slots: Slots;
 }
 
 export interface FullServiceMap extends ClientMap, ServiceMap {}
@@ -39,6 +41,7 @@ const buildServices = (config: Config, clients: ClientMap): FullServiceMap => {
   services.dialog = new Dialog(services, config);
   services.chips = new Chips(services, config);
   services.rateLimit = new RateLimit(services, config);
+  services.slots = new Slots(services, config);
 
   return services;
 };

--- a/lib/services/runtime/handlers/noMatch.ts
+++ b/lib/services/runtime/handlers/noMatch.ts
@@ -2,7 +2,7 @@ import { Node } from '@voiceflow/api-sdk';
 import { replaceVariables, sanitizeVariables } from '@voiceflow/common';
 import { EventType, TraceType } from '@voiceflow/general-types';
 import { Node as ChoiceNode, TraceFrame as ChoiceTrace } from '@voiceflow/general-types/build/nodes/interaction';
-import { TraceFrame } from '@voiceflow/general-types/build/nodes/speak';
+import { SpeakType, TraceFrame } from '@voiceflow/general-types/build/nodes/speak';
 import { Runtime, Store } from '@voiceflow/runtime';
 import _ from 'lodash';
 
@@ -44,7 +44,7 @@ export const NoMatchHandler = () => ({
 
     runtime.trace.addTrace<TraceFrame>({
       type: TraceType.SPEAK,
-      payload: { message: output },
+      payload: { message: output, type: SpeakType.MESSAGE },
     });
 
     if (Array.isArray(node.interactions)) {

--- a/lib/services/runtime/handlers/speak.ts
+++ b/lib/services/runtime/handlers/speak.ts
@@ -1,6 +1,6 @@
 import { replaceVariables, sanitizeVariables } from '@voiceflow/common';
 import { TraceType } from '@voiceflow/general-types';
-import { Node, TraceFrame } from '@voiceflow/general-types/build/nodes/speak';
+import { Node, SpeakType, TraceFrame } from '@voiceflow/general-types/build/nodes/speak';
 import { HandlerFactory } from '@voiceflow/runtime';
 import _ from 'lodash';
 
@@ -29,7 +29,7 @@ const SpeakHandler: HandlerFactory<Node> = () => ({
       });
 
       runtime.stack.top().storage.set<SpeakFrame>(FrameType.SPEAK, output);
-      runtime.trace.addTrace<TraceFrame>({ type: TraceType.SPEAK, payload: { message: output } });
+      runtime.trace.addTrace<TraceFrame>({ type: TraceType.SPEAK, payload: { message: output, type: SpeakType.MESSAGE } });
     }
 
     return node.nextId ?? null;

--- a/lib/services/runtime/init.ts
+++ b/lib/services/runtime/init.ts
@@ -1,7 +1,7 @@
 import { BlockTrace, TraceType as GeneralTraceType, TraceType } from '@voiceflow/general-types';
 import { TraceFrame as ExitTraceFrame } from '@voiceflow/general-types/build/nodes/exit';
 import { TraceFrame as FlowTraceFrame } from '@voiceflow/general-types/build/nodes/flow';
-import { TraceFrame as SpeakTraceFrame } from '@voiceflow/general-types/build/nodes/speak';
+import { SpeakType, TraceFrame as SpeakTraceFrame } from '@voiceflow/general-types/build/nodes/speak';
 import { TraceFrame as StreamTraceFrame, TraceStreamAction } from '@voiceflow/general-types/build/nodes/stream';
 import Client, { EventType } from '@voiceflow/runtime';
 
@@ -30,7 +30,7 @@ const init = (client: Client) => {
           draft[StorageType.OUTPUT] += output;
         });
 
-        runtime.trace.addTrace<SpeakTraceFrame>({ type: TraceType.SPEAK, payload: { message: output } });
+        runtime.trace.addTrace<SpeakTraceFrame>({ type: TraceType.SPEAK, payload: { message: output, type: SpeakType.MESSAGE } });
       }
     }
   });

--- a/lib/services/slots/index.ts
+++ b/lib/services/slots/index.ts
@@ -1,0 +1,64 @@
+/**
+ * [[include:chips.md]]
+ * @packageDocumentation
+ */
+
+// import { TraceType } from '@voiceflow/general-types';
+import _ from 'lodash';
+
+import { Context, ContextHandler } from '@/types';
+
+import { isIntentRequest } from '../runtime/types';
+import { AbstractManager, injectServices } from '../utils';
+
+export const utils = {};
+
+interface Entity {
+  name: string;
+  value: string;
+  rawValue?: string | string[][];
+}
+
+interface Slot {
+  type: {
+    value?: string | undefined;
+  };
+  name: string;
+}
+
+@injectServices({ utils })
+class SlotsService extends AbstractManager<{ utils: typeof utils }> implements ContextHandler {
+  // Combines the NATO/APCO words identified by LUIS together with their first letters.
+  // entity.rawValue contains the words to parse and entity.value will store the result.
+  // Ex: rawValue: [['November'],['India'],['Charlie'],['Echo']] -> value: 'NICE'
+  // (The only exceptions to taking the first letter of the strings is '00' and '000').
+  natoApcoConverter = (entities: Entity[], slots: Slot[]) => {
+    entities.forEach((entity) => {
+      slots.forEach((slot) => {
+        if (entity.name === slot.name && slot.type.value === 'VF.NATOAPCO') {
+          if (Array.isArray(entity.rawValue)) {
+            entity.value = entity.rawValue.reduce((acc, cur) => (cur[0] === '00' || cur[0] === '000' ? acc + cur[0] : acc + cur[0][0]), '');
+          }
+        }
+      });
+    });
+  };
+
+  handle = async (context: Context) => {
+    if (!isIntentRequest(context.request)) {
+      return context;
+    }
+
+    const version = await context.data.api.getVersion(context.versionID);
+
+    if (!version) {
+      throw new Error('Version not found!');
+    }
+
+    this.natoApcoConverter(context.request?.payload.entities, version.platformData.slots);
+
+    return context;
+  };
+}
+
+export default SlotsService;

--- a/lib/services/slots/index.ts
+++ b/lib/services/slots/index.ts
@@ -1,9 +1,3 @@
-/**
- * [[include:chips.md]]
- * @packageDocumentation
- */
-
-// import { TraceType } from '@voiceflow/general-types';
 import _ from 'lodash';
 
 import { Context, ContextHandler } from '@/types';
@@ -16,7 +10,7 @@ export const utils = {};
 interface Entity {
   name: string;
   value: string;
-  rawValue?: string | string[][];
+  rawValue?: string[] | string[][];
 }
 
 interface Slot {
@@ -25,6 +19,8 @@ interface Slot {
   };
   name: string;
 }
+
+const natoApcoExceptions = ['00', '000'];
 
 @injectServices({ utils })
 class SlotsService extends AbstractManager<{ utils: typeof utils }> implements ContextHandler {
@@ -36,9 +32,11 @@ class SlotsService extends AbstractManager<{ utils: typeof utils }> implements C
     entities.forEach((entity) => {
       slots.forEach((slot) => {
         if (entity.name === slot.name && slot.type.value === 'VF.NATOAPCO') {
-          if (Array.isArray(entity.rawValue)) {
-            entity.value = entity.rawValue.reduce((acc, cur) => (cur[0] === '00' || cur[0] === '000' ? acc + cur[0] : acc + cur[0][0]), '');
-          }
+          // entity.rawValue is always string[][] for NATO/APCO slots
+          entity.value = (entity.rawValue as string[][]).reduce(
+            (acc, cur) => (natoApcoExceptions.includes(cur[0]) ? acc + cur[0] : acc + cur[0][0]),
+            ''
+          );
         }
       });
     });

--- a/lib/services/slots/index.ts
+++ b/lib/services/slots/index.ts
@@ -30,7 +30,7 @@ interface Slot {
 class SlotsService extends AbstractManager<{ utils: typeof utils }> implements ContextHandler {
   // Combines the NATO/APCO words identified by LUIS together with their first letters.
   // entity.rawValue contains the words to parse and entity.value will store the result.
-  // Ex: rawValue: [['November'],['India'],['Charlie'],['Echo']] -> value: 'NICE'
+  // Ex: rawValue: [['November'],['India'],['Charlie'],['Echo']] -> value: 'NICE'.
   // (The only exceptions to taking the first letter of the strings is '00' and '000').
   natoApcoConverter = (entities: Entity[], slots: Slot[]) => {
     entities.forEach((entity) => {

--- a/lib/services/tts/index.ts
+++ b/lib/services/tts/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { TraceType } from '@voiceflow/general-types';
-import { TraceFrame as SpeakTrace } from '@voiceflow/general-types/build/nodes/speak';
+import { SpeakType, TraceFrame as SpeakTrace } from '@voiceflow/general-types/build/nodes/speak';
 import _ from 'lodash';
 
 import log from '@/logger';
@@ -31,7 +31,7 @@ class TTS extends AbstractManager<{ utils: typeof utils }> implements ContextHan
       return data.map((payload) => ({ type: TraceType.SPEAK, payload }));
     } catch (error) {
       log.error(error);
-      return [{ type: TraceType.SPEAK, payload: { message, type: 'speak' } }];
+      return [{ type: TraceType.SPEAK, payload: { message, type: SpeakType.AUDIO } }];
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@types/bluebird": "^3.5.30",
+    "@types/bluebird": "^3.5.32",
     "@types/chai": "^4.2.7",
     "@types/chai-as-promised": "^7.1.2",
     "@types/compression": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@voiceflow/api-sdk": "v1.27.0",
     "@voiceflow/backend-utils": "^2.2.0",
     "@voiceflow/common": "6.5.0",
-    "@voiceflow/general-types": "^1.25.2",
+    "@voiceflow/general-types": "^1.31.0",
     "@voiceflow/logger": "^1.4.2",
     "@voiceflow/natural-language-commander": "^0.5.1",
     "@voiceflow/runtime": "1.24.1",

--- a/tests/lib/controllers/interact.unit.ts
+++ b/tests/lib/controllers/interact.unit.ts
@@ -30,6 +30,7 @@ describe('interact controller unit tests', () => {
         state: { handle: sinon.stub().resolves(output('state')) },
         asr: { handle: sinon.stub().resolves(output('asr')) },
         nlu: { handle: sinon.stub().resolves(output('nlu')) },
+        slots: { handle: sinon.stub().resolves(output('slots')) },
         tts: { handle: sinon.stub().resolves(output('tts')) },
         chips: { handle: sinon.stub().resolves(output('chips', { trace: 'trace' })) },
         runtime: { handle: sinon.stub().resolves(output('runtime')) },
@@ -48,7 +49,8 @@ describe('interact controller unit tests', () => {
       expect(services.state.handle.args).to.eql([[context]]);
       expect(services.asr.handle.args).to.eql([[output('state')]]);
       expect(services.nlu.handle.args).to.eql([[output('asr')]]);
-      expect(services.dialog.handle.args).to.eql([[output('nlu')]]);
+      expect(services.slots.handle.args).to.eql([[output('nlu')]]);
+      expect(services.dialog.handle.args).to.eql([[output('slots')]]);
       expect(services.runtime.handle.args).to.eql([[output('dialog')]]);
       expect(services.tts.handle.args).to.eql([[output('runtime')]]);
       expect(services.chips.handle.args).to.eql([[output('tts')]]);
@@ -69,6 +71,7 @@ describe('interact controller unit tests', () => {
         state: { handle: sinon.stub().resolves(output('state')) },
         asr: { handle: sinon.stub().resolves(output('asr')) },
         nlu: { handle: sinon.stub().resolves(output('nlu')) },
+        slots: { handle: sinon.stub().resolves(output('slots')) },
         tts: { handle: sinon.stub().resolves(output('tts')) },
         chips: { handle: sinon.stub().resolves(output('chips', { trace: 'trace' })) },
         runtime: { handle: sinon.stub().resolves(output('runtime')) },
@@ -103,6 +106,7 @@ describe('interact controller unit tests', () => {
       state: { handle: sinon.stub().resolves(output('state')) },
       asr: { handle: sinon.stub().resolves(output('asr')) },
       nlu: { handle: sinon.stub().resolves(output('nlu')) },
+      slots: { handle: sinon.stub().resolves(output('slots')) },
       tts: { handle: sinon.stub().resolves(output('tts')) },
       chips: { handle: sinon.stub().resolves(output('chips', { trace: 'trace' })) },
       runtime: { handle: sinon.stub().resolves(output('runtime')) },
@@ -133,6 +137,7 @@ describe('interact controller unit tests', () => {
       state: { handle: sinon.stub().resolves(output('state')) },
       asr: { handle: sinon.stub().resolves(output('asr')) },
       nlu: { handle: sinon.stub().resolves(output('nlu')) },
+      slots: { handle: sinon.stub().resolves(output('slots')) },
       tts: { handle: sinon.stub().resolves(output('tts')) },
       chips: { handle: sinon.stub().resolves(output('chips', { trace: 'trace' })) },
       runtime: { handle: sinon.stub().resolves(output('runtime')) },

--- a/tests/lib/services/dialog/index.unit.ts
+++ b/tests/lib/services/dialog/index.unit.ts
@@ -145,6 +145,7 @@ describe('dialog manager unit tests', () => {
             type: 'speak',
             payload: {
               message: 'what flavor?',
+              type: 'message',
             },
           },
           {

--- a/tests/lib/services/slots/index.unit.ts
+++ b/tests/lib/services/slots/index.unit.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { RequestType } from '@/../general-types/build';
+import SlotsManager, { utils as defaultUtils } from '@/lib/services/slots';
+
+describe('slots manager unit tests', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('handle', () => {
+    it('reduces NATOAPCO slot type values correctly', async () => {
+      const version = {
+        platformData: {
+          slots: [
+            {
+              name: 'natoSlot',
+              type: {
+                value: 'VF.NATOAPCO',
+              },
+            },
+            {
+              name: 'otherSlot',
+              type: {
+                value: 'VF.NUMBER',
+              },
+            },
+          ],
+        },
+      };
+
+      const context = {
+        data: {
+          api: {
+            getVersion: sinon.stub().resolves(version),
+          },
+        },
+        request: {
+          type: RequestType.INTENT,
+          payload: {
+            intent: {
+              name: 'foo',
+            },
+            entities: [
+              {
+                name: 'natoSlot',
+                rawValue: [['November'], ['India'], ['Charlie'], ['Echo'], ['-'], ['1'], ['000'], ['.'], ['00']],
+              },
+              {
+                name: 'otherSlot',
+                value: 'unchanged',
+              },
+            ],
+          },
+        },
+      };
+      const slots = new SlotsManager({ utils: { ...defaultUtils } } as any, {} as any);
+
+      const newContext = await slots.handle(context as any);
+      const newEntities = (newContext.request?.payload as any).entities;
+      expect(newEntities[0].value).to.eql('NICE-1000.00');
+      expect(newEntities[1].value).to.eql('unchanged');
+    });
+  });
+});

--- a/tests/lib/services/slots/index.unit.ts
+++ b/tests/lib/services/slots/index.unit.ts
@@ -1,7 +1,7 @@
+import { RequestType } from '@voiceflow/general-types/build';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { RequestType } from '@/../general-types/build';
 import SlotsManager, { utils as defaultUtils } from '@/lib/services/slots';
 
 describe('slots manager unit tests', () => {

--- a/tests/lib/services/slots/index.unit.ts
+++ b/tests/lib/services/slots/index.unit.ts
@@ -12,21 +12,23 @@ describe('slots manager unit tests', () => {
   describe('handle', () => {
     it('reduces NATOAPCO slot type values correctly', async () => {
       const version = {
-        platformData: {
-          slots: [
-            {
-              name: 'natoSlot',
-              type: {
-                value: 'VF.NATOAPCO',
+        prototype: {
+          model: {
+            slots: [
+              {
+                name: 'natoSlot',
+                type: {
+                  value: 'VF.NATOAPCO',
+                },
               },
-            },
-            {
-              name: 'otherSlot',
-              type: {
-                value: 'VF.NUMBER',
+              {
+                name: 'otherSlot',
+                type: {
+                  value: 'VF.NUMBER',
+                },
               },
-            },
-          ],
+            ],
+          },
         },
       };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,11 +957,11 @@
     "@voiceflow/api-sdk" "1.22.0"
 
 "@voiceflow/general-types@^1.25.2":
-  version "1.25.2"
-  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.25.2.tgz#fca14bd452b4102e47bafd3bb9218a1c19b1654e"
-  integrity sha512-drx3ijuLB62QFe3FhOsdWW95v7Yf5g9ljgWe973SUAoaGjBM/EpqUhR6fCWGR8FQBHIkAYCpGEBvKYwCW9n46g==
+  version "1.28.1"
+  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.28.1.tgz#84ce708c2b22d0e146953cdf31e0248bcf581aef"
+  integrity sha512-oiuC11+61Sg1BloLXNdidjJNIX4sb28e2+uVZ8OkmGx3BSLrYkksACdex6sRRgf7nmv0Siaz5BZ9M24GZbgNNA==
   dependencies:
-    "@voiceflow/api-sdk" "1.22.0"
+    "@voiceflow/api-sdk" "1.24.1"
 
 "@voiceflow/git-branch-check@^1.1.3":
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,10 +883,10 @@
     regenerator-runtime "^0.13.5"
     superstruct "^0.10.12"
 
-"@voiceflow/api-sdk@1.24.1":
-  version "1.24.1"
-  resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-1.24.1.tgz#5ac1837205b4d7b064c385cc51c25517f993751f"
-  integrity sha512-KTVN/yRcyq8UgWLT76C1x4hNGmXRv7oftbpj2RnD8n1PQOQCDwudrn5yRCwBUVBhngm95SPwKvJnTqlQ4Bi+rQ==
+"@voiceflow/api-sdk@1.25.0":
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-1.25.0.tgz#0189df2e4e9ae5d51a68f152f89de44664e6f40d"
+  integrity sha512-xdBr87++LN5lJyRBjbxgQBq1krYREKDOfCQHDVtpATCG6iB4wyuZrmMZm5zxTb+BIhNmoFVG0JHvNwhnDA/XqQ==
   dependencies:
     "@types/atob" "^2.1.2"
     "@voiceflow/logger" "^1.4.2"
@@ -967,12 +967,12 @@
   dependencies:
     "@voiceflow/api-sdk" "1.22.0"
 
-"@voiceflow/general-types@^1.25.2":
-  version "1.28.1"
-  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.28.1.tgz#84ce708c2b22d0e146953cdf31e0248bcf581aef"
-  integrity sha512-oiuC11+61Sg1BloLXNdidjJNIX4sb28e2+uVZ8OkmGx3BSLrYkksACdex6sRRgf7nmv0Siaz5BZ9M24GZbgNNA==
+"@voiceflow/general-types@^1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.31.0.tgz#54162f021033ed62773e24a4a4b48cdd34147ada"
+  integrity sha512-fzL7rx3LyHh9YIFkQ+SDy8REof3zpV7NlevjBMVdyyHfy4ETnFKnB50TPGYEvMe7J9tFqGtCTWXPskP8rZu9Pg==
   dependencies:
-    "@voiceflow/api-sdk" "1.24.1"
+    "@voiceflow/api-sdk" "1.25.0"
 
 "@voiceflow/git-branch-check@^1.1.3":
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,6 +883,17 @@
     regenerator-runtime "^0.13.5"
     superstruct "^0.10.12"
 
+"@voiceflow/api-sdk@1.24.1":
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-1.24.1.tgz#5ac1837205b4d7b064c385cc51c25517f993751f"
+  integrity sha512-KTVN/yRcyq8UgWLT76C1x4hNGmXRv7oftbpj2RnD8n1PQOQCDwudrn5yRCwBUVBhngm95SPwKvJnTqlQ4Bi+rQ==
+  dependencies:
+    "@types/atob" "^2.1.2"
+    "@voiceflow/logger" "^1.4.2"
+    atob "^2.1.2"
+    axios "^0.21.1"
+    superstruct "^0.10.12"
+
 "@voiceflow/api-sdk@1.27.0", "@voiceflow/api-sdk@v1.27.0":
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-1.27.0.tgz#d128a3e6c39406e4087dc16eee00bc448e9e610a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,10 +525,10 @@
   resolved "https://registry.yarnpkg.com/@types/atob/-/atob-2.1.2.tgz#157eb0cc46264a8c55f2273a836c7a1a644fb820"
   integrity sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg==
 
-"@types/bluebird@^3.5.30":
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.32.tgz#381e7b59e39f010d20bbf7e044e48f5caf1ab620"
-  integrity sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g==
+"@types/bluebird@^3.5.32":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.33.tgz#d79c020f283bd50bd76101d7d300313c107325fc"
+  integrity sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ==
 
 "@types/body-parser@*":
   version "1.19.0"


### PR DESCRIPTION
**Fixes or implements CORE-4839 and CORE-4840**

### Brief description. What is this change?
Implements NATO/APCO slot type in a new handler, SlotsService. There are also some additions of `type: SpeakType.MESSAGE` to SpeakTraces as type is no longer optional.

### Implementation details. How do you make this change?
- SlotsService combines the NATO/APCO words identified by LUIS together with their first letters. entity.rawValue contains the words to parse and entity.value will store the result. Ex: rawValue: [['November'],['India'],['Charlie'],['Echo']] -> value: 'NICE'. The only exceptions to taking the first letter of the strings is '00' and '000', these stay the same.
- Unit tested the SlotService handler

### Related PRs
| branch              | PR          |
| ------------------- | ----------- |
| general-service | [link](https://github.com/voiceflow/general-service/pull/57) |
| luis-authoring-service | [link](https://github.com/voiceflow/luis-authoring-service/pull/45) |
| general-types | [link](https://github.com/voiceflow/general-types/pull/45) |

### Checklist

- [ ✅  ] title of PR reflects the branch name
- [ ✅  ] all commits adhere to conventional commits
- [ ✅  ] appropriate tests have been written
- [ ✅  ] all the dependencies are upgraded