### PR TITLE
feat: API Key Verification (CORE-5221)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -12,7 +12,6 @@ LOG_LEVEL='warn'
 MIDDLEWARE_VERBOSITY='none'
 
 CREATOR_API_ENDPOINT='https://localhost:8080'
-CREATOR_API_AUTHORIZATION='foo'
 
 # required for nlu and tts services
 GENERAL_SERVICE_ENDPOINT='https://localhost:6970'

--- a/backend/serviceManager.ts
+++ b/backend/serviceManager.ts
@@ -31,7 +31,7 @@ class ServiceManager {
    * Start services
    */
   async start() {
-    await initClients();
+    await initClients(this.clients);
   }
 
   /**

--- a/backend/serviceManager.ts
+++ b/backend/serviceManager.ts
@@ -31,7 +31,7 @@ class ServiceManager {
    * Start services
    */
   async start() {
-    await initClients(this.clients);
+    await initClients();
   }
 
   /**

--- a/config.ts
+++ b/config.ts
@@ -41,7 +41,7 @@ const CONFIG: Config = {
   CREATOR_API_AUTHORIZATION: getOptionalProcessEnv('CREATOR_API_AUTHORIZATION'),
 
   // creator-app config
-  CREATOR_APP_ENDPOINT: getOptionalProcessEnv('CREATOR_APP_ENDPOINT'),
+  CREATOR_APP_ORIGIN: getOptionalProcessEnv('CREATOR_APP_ORIGIN'),
 
   AWS_ACCESS_KEY_ID: getOptionalProcessEnv('AWS_ACCESS_KEY_ID'),
   AWS_SECRET_ACCESS_KEY: getOptionalProcessEnv('AWS_SECRET_ACCESS_KEY'),

--- a/config.ts
+++ b/config.ts
@@ -36,9 +36,12 @@ const CONFIG: Config = {
   VF_DATA_ENDPOINT: getOptionalProcessEnv('VF_DATA_ENDPOINT'), // server-data-api endpoint
   ADMIN_SERVER_DATA_API_TOKEN: getOptionalProcessEnv('ADMIN_SERVER_DATA_API_TOKEN'), // Server-data-api auth token
 
-  // creator-api conifg
+  // creator-api config
   CREATOR_API_ENDPOINT: getOptionalProcessEnv('CREATOR_API_ENDPOINT'),
   CREATOR_API_AUTHORIZATION: getOptionalProcessEnv('CREATOR_API_AUTHORIZATION'),
+
+  // creator-app config
+  CREATOR_APP_ENDPOINT: getOptionalProcessEnv('CREATOR_APP_ENDPOINT'),
 
   AWS_ACCESS_KEY_ID: getOptionalProcessEnv('AWS_ACCESS_KEY_ID'),
   AWS_SECRET_ACCESS_KEY: getOptionalProcessEnv('AWS_SECRET_ACCESS_KEY'),

--- a/lib/clients/dataAPI.ts
+++ b/lib/clients/dataAPI.ts
@@ -13,7 +13,7 @@ class DataAPI {
 
   remoteDataApi: RemoteDataAPI | undefined;
 
-  creatorAppEndpoint: string;
+  creatorAppOrigin: string | null;
 
   creatorAPIEndpoint: string | null;
 
@@ -35,7 +35,7 @@ class DataAPI {
       CREATOR_APP_ORIGIN,
     } = config;
 
-    this.creatorAppEndpoint = CREATOR_APP_ORIGIN ?? '';
+    this.creatorAppOrigin = CREATOR_APP_ORIGIN;
     this.creatorAPIEndpoint = CREATOR_API_ENDPOINT;
     this.creatorAPIAuthorization = CREATOR_API_AUTHORIZATION ?? '';
     this.api = API;
@@ -68,7 +68,7 @@ class DataAPI {
     if (this.localDataApi) {
       return this.localDataApi;
     }
-    if (origin === this.creatorAppEndpoint) {
+    if (this.creatorAPIAuthorization && origin === this.creatorAppOrigin) {
       if (!this.remoteDataApi) {
         throw new Error('no remote data API env configuration set');
       }

--- a/lib/clients/dataAPI.ts
+++ b/lib/clients/dataAPI.ts
@@ -68,7 +68,7 @@ class DataAPI {
     if (this.localDataApi) {
       return this.localDataApi;
     }
-    if (this.creatorAPIAuthorization && origin === this.creatorAppOrigin) {
+    if (this.creatorAppOrigin && origin === this.creatorAppOrigin) {
       if (!this.remoteDataApi) {
         throw new Error('no remote data API env configuration set');
       }

--- a/lib/clients/dataAPI.ts
+++ b/lib/clients/dataAPI.ts
@@ -1,4 +1,4 @@
-import { CreatorDataApi, DataAPI, LocalDataApi } from '@voiceflow/runtime';
+import { CreatorDataApi, LocalDataApi } from '@voiceflow/runtime';
 
 import { Config } from '@/types';
 
@@ -8,32 +8,75 @@ import Static from './static';
 /**
  * Build all clients
  */
-export default (config: Config, API = { LocalDataApi, RemoteDataAPI, CreatorDataApi }) => {
-  const { PROJECT_SOURCE, ADMIN_SERVER_DATA_API_TOKEN, VF_DATA_ENDPOINT, CREATOR_API_AUTHORIZATION, CREATOR_API_ENDPOINT } = config;
-  let dataAPI: DataAPI<any, any>;
+class DataAPI {
+  localDataApi: LocalDataApi<any, any> | undefined;
 
-  // fetch from local VF file
-  if (PROJECT_SOURCE) {
-    dataAPI = new API.LocalDataApi({ projectSource: PROJECT_SOURCE }, { fs: Static.fs, path: Static.path });
+  remoteDataApi: RemoteDataAPI | undefined;
+
+  creatorDataApi: CreatorDataApi<any, any> | undefined;
+
+  creatorAppEndpoint = '';
+
+  constructor(config: Config, API = { LocalDataApi, RemoteDataAPI, CreatorDataApi }) {
+    const {
+      PROJECT_SOURCE,
+      ADMIN_SERVER_DATA_API_TOKEN,
+      VF_DATA_ENDPOINT,
+      CREATOR_API_AUTHORIZATION,
+      CREATOR_API_ENDPOINT,
+      CREATOR_APP_ENDPOINT,
+    } = config;
+
+    this.creatorAppEndpoint = CREATOR_APP_ENDPOINT ?? '';
+
+    // fetch from local VF file
+    if (PROJECT_SOURCE) {
+      this.localDataApi = new API.LocalDataApi({ projectSource: PROJECT_SOURCE }, { fs: Static.fs, path: Static.path });
+    }
+
+    // fetch from server-data-api
+    if (ADMIN_SERVER_DATA_API_TOKEN && VF_DATA_ENDPOINT) {
+      this.remoteDataApi = new API.RemoteDataAPI(
+        { platform: 'general', adminToken: ADMIN_SERVER_DATA_API_TOKEN, dataEndpoint: VF_DATA_ENDPOINT },
+        { axios: Static.axios }
+      );
+    }
+
+    // fetch from creator-api
+    if (CREATOR_API_ENDPOINT) {
+      this.creatorDataApi = new API.CreatorDataApi({ endpoint: `${CREATOR_API_ENDPOINT}/v2`, authorization: CREATOR_API_AUTHORIZATION ?? undefined });
+    }
+
+    // configuration not set
+    if (!this.localDataApi && !this.remoteDataApi && !this.creatorDataApi) {
+      throw new Error('no data API env configuration set');
+    }
   }
 
-  // fetch from server-data-api
-  else if (ADMIN_SERVER_DATA_API_TOKEN && VF_DATA_ENDPOINT) {
-    dataAPI = new API.RemoteDataAPI(
-      { platform: 'general', adminToken: ADMIN_SERVER_DATA_API_TOKEN, dataEndpoint: VF_DATA_ENDPOINT },
-      { axios: Static.axios }
-    );
+  public async init() {
+    await this.localDataApi?.init();
+    await this.remoteDataApi?.init();
+    await this.creatorDataApi?.init();
   }
 
-  // fetch from creator-api
-  else if (CREATOR_API_AUTHORIZATION && CREATOR_API_ENDPOINT) {
-    dataAPI = new API.CreatorDataApi({ endpoint: `${CREATOR_API_ENDPOINT}/v2`, authorization: CREATOR_API_AUTHORIZATION });
-  }
+  public get(authorization?: string, origin?: string) {
+    if (this.localDataApi) {
+      return this.localDataApi;
+    }
+    if (origin === this.creatorAppEndpoint) {
+      if (!this.remoteDataApi) {
+        throw new Error('no remote data API env configuration set');
+      }
 
-  // configuration not set
-  else {
-    throw new Error('no data API env configuration set');
-  }
+      return this.remoteDataApi;
+    }
+    if (!this.creatorDataApi) {
+      throw new Error('no creator data API env configuration set');
+    }
 
-  return dataAPI;
-};
+    this.creatorDataApi!.updateAuthorization(authorization);
+    return this.creatorDataApi;
+  }
+}
+
+export default DataAPI;

--- a/lib/clients/dataAPI.ts
+++ b/lib/clients/dataAPI.ts
@@ -24,10 +24,10 @@ class DataAPI {
       VF_DATA_ENDPOINT,
       CREATOR_API_AUTHORIZATION,
       CREATOR_API_ENDPOINT,
-      CREATOR_APP_ENDPOINT,
+      CREATOR_APP_ORIGIN,
     } = config;
 
-    this.creatorAppEndpoint = CREATOR_APP_ENDPOINT ?? '';
+    this.creatorAppEndpoint = CREATOR_APP_ORIGIN ?? '';
 
     // fetch from local VF file
     if (PROJECT_SOURCE) {

--- a/lib/clients/index.ts
+++ b/lib/clients/index.ts
@@ -1,5 +1,3 @@
-import { DataAPI as DataAPIType } from '@voiceflow/runtime';
-
 import { Config } from '@/types';
 
 import DataAPI from './dataAPI';
@@ -7,7 +5,7 @@ import Metrics, { MetricsType } from './metrics';
 import Static, { StaticType } from './static';
 
 export interface ClientMap extends StaticType {
-  dataAPI: DataAPIType<any, any>;
+  dataAPI: DataAPI;
   metrics: MetricsType;
 }
 
@@ -17,7 +15,7 @@ export interface ClientMap extends StaticType {
 const buildClients = (config: Config): ClientMap => {
   return {
     ...Static,
-    dataAPI: DataAPI(config),
+    dataAPI: new DataAPI(config),
     metrics: Metrics(config),
   };
 };

--- a/lib/clients/index.ts
+++ b/lib/clients/index.ts
@@ -20,8 +20,8 @@ const buildClients = (config: Config): ClientMap => {
   };
 };
 
-export const initClients = async (clients: ClientMap) => {
-  await clients.dataAPI.init();
+export const initClients = async () => {
+  // no-op
 };
 
 export default buildClients;

--- a/lib/clients/index.ts
+++ b/lib/clients/index.ts
@@ -20,8 +20,8 @@ const buildClients = (config: Config): ClientMap => {
   };
 };
 
-export const initClients = async () => {
-  // no-op
+export const initClients = async (clients: ClientMap) => {
+  await clients.dataAPI.init();
 };
 
 export default buildClients;

--- a/lib/controllers/interact.ts
+++ b/lib/controllers/interact.ts
@@ -14,7 +14,7 @@ import { AbstractController } from './utils';
 
 class InteractController extends AbstractController {
   async state(req: { headers: { authorization?: string; origin?: string }; params: { versionID: string } }) {
-    const api = this.services.dataAPI.get(req.headers.authorization, req.headers.origin);
+    const api = await this.services.dataAPI.get(req.headers.authorization, req.headers.origin);
     const version = await api.getVersion(req.params.versionID);
     return this.services.state.generate(version);
   }

--- a/lib/controllers/interact.ts
+++ b/lib/controllers/interact.ts
@@ -13,8 +13,9 @@ import { Context } from '@/types';
 import { AbstractController } from './utils';
 
 class InteractController extends AbstractController {
-  async state(req: { params: { versionID: string } }) {
-    const version = await this.services.dataAPI.getVersion(req.params.versionID);
+  async state(req: { headers: { authorization?: string; origin?: string }; params: { versionID: string } }) {
+    const api = this.services.dataAPI.get(req.headers.authorization, req.headers.origin);
+    const version = await api.getVersion(req.params.versionID);
     return this.services.state.generate(version);
   }
 
@@ -22,11 +23,11 @@ class InteractController extends AbstractController {
     const { runtime, metrics, nlu, tts, chips, dialog, asr, state: stateManager } = this.services;
 
     metrics.generalRequest();
-
     const {
       body: { state, request = null, config = {} },
       params: { versionID },
       query: { locale },
+      headers: { authorization, origin },
     } = req;
 
     const turn = new TurnBuilder<Context>(stateManager);
@@ -39,7 +40,7 @@ class InteractController extends AbstractController {
 
     turn.addHandlers(chips);
 
-    return turn.resolve({ state, request, versionID, data: { locale } });
+    return turn.resolve({ state, request, versionID, data: { locale, authorization, origin } });
   }
 }
 

--- a/lib/controllers/interact.ts
+++ b/lib/controllers/interact.ts
@@ -40,7 +40,7 @@ class InteractController extends AbstractController {
 
     turn.addHandlers(chips);
 
-    return turn.resolve({ state, request, versionID, data: { locale, authorization, origin } });
+    return turn.resolve({ state, request, versionID, data: { locale, reqHeaders: { authorization, origin } } });
   }
 }
 

--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -9,6 +9,7 @@ import Client from '@voiceflow/runtime';
 import { Config, Context, ContextHandler } from '@/types';
 
 import { FullServiceMap } from '../index';
+import CacheDataAPI from '../state/cacheDataAPI';
 import { AbstractManager, injectServices } from '../utils';
 import Handlers from './handlers';
 import init from './init';
@@ -22,18 +23,19 @@ export const utils = {
 
 @injectServices({ utils })
 class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements ContextHandler {
-  private client: Client<RuntimeRequest>;
+  private client?: Client<RuntimeRequest>;
 
   private handlers: ReturnType<typeof Handlers>;
 
   constructor(services: FullServiceMap, config: Config) {
     super(services, config);
-
     this.handlers = this.services.utils.Handlers(config);
+  }
 
+  createClient(api: CacheDataAPI) {
     this.client = new this.services.utils.Client({
-      api: services.dataAPI,
-      services,
+      api,
+      services: this.services,
       handlers: this.handlers,
     });
 
@@ -43,7 +45,11 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
   public async handle({ versionID, state, request, ...context }: Context) {
     if (!isRuntimeRequest(request)) throw new Error(`invalid runtime request type: ${JSON.stringify(request)}`);
 
-    const runtime = this.client.createRuntime(versionID, state, request, { api: context.data.api });
+    if (!this.client) {
+      this.createClient(context.data.api);
+    }
+
+    const runtime = this.client!.createRuntime(versionID, state, request, { api: context.data.api });
 
     if (isIntentRequest(request)) {
       runtime.trace.debug(

--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -45,11 +45,8 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
   public async handle({ versionID, state, request, ...context }: Context) {
     if (!isRuntimeRequest(request)) throw new Error(`invalid runtime request type: ${JSON.stringify(request)}`);
 
-    if (!this.client) {
-      this.createClient(context.data.api);
-    }
-
-    const runtime = this.client!.createRuntime(versionID, state, request, { api: context.data.api });
+    this.createClient(context.data.api);
+    const runtime = this.client!.createRuntime(versionID, state, request);
 
     if (isIntentRequest(request)) {
       runtime.trace.debug(

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -65,7 +65,8 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
     }
 
     // cache per interaction (save version call during request/response cycle)
-    const api = new CacheDataAPI(this.services.dataAPI.get(context.data?.reqHeaders?.authorization, context.data?.reqHeaders?.origin));
+    const dataApi = await this.services.dataAPI.get(context.data?.reqHeaders?.authorization, context.data?.reqHeaders?.origin);
+    const api = new CacheDataAPI(dataApi);
     const version = await api.getVersion(context.versionID!);
 
     const locale = context.data?.locale || version.prototype?.data?.locales?.[0];

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -65,7 +65,7 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
     }
 
     // cache per interaction (save version call during request/response cycle)
-    const api = new CacheDataAPI(this.services.dataAPI);
+    const api = new CacheDataAPI(this.services.dataAPI.get(context.data?.authorization, context.data?.origin));
     const version = await api.getVersion(context.versionID!);
 
     const locale = context.data?.locale || version.prototype?.data?.locales?.[0];

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -65,7 +65,7 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
     }
 
     // cache per interaction (save version call during request/response cycle)
-    const api = new CacheDataAPI(this.services.dataAPI.get(context.data?.authorization, context.data?.origin));
+    const api = new CacheDataAPI(this.services.dataAPI.get(context.data?.reqHeaders?.authorization, context.data?.reqHeaders?.origin));
     const version = await api.getVersion(context.versionID!);
 
     const locale = context.data?.locale || version.prototype?.data?.locales?.[0];

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "dependencies": {
-    "@voiceflow/api-sdk": "1.22.0",
+    "@voiceflow/api-sdk": "v1.27.0",
     "@voiceflow/backend-utils": "^2.2.0",
     "@voiceflow/common": "6.5.0",
     "@voiceflow/general-types": "^1.25.2",

--- a/tests/lib/clients/dataAPI.unit.ts
+++ b/tests/lib/clients/dataAPI.unit.ts
@@ -10,9 +10,10 @@ describe('dataAPI client unit tests', () => {
     sinon.restore();
   });
 
-  it('local api', () => {
+  it('local api', async () => {
+    const initStub = sinon.stub();
     const API = {
-      LocalDataApi: sinon.stub().returns({ type: 'local' }),
+      LocalDataApi: sinon.stub().returns({ type: 'local', init: initStub }),
       RemoteDataAPI: sinon.stub().returns({ type: 'remote' }),
       CreatorDataApi: sinon.stub().returns({ type: 'creator' }),
     };
@@ -26,16 +27,18 @@ describe('dataAPI client unit tests', () => {
       CREATOR_APP_ORIGIN: 'voiceflow.com',
     };
 
-    expect(new DataAPI(config as any, API as any).get()).to.eql({ type: 'local' });
+    expect(await new DataAPI(config as any, API as any).get()).to.eql({ type: 'local', init: initStub });
     expect(API.LocalDataApi.args).to.eql([[{ projectSource: config.PROJECT_SOURCE }, { fs: Static.fs, path: Static.path }]]);
-    expect(API.CreatorDataApi.callCount).to.eql(1);
-    expect(API.RemoteDataAPI.callCount).to.eql(1);
+    expect(initStub.callCount).to.eql(1);
+    expect(API.CreatorDataApi.callCount).to.eql(0);
+    expect(API.RemoteDataAPI.callCount).to.eql(0);
   });
 
-  it('remote api', () => {
+  it('remote api', async () => {
+    const initStub = sinon.stub();
     const API = {
       LocalDataApi: sinon.stub().returns({ type: 'local' }),
-      RemoteDataAPI: sinon.stub().returns({ type: 'remote' }),
+      RemoteDataAPI: sinon.stub().returns({ type: 'remote', init: initStub }),
       CreatorDataApi: sinon.stub().returns({ type: 'creator' }),
     };
 
@@ -49,24 +52,21 @@ describe('dataAPI client unit tests', () => {
 
     const origin = 'voiceflow.com';
 
-    expect(new DataAPI(config as any, API as any).get('', origin)).to.eql({ type: 'remote' });
+    expect(await new DataAPI(config as any, API as any).get('', origin)).to.eql({ type: 'remote', init: initStub });
     expect(API.RemoteDataAPI.args).to.eql([
       [{ platform: 'general', adminToken: config.ADMIN_SERVER_DATA_API_TOKEN, dataEndpoint: config.VF_DATA_ENDPOINT }, { axios: Static.axios }],
     ]);
-    expect(API.CreatorDataApi.callCount).to.eql(1);
+    expect(initStub.callCount).to.eql(1);
+    expect(API.CreatorDataApi.callCount).to.eql(0);
     expect(API.LocalDataApi.callCount).to.eql(0);
   });
 
-  it('creator api', () => {
-    const updateAuthorizationStub = sinon.stub();
-    const creatorDataAPIReturn = {
-      type: 'creator',
-      updateAuthorization: updateAuthorizationStub,
-    };
+  it('creator api', async () => {
+    const initStub = sinon.stub();
     const API = {
       LocalDataApi: sinon.stub().returns({ type: 'local' }),
       RemoteDataAPI: sinon.stub().returns({ type: 'remote' }),
-      CreatorDataApi: sinon.stub().returns(creatorDataAPIReturn),
+      CreatorDataApi: sinon.stub().returns({ type: 'creator', init: initStub }),
     };
 
     const config = {
@@ -78,23 +78,23 @@ describe('dataAPI client unit tests', () => {
     };
 
     const origin = 'other-site.com';
-
     const dataAPI = new DataAPI(config as any, API as any);
 
-    expect(dataAPI.get('', origin)).to.eql(creatorDataAPIReturn);
+    expect(await dataAPI.get('', origin)).to.eql({ type: 'creator', init: initStub });
     expect(API.CreatorDataApi.args).to.eql([[{ endpoint: `${config.CREATOR_API_ENDPOINT}/v2`, authorization: config.CREATOR_API_AUTHORIZATION }]]);
-    expect(API.RemoteDataAPI.callCount).to.eql(1);
+    expect(initStub.callCount).to.eql(1);
     expect(API.LocalDataApi.callCount).to.eql(0);
+    expect(API.RemoteDataAPI.callCount).to.eql(0);
 
-    expect(dataAPI.get('new auth', origin)).to.eql(creatorDataAPIReturn);
-    expect(updateAuthorizationStub.secondCall.args).to.eql(['new auth']);
+    expect(await dataAPI.get('new auth', origin)).to.eql({ type: 'creator', init: initStub });
+    expect(API.CreatorDataApi.secondCall.args).to.eql([{ endpoint: `${config.CREATOR_API_ENDPOINT}/v2`, authorization: 'new auth' }]);
   });
 
   it('fails if no data API env configuration set', () => {
     expect(() => new DataAPI({} as any, {} as any)).to.throw('no data API env configuration set');
   });
 
-  it('fails if origin matches but no remote data API env configuration set', () => {
+  it('fails if origin matches but no remote data API env configuration set', async () => {
     const API = {
       LocalDataApi: sinon.stub().returns({ type: 'local' }),
       RemoteDataAPI: sinon.stub().returns({ type: 'remote' }),
@@ -108,11 +108,12 @@ describe('dataAPI client unit tests', () => {
     };
 
     const origin = 'voiceflow.com';
+    const dataAPI = new DataAPI(config as any, API as any);
 
-    expect(() => new DataAPI(config as any, API as any).get('', origin)).to.throw('no remote data API env configuration set');
+    expect(dataAPI.get('', origin)).to.be.rejectedWith('no remote data API env configuration set');
   });
 
-  it('fails if no PROJECT_SOURCE and origin does not match but no creator data API env configuration set', () => {
+  it('fails if no PROJECT_SOURCE and origin does not match but no creator data API env configuration set', async () => {
     const API = {
       LocalDataApi: sinon.stub().returns({ type: 'local' }),
       RemoteDataAPI: sinon.stub().returns({ type: 'remote' }),
@@ -126,7 +127,8 @@ describe('dataAPI client unit tests', () => {
     };
 
     const origin = 'other-site.com';
+    const dataAPI = new DataAPI(config as any, API as any);
 
-    expect(() => new DataAPI(config as any, API as any).get('', origin)).to.throw('no creator data API env configuration set');
+    expect(dataAPI.get('', origin)).to.be.rejectedWith('no creator data API env configuration set');
   });
 });

--- a/tests/lib/clients/dataAPI.unit.ts
+++ b/tests/lib/clients/dataAPI.unit.ts
@@ -19,12 +19,17 @@ describe('dataAPI client unit tests', () => {
 
     const config = {
       PROJECT_SOURCE: 'cool.vf',
+      ADMIN_SERVER_DATA_API_TOKEN: 'token',
+      VF_DATA_ENDPOINT: 'endpoint',
+      CREATOR_API_AUTHORIZATION: 'creator auth',
+      CREATOR_API_ENDPOINT: 'creator endpoint',
+      CREATOR_APP_ENDPOINT: 'voiceflow.com',
     };
 
-    expect(DataAPI(config as any, API as any)).to.eql({ type: 'local' });
+    expect(new DataAPI(config as any, API as any).get()).to.eql({ type: 'local' });
     expect(API.LocalDataApi.args).to.eql([[{ projectSource: config.PROJECT_SOURCE }, { fs: Static.fs, path: Static.path }]]);
-    expect(API.CreatorDataApi.callCount).to.eql(0);
-    expect(API.RemoteDataAPI.callCount).to.eql(0);
+    expect(API.CreatorDataApi.callCount).to.eql(1);
+    expect(API.RemoteDataAPI.callCount).to.eql(1);
   });
 
   it('remote api', () => {
@@ -39,17 +44,57 @@ describe('dataAPI client unit tests', () => {
       VF_DATA_ENDPOINT: 'endpoint',
       CREATOR_API_AUTHORIZATION: 'creator auth',
       CREATOR_API_ENDPOINT: 'creator endpoint',
+      CREATOR_APP_ENDPOINT: 'voiceflow.com',
     };
 
-    expect(DataAPI(config as any, API as any)).to.eql({ type: 'remote' });
+    const origin = 'voiceflow.com';
+
+    expect(new DataAPI(config as any, API as any).get('', origin)).to.eql({ type: 'remote' });
     expect(API.RemoteDataAPI.args).to.eql([
       [{ platform: 'general', adminToken: config.ADMIN_SERVER_DATA_API_TOKEN, dataEndpoint: config.VF_DATA_ENDPOINT }, { axios: Static.axios }],
     ]);
-    expect(API.CreatorDataApi.callCount).to.eql(0);
+    expect(API.CreatorDataApi.callCount).to.eql(1);
     expect(API.LocalDataApi.callCount).to.eql(0);
   });
 
   it('creator api', () => {
+    const updateAuthorizationStub = sinon.stub();
+    const creatorDataAPIReturn = {
+      type: 'creator',
+      updateAuthorization: updateAuthorizationStub,
+    };
+    const API = {
+      LocalDataApi: sinon.stub().returns({ type: 'local' }),
+      RemoteDataAPI: sinon.stub().returns({ type: 'remote' }),
+      CreatorDataApi: sinon.stub().returns(creatorDataAPIReturn),
+    };
+
+    const config = {
+      ADMIN_SERVER_DATA_API_TOKEN: 'token',
+      VF_DATA_ENDPOINT: 'endpoint',
+      CREATOR_API_AUTHORIZATION: 'creator auth',
+      CREATOR_API_ENDPOINT: 'creator endpoint',
+      CREATOR_APP_ENDPOINT: 'voiceflow.com',
+    };
+
+    const origin = 'other-site.com';
+
+    const dataAPI = new DataAPI(config as any, API as any);
+
+    expect(dataAPI.get('', origin)).to.eql(creatorDataAPIReturn);
+    expect(API.CreatorDataApi.args).to.eql([[{ endpoint: `${config.CREATOR_API_ENDPOINT}/v2`, authorization: config.CREATOR_API_AUTHORIZATION }]]);
+    expect(API.RemoteDataAPI.callCount).to.eql(1);
+    expect(API.LocalDataApi.callCount).to.eql(0);
+
+    expect(dataAPI.get('new auth', origin)).to.eql(creatorDataAPIReturn);
+    expect(updateAuthorizationStub.secondCall.args).to.eql(['new auth']);
+  });
+
+  it('fails if no data API env configuration set', () => {
+    expect(() => new DataAPI({} as any, {} as any)).to.throw('no data API env configuration set');
+  });
+
+  it('fails if origin matches but no remote data API env configuration set', () => {
     const API = {
       LocalDataApi: sinon.stub().returns({ type: 'local' }),
       RemoteDataAPI: sinon.stub().returns({ type: 'remote' }),
@@ -59,15 +104,29 @@ describe('dataAPI client unit tests', () => {
     const config = {
       CREATOR_API_AUTHORIZATION: 'creator auth',
       CREATOR_API_ENDPOINT: 'creator endpoint',
+      CREATOR_APP_ENDPOINT: 'voiceflow.com',
     };
 
-    expect(DataAPI(config as any, API as any)).to.eql({ type: 'creator' });
-    expect(API.CreatorDataApi.args).to.eql([[{ endpoint: `${config.CREATOR_API_ENDPOINT}/v2`, authorization: config.CREATOR_API_AUTHORIZATION }]]);
-    expect(API.RemoteDataAPI.callCount).to.eql(0);
-    expect(API.LocalDataApi.callCount).to.eql(0);
+    const origin = 'voiceflow.com';
+
+    expect(() => new DataAPI(config as any, API as any).get('', origin)).to.throw('no remote data API env configuration set');
   });
 
-  it('fails', () => {
-    expect(() => DataAPI({} as any, {} as any)).to.throw('no data API env configuration set');
+  it('fails if no PROJECT_SOURCE and origin does not match but no creator data API env configuration set', () => {
+    const API = {
+      LocalDataApi: sinon.stub().returns({ type: 'local' }),
+      RemoteDataAPI: sinon.stub().returns({ type: 'remote' }),
+      CreatorDataApi: sinon.stub().returns({ type: 'creator' }),
+    };
+
+    const config = {
+      ADMIN_SERVER_DATA_API_TOKEN: 'token',
+      VF_DATA_ENDPOINT: 'endpoint',
+      CREATOR_APP_ENDPOINT: 'voiceflow.com',
+    };
+
+    const origin = 'other-site.com';
+
+    expect(() => new DataAPI(config as any, API as any).get('', origin)).to.throw('no creator data API env configuration set');
   });
 });

--- a/tests/lib/clients/dataAPI.unit.ts
+++ b/tests/lib/clients/dataAPI.unit.ts
@@ -11,9 +11,8 @@ describe('dataAPI client unit tests', () => {
   });
 
   it('local api', async () => {
-    const initStub = sinon.stub();
     const API = {
-      LocalDataApi: sinon.stub().returns({ type: 'local', init: initStub }),
+      LocalDataApi: sinon.stub().returns({ type: 'local' }),
       RemoteDataAPI: sinon.stub().returns({ type: 'remote' }),
       CreatorDataApi: sinon.stub().returns({ type: 'creator' }),
     };
@@ -27,18 +26,16 @@ describe('dataAPI client unit tests', () => {
       CREATOR_APP_ORIGIN: 'voiceflow.com',
     };
 
-    expect(await new DataAPI(config as any, API as any).get()).to.eql({ type: 'local', init: initStub });
+    expect(await new DataAPI(config as any, API as any).get()).to.eql({ type: 'local' });
     expect(API.LocalDataApi.args).to.eql([[{ projectSource: config.PROJECT_SOURCE }, { fs: Static.fs, path: Static.path }]]);
-    expect(initStub.callCount).to.eql(1);
     expect(API.CreatorDataApi.callCount).to.eql(0);
-    expect(API.RemoteDataAPI.callCount).to.eql(0);
+    expect(API.RemoteDataAPI.callCount).to.eql(1);
   });
 
   it('remote api', async () => {
-    const initStub = sinon.stub();
     const API = {
       LocalDataApi: sinon.stub().returns({ type: 'local' }),
-      RemoteDataAPI: sinon.stub().returns({ type: 'remote', init: initStub }),
+      RemoteDataAPI: sinon.stub().returns({ type: 'remote' }),
       CreatorDataApi: sinon.stub().returns({ type: 'creator' }),
     };
 
@@ -52,11 +49,10 @@ describe('dataAPI client unit tests', () => {
 
     const origin = 'voiceflow.com';
 
-    expect(await new DataAPI(config as any, API as any).get('', origin)).to.eql({ type: 'remote', init: initStub });
+    expect(await new DataAPI(config as any, API as any).get('', origin)).to.eql({ type: 'remote' });
     expect(API.RemoteDataAPI.args).to.eql([
       [{ platform: 'general', adminToken: config.ADMIN_SERVER_DATA_API_TOKEN, dataEndpoint: config.VF_DATA_ENDPOINT }, { axios: Static.axios }],
     ]);
-    expect(initStub.callCount).to.eql(1);
     expect(API.CreatorDataApi.callCount).to.eql(0);
     expect(API.LocalDataApi.callCount).to.eql(0);
   });
@@ -84,7 +80,7 @@ describe('dataAPI client unit tests', () => {
     expect(API.CreatorDataApi.args).to.eql([[{ endpoint: `${config.CREATOR_API_ENDPOINT}/v2`, authorization: config.CREATOR_API_AUTHORIZATION }]]);
     expect(initStub.callCount).to.eql(1);
     expect(API.LocalDataApi.callCount).to.eql(0);
-    expect(API.RemoteDataAPI.callCount).to.eql(0);
+    expect(API.RemoteDataAPI.callCount).to.eql(1);
 
     expect(await dataAPI.get('new auth', origin)).to.eql({ type: 'creator', init: initStub });
     expect(API.CreatorDataApi.secondCall.args).to.eql([{ endpoint: `${config.CREATOR_API_ENDPOINT}/v2`, authorization: 'new auth' }]);

--- a/tests/lib/clients/dataAPI.unit.ts
+++ b/tests/lib/clients/dataAPI.unit.ts
@@ -23,7 +23,7 @@ describe('dataAPI client unit tests', () => {
       VF_DATA_ENDPOINT: 'endpoint',
       CREATOR_API_AUTHORIZATION: 'creator auth',
       CREATOR_API_ENDPOINT: 'creator endpoint',
-      CREATOR_APP_ENDPOINT: 'voiceflow.com',
+      CREATOR_APP_ORIGIN: 'voiceflow.com',
     };
 
     expect(new DataAPI(config as any, API as any).get()).to.eql({ type: 'local' });
@@ -44,7 +44,7 @@ describe('dataAPI client unit tests', () => {
       VF_DATA_ENDPOINT: 'endpoint',
       CREATOR_API_AUTHORIZATION: 'creator auth',
       CREATOR_API_ENDPOINT: 'creator endpoint',
-      CREATOR_APP_ENDPOINT: 'voiceflow.com',
+      CREATOR_APP_ORIGIN: 'voiceflow.com',
     };
 
     const origin = 'voiceflow.com';
@@ -74,7 +74,7 @@ describe('dataAPI client unit tests', () => {
       VF_DATA_ENDPOINT: 'endpoint',
       CREATOR_API_AUTHORIZATION: 'creator auth',
       CREATOR_API_ENDPOINT: 'creator endpoint',
-      CREATOR_APP_ENDPOINT: 'voiceflow.com',
+      CREATOR_APP_ORIGIN: 'voiceflow.com',
     };
 
     const origin = 'other-site.com';
@@ -104,7 +104,7 @@ describe('dataAPI client unit tests', () => {
     const config = {
       CREATOR_API_AUTHORIZATION: 'creator auth',
       CREATOR_API_ENDPOINT: 'creator endpoint',
-      CREATOR_APP_ENDPOINT: 'voiceflow.com',
+      CREATOR_APP_ORIGIN: 'voiceflow.com',
     };
 
     const origin = 'voiceflow.com';
@@ -122,7 +122,7 @@ describe('dataAPI client unit tests', () => {
     const config = {
       ADMIN_SERVER_DATA_API_TOKEN: 'token',
       VF_DATA_ENDPOINT: 'endpoint',
-      CREATOR_APP_ENDPOINT: 'voiceflow.com',
+      CREATOR_APP_ORIGIN: 'voiceflow.com',
     };
 
     const origin = 'other-site.com';

--- a/tests/lib/controllers/interact.unit.ts
+++ b/tests/lib/controllers/interact.unit.ts
@@ -7,11 +7,21 @@ describe('interact controller unit tests', () => {
   describe('handler', () => {
     it('works correctly', async () => {
       const req = {
+        headers: { authorization: 'auth', origin: 'origin' },
         body: { state: { foo: 'bar' }, request: 'request', config: { tts: true } },
         params: { versionID: 'versionID' },
         query: { locale: 'locale' },
       };
-      const context = { state: req.body.state, request: req.body.request, versionID: req.params.versionID, data: { locale: req.query.locale } };
+      const context = {
+        state: req.body.state,
+        request: req.body.request,
+        versionID: req.params.versionID,
+        data: {
+          authorization: req.headers.authorization,
+          locale: req.query.locale,
+          origin: req.headers.origin,
+        },
+      };
       const output = (state: string, params?: any) => ({ ...context, ...params, state, end: false });
 
       const services = {
@@ -46,6 +56,7 @@ describe('interact controller unit tests', () => {
     it('omits TTS if specified in config', async () => {
       const req = {
         body: { state: { foo: 'bar' }, request: 'request', config: { tts: false } },
+        headers: {},
         params: { versionID: 'versionID' },
         query: { locale: 'locale' },
       };
@@ -79,6 +90,7 @@ describe('interact controller unit tests', () => {
   it('includes TTS if config is unspecified', async () => {
     const req = {
       body: { state: { foo: 'bar' }, request: 'request' },
+      headers: {},
       params: { versionID: 'versionID' },
       query: { locale: 'locale' },
     };
@@ -108,6 +120,7 @@ describe('interact controller unit tests', () => {
   it('includes TTS if tts is unspecified', async () => {
     const req = {
       body: { state: { foo: 'bar' }, request: 'request', config: {} },
+      headers: {},
       params: { versionID: 'versionID' },
       query: { locale: 'locale' },
     };

--- a/tests/lib/controllers/interact.unit.ts
+++ b/tests/lib/controllers/interact.unit.ts
@@ -17,9 +17,11 @@ describe('interact controller unit tests', () => {
         request: req.body.request,
         versionID: req.params.versionID,
         data: {
-          authorization: req.headers.authorization,
           locale: req.query.locale,
-          origin: req.headers.origin,
+          reqHeaders: {
+            authorization: req.headers.authorization,
+            origin: req.headers.origin,
+          },
         },
       };
       const output = (state: string, params?: any) => ({ ...context, ...params, state, end: false });

--- a/tests/lib/services/runtime/index.unit.ts
+++ b/tests/lib/services/runtime/index.unit.ts
@@ -60,7 +60,8 @@ describe('runtime manager unit tests', () => {
         versionID: VERSION_ID,
         data: { api: { getProgram: 'api' } },
       });
-      expect(client.createRuntime.args).to.eql([[VERSION_ID, state, request, { api: context.data.api }]]);
+      expect(utils.Client.firstCall.args[0].api).to.eql({ getProgram: 'api' });
+      expect(client.createRuntime.args).to.eql([[VERSION_ID, state, request]]);
       expect(runtime.update.callCount).to.eql(1);
     });
 
@@ -106,7 +107,8 @@ describe('runtime manager unit tests', () => {
         versionID: VERSION_ID,
         data: { api: { getProgram: 'api' } },
       });
-      expect(client.createRuntime.args).to.eql([[VERSION_ID, state, request, { api: context.data.api }]]);
+      expect(utils.Client.firstCall.args[0].api).to.eql({ getProgram: 'api' });
+      expect(client.createRuntime.args).to.eql([[VERSION_ID, state, request]]);
       expect(utils.Handlers.callCount).to.eql(1);
     });
 

--- a/tests/lib/services/state/index.unit.ts
+++ b/tests/lib/services/state/index.unit.ts
@@ -38,16 +38,18 @@ describe('state manager unit tests', () => {
 
   describe('generate', () => {
     it('works', async () => {
+      const getVersionStub = sinon.stub().resolves(version);
       const services = {
         dataAPI: {
-          getVersion: sinon.stub(),
+          get: sinon.stub().returns({ getVersion: getVersionStub }),
         },
       };
 
       const stateManager = new StateManager({ ...services, utils: { ...defaultUtils } } as any, {} as any);
 
       expect(await stateManager.generate(version as any)).to.eql({ ...state, variables: { variable1: 1, variable2: 2 } });
-      expect(services.dataAPI.getVersion.callCount).to.eql(0);
+      expect(services.dataAPI.get.callCount).to.eql(0);
+      expect(getVersionStub.callCount).to.eql(0);
     });
   });
 
@@ -68,9 +70,10 @@ describe('state manager unit tests', () => {
 
   describe('handle', () => {
     it('works', async () => {
+      const getVersionStub = sinon.stub().resolves(version);
       const services = {
         dataAPI: {
-          getVersion: sinon.stub().resolves(version),
+          get: sinon.stub().returns({ getVersion: getVersionStub }),
         },
       };
 
@@ -95,7 +98,7 @@ describe('state manager unit tests', () => {
         },
       });
       expect(await newContext.data.api.getVersion(VERSION_ID)).to.eql(version);
-      expect(services.dataAPI.getVersion.args).to.eql([[VERSION_ID]]);
+      expect(getVersionStub.args).to.eql([[VERSION_ID]]);
     });
   });
 });

--- a/types.ts
+++ b/types.ts
@@ -32,6 +32,8 @@ export interface Config {
   CREATOR_API_ENDPOINT: string | null;
   CREATOR_API_AUTHORIZATION: string | null;
 
+  CREATOR_APP_ENDPOINT: string | null;
+
   ADMIN_SERVER_DATA_API_TOKEN: string | null;
   VF_DATA_ENDPOINT: string | null;
   // Logging

--- a/types.ts
+++ b/types.ts
@@ -74,6 +74,8 @@ export type AnyClass = Class<any, any[]>;
 export type ContextData = {
   locale?: string;
   api: CacheDataAPI;
+  authorization?: string;
+  origin?: string;
 };
 
 export type Context = Runtime.Context<GeneralRequest, GeneralTrace, ContextData>;

--- a/types.ts
+++ b/types.ts
@@ -32,7 +32,7 @@ export interface Config {
   CREATOR_API_ENDPOINT: string | null;
   CREATOR_API_AUTHORIZATION: string | null;
 
-  CREATOR_APP_ENDPOINT: string | null;
+  CREATOR_APP_ORIGIN: string | null;
 
   ADMIN_SERVER_DATA_API_TOKEN: string | null;
   VF_DATA_ENDPOINT: string | null;

--- a/types.ts
+++ b/types.ts
@@ -74,8 +74,10 @@ export type AnyClass = Class<any, any[]>;
 export type ContextData = {
   locale?: string;
   api: CacheDataAPI;
-  authorization?: string;
-  origin?: string;
+  reqHeaders?: {
+    authorization?: string;
+    origin?: string;
+  };
 };
 
 export type Context = Runtime.Context<GeneralRequest, GeneralTrace, ContextData>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -876,6 +876,17 @@
     regenerator-runtime "^0.13.5"
     superstruct "^0.10.12"
 
+"@voiceflow/api-sdk@v1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-1.27.0.tgz#d128a3e6c39406e4087dc16eee00bc448e9e610a"
+  integrity sha512-kAYOEhA1zdHRHWz9onPC4g/ikAUiUaR/VFw12LFR+WzxXniwQ/J4qpcaJqCj9x+AEQ9AeC2QvEGICVu4JOaeXw==
+  dependencies:
+    "@types/atob" "^2.1.2"
+    "@voiceflow/logger" "^1.4.2"
+    atob "^2.1.2"
+    axios "^0.21.1"
+    superstruct "^0.10.12"
+
 "@voiceflow/backend-utils@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@voiceflow/backend-utils/-/backend-utils-2.2.0.tgz#d1a51a00103d7e4bbc8ccff5909a6e3d6437b84a"
@@ -1401,6 +1412,13 @@ axios@^0.19.0, axios@^0.19.2:
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
+
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
 
 axobject-query@^2.1.2:
   version "2.2.0"
@@ -3312,6 +3330,11 @@ follow-redirects@1.5.10:
   integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
     debug "=3.1.0"
+
+follow-redirects@^1.10.0:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
+  integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
**Fixes or implements CORE-5221**

### Brief description. What is this change?
Allows for API key support when hitting the interact endpoint.

For req with origin voiceflow.com, dataAPI uses server-data-api. Otherwise, it uses creator-api and attaches the API key that the user request should have. The API key could come from an environment variable, or overrode by one in the request header.

This keeps server-data-api as our internal interface to the db and creator-api as the external interface protected by auth_vf or api-key.

### Implementation details. How do you make this change?
DataAPI is now a class instead of a function, which creates all three APIs if it has the information to. When an API call needs to be made, get() is called, which takes in the authorization (API key or auth_vf) and the origin of the request and determines which API it should make the call to.

⚠️⚠️⚠️ CREATOR_APP_ORIGIN is a new environment variable which needs to be updated in production. This is needed so that dataAPI can use server-data-api if a request's origin is CREATOR_APP_ORIGIN. ⚠️⚠️⚠️

### Related PRs
| branch              | PR          |
| ------------------- | ----------- |
| api-sdk     | [link](https://github.com/voiceflow/api-sdk/pull/50) |

### Checklist

- [ ✅  ] title of PR reflects the branch name
- [ ✅  ] all commits adhere to conventional commits
- [ ✅  ] appropriate tests have been written
- [ ✅  ] all the dependencies are upgraded