### PR TITLE
feat: one shot intent handler (CORE-000)

### DIFF
--- a/lib/services/runtime/handlers/state/index.ts
+++ b/lib/services/runtime/handlers/state/index.ts
@@ -1,3 +1,4 @@
+import oneShotHandler from './oneShot';
 import streamStateHandler from './stream';
 
-export default () => [streamStateHandler()];
+export default () => [streamStateHandler(), oneShotHandler()];

--- a/lib/services/runtime/handlers/state/oneShot.ts
+++ b/lib/services/runtime/handlers/state/oneShot.ts
@@ -1,0 +1,29 @@
+import { NodeType } from '@voiceflow/general-types';
+import { Node } from '@voiceflow/general-types/build/nodes/start';
+import { Action, HandlerFactory } from '@voiceflow/runtime';
+
+import { isIntentRequest } from '../../types';
+import CommandHandler from '../command';
+
+const utilsObj = {
+  commandHandler: CommandHandler(),
+};
+
+export const OneShotIntentHandler: HandlerFactory<Node, typeof utilsObj> = (utils) => ({
+  canHandle: (node, runtime) => {
+    return isIntentRequest(runtime.getRequest()) && node.type === NodeType.START;
+  },
+  handle: (node, runtime, variables) => {
+    // request for this turn has been processed, set action to response
+    runtime.setAction(Action.RESPONSE);
+
+    if (utils.commandHandler.canHandle(runtime)) {
+      return utils.commandHandler.handle(runtime, variables);
+    }
+
+    // if nothing matches, just pretend that this is like a launch request
+    return node.nextId || null;
+  },
+});
+
+export default () => OneShotIntentHandler(utilsObj);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-000**

### Brief description. What is this change?

So there is this edge case if the user sends a text request when the stack hasn't loaded yet or their session is not initialized. That means that they will be on the start block.

What we do is see if there are any intent blocks or command blocks that can handle their request. If not, just proceed down the start block as normal, and consider the request handled.

We already use this pattern for alexa

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to undertand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependendencies are upgraded