### PR TITLE
fix: stop number slot from being filled with entire utterances (CORE-5164)

### DIFF
--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -110,7 +110,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
 
         // Remove the dmPrefix from entity values that it has accidentally been attached to
         dmPrefixedResult.payload.entities.forEach((entity) => {
-          entity.value = typeof entity.value === 'string' ? entity.value.replace(prefix, '').trim() : entity.value;
+          entity.value = _.isString(entity.value) ? entity.value.replace(prefix, '').trim() : entity.value;
         });
 
         const isFallback = this.handleDMContext(dmStateStore, dmPrefixedResult, incomingRequest, version.prototype.model);

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -110,7 +110,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
 
         // Remove the dmPrefix from entity values that it has accidentally been attached to
         dmPrefixedResult.payload.entities.forEach((entity) => {
-          entity.value = entity.value.replace(prefix, '').trim();
+          entity.value = typeof entity.value === 'string' ? entity.value.replace(prefix, '').trim() : entity.value;
         });
 
         const isFallback = this.handleDMContext(dmStateStore, dmPrefixedResult, incomingRequest, version.prototype.model);


### PR DESCRIPTION
**Fixes or implements CORE-5164**

### Brief description. What is this change?
The bug in the ticket is that our built-in Number slot type is filling with entire utterances, not just the number value within those utterances. The reason this happens is because LUIS matches the amount entity with a value of type `number` instead of `string`. The code in this PR assumed entity.value was always a `string`, so it would throw an error when it tried to called .replace() on a `number`. This lead to it going down the wrong path and putting the entire utterance into the slot value.

### Checklist

- [ ✅  ] title of PR reflects the branch name
- [ ✅  ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ✅  ] all the dependencies are upgraded