### PR TITLE
fix: account for empty stack (CORE-000)

### DIFF
--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -59,9 +59,18 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
 
     const locale = context.data?.locale || version.prototype?.data?.locales?.[0];
 
+    let { state } = context;
+
+    if (!state) {
+      state = this.generate(version);
+    } else if (!state.stack.length) {
+      // if stack is empty, repopulate the stack
+      state = { ...state, stack: this.generate(version).stack };
+    }
+
     return {
       ...context,
-      state: context.state || this.generate(version),
+      state,
       trace: [] as GeneralTrace[],
       request: context.request || null,
       versionID: context.versionID,

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -22,7 +22,7 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
    * generate a context for a new session
    * @param versionID - project version to generate the context for
    */
-  generate({ prototype, variables, rootDiagramID }: Version<any>): State {
+  generate({ prototype, variables, rootDiagramID }: Version<any>, state?: State): State {
     const entities = prototype?.model.slots.map(({ name }) => name) || [];
 
     const DEFAULT_STACK = [{ programID: rootDiagramID, storage: {}, variables: {} }];
@@ -41,9 +41,11 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
         ...initializeStore(entities),
         ...initializeStore(variables),
         ...prototype?.context.variables,
+        ...state?.variables,
       },
       storage: {
         ...prototype?.context.storage,
+        ...state?.storage,
       },
     };
   }
@@ -65,7 +67,7 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
       state = this.generate(version);
     } else if (!state.stack.length) {
       // if stack is empty, repopulate the stack
-      state = { ...state, stack: this.generate(version).stack };
+      state = this.generate(version, state);
     }
 
     return {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-000**

### Brief description. What is this change?

we want to give consumers the same thing we do on alexa and google: if they have an existing state but finished their previous session (stack empty) then just populate the stack again and persist their variables + storage

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to undertand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependendencies are upgraded