### PR TITLE
feat: rate limiting (CORE-5291)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -15,3 +15,6 @@ CREATOR_API_ENDPOINT='https://localhost:8080'
 
 # required for nlu and tts services
 GENERAL_SERVICE_ENDPOINT='https://localhost:6970'
+
+REDIS_CLUSTER_HOST='localhost'
+REDIS_CLUSTER_PORT=6379

--- a/backend/api/routers/interact.ts
+++ b/backend/api/routers/interact.ts
@@ -9,11 +9,10 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
 
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
   router.use(middlewares.rateLimit.verify);
-  router.use(middlewares.rateLimit.consume);
 
-  router.get('/:versionID/state', controllers.interact.state);
+  router.get('/:versionID/state', middlewares.rateLimit.consume, controllers.interact.state);
 
-  router.post('/:versionID', controllers.interact.handler);
+  router.post('/:versionID', middlewares.rateLimit.consume, controllers.interact.handler);
 
   return router;
 };

--- a/backend/api/routers/interact.ts
+++ b/backend/api/routers/interact.ts
@@ -4,10 +4,13 @@ import express from 'express';
 import { BODY_PARSER_SIZE_LIMIT } from '@/backend/constants';
 import { ControllerMap, MiddlewareMap } from '@/lib';
 
-export default (_: MiddlewareMap, controllers: ControllerMap) => {
+export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   const router = express.Router();
 
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
+  router.use(middlewares.rateLimit.verify);
+  router.use(middlewares.rateLimit.consume);
+
   router.get('/:versionID/state', controllers.interact.state);
 
   router.post('/:versionID', controllers.interact.handler);

--- a/config.ts
+++ b/config.ts
@@ -56,6 +56,13 @@ const CONFIG: Config = {
   // Logging
   LOG_LEVEL: getOptionalProcessEnv('LOG_LEVEL'),
   MIDDLEWARE_VERBOSITY: getOptionalProcessEnv('MIDDLEWARE_VERBOSITY'),
+
+  REDIS_CLUSTER_HOST: getRequiredProcessEnv('REDIS_CLUSTER_HOST'),
+  REDIS_CLUSTER_PORT: Number(getRequiredProcessEnv('REDIS_CLUSTER_PORT')),
+
+  // 500 requests per minute
+  RATE_LIMITER_POINTS: Number(getOptionalProcessEnv('RATE_LIMITER_POINTS', '500')),
+  RATE_LIMITER_DURATION: Number(getOptionalProcessEnv('RATE_LIMITER_DURATION', '60')),
 };
 
 export default CONFIG;

--- a/config.ts
+++ b/config.ts
@@ -60,9 +60,13 @@ const CONFIG: Config = {
   REDIS_CLUSTER_HOST: getRequiredProcessEnv('REDIS_CLUSTER_HOST'),
   REDIS_CLUSTER_PORT: Number(getRequiredProcessEnv('REDIS_CLUSTER_PORT')),
 
+  // rate limiting
+  // 1000 request per minute
+  RATE_LIMITER_POINTS_PUBLIC: Number(getOptionalProcessEnv('RATE_LIMITER_POINTS_PUBLIC', '1000')),
+  RATE_LIMITER_DURATION_PUBLIC: Number(getOptionalProcessEnv('RATE_LIMITER_DURATION_PUBLIC', '60')),
   // 500 requests per minute
-  RATE_LIMITER_POINTS: Number(getOptionalProcessEnv('RATE_LIMITER_POINTS', '500')),
-  RATE_LIMITER_DURATION: Number(getOptionalProcessEnv('RATE_LIMITER_DURATION', '60')),
+  RATE_LIMITER_POINTS_PRIVATE: Number(getOptionalProcessEnv('RATE_LIMITER_POINTS_PRIVATE', '500')),
+  RATE_LIMITER_DURATION_PRIVATE: Number(getOptionalProcessEnv('RATE_LIMITER_DURATION_PRIVATE', '60')),
 };
 
 export default CONFIG;

--- a/lib/clients/index.ts
+++ b/lib/clients/index.ts
@@ -2,21 +2,29 @@ import { Config } from '@/types';
 
 import DataAPI from './dataAPI';
 import Metrics, { MetricsType } from './metrics';
+import { RateLimiterClient } from './rateLimiter';
+import { RedisClient } from './redis';
 import Static, { StaticType } from './static';
 
 export interface ClientMap extends StaticType {
   dataAPI: DataAPI;
   metrics: MetricsType;
+  redis: ReturnType<typeof RedisClient>;
+  rateLimiterClient: ReturnType<typeof RateLimiterClient>;
 }
 
 /**
  * Build all clients
  */
 const buildClients = (config: Config): ClientMap => {
+  const redis = RedisClient(config);
+
   return {
     ...Static,
     dataAPI: new DataAPI(config),
     metrics: Metrics(config),
+    redis,
+    rateLimiterClient: RateLimiterClient(redis, config),
   };
 };
 

--- a/lib/clients/rateLimiter.ts
+++ b/lib/clients/rateLimiter.ts
@@ -1,0 +1,15 @@
+import { RateLimiterRedis } from 'rate-limiter-flexible';
+
+import { Config } from '@/types';
+
+import { Redis } from './redis';
+
+export type RateLimiter = RateLimiterRedis;
+
+export const RateLimiterClient = (redis: Redis, { RATE_LIMITER_POINTS, RATE_LIMITER_DURATION }: Config) =>
+  new RateLimiterRedis({
+    points: RATE_LIMITER_POINTS,
+    duration: RATE_LIMITER_DURATION,
+    keyPrefix: 'general-runtime-rate-limiter',
+    storeClient: redis,
+  });

--- a/lib/clients/rateLimiter.ts
+++ b/lib/clients/rateLimiter.ts
@@ -6,10 +6,22 @@ import { Redis } from './redis';
 
 export type RateLimiter = RateLimiterRedis;
 
-export const RateLimiterClient = (redis: Redis, { RATE_LIMITER_POINTS, RATE_LIMITER_DURATION }: Config) =>
-  new RateLimiterRedis({
-    points: RATE_LIMITER_POINTS,
-    duration: RATE_LIMITER_DURATION,
-    keyPrefix: 'general-runtime-rate-limiter',
+export const RateLimiterClient = (
+  redis: Redis,
+  { RATE_LIMITER_POINTS_PUBLIC, RATE_LIMITER_DURATION_PUBLIC, RATE_LIMITER_POINTS_PRIVATE, RATE_LIMITER_DURATION_PRIVATE }: Config
+) => ({
+  // public rate limiter - req from creator-app or clients without an authorization
+  public: new RateLimiterRedis({
+    points: RATE_LIMITER_POINTS_PUBLIC,
+    duration: RATE_LIMITER_DURATION_PUBLIC,
+    keyPrefix: 'general-runtime-rate-limiter-public',
     storeClient: redis,
-  });
+  }),
+  // private rate limiter - req from clients with authorization (auth_vf token or api key)
+  private: new RateLimiterRedis({
+    points: RATE_LIMITER_POINTS_PRIVATE,
+    duration: RATE_LIMITER_DURATION_PRIVATE,
+    keyPrefix: 'general-runtime-rate-limiter-private',
+    storeClient: redis,
+  }),
+});

--- a/lib/clients/redis.ts
+++ b/lib/clients/redis.ts
@@ -1,0 +1,7 @@
+import IORedis from 'ioredis';
+
+import { Config } from '@/types';
+
+export type Redis = IORedis.Redis;
+
+export const RedisClient = ({ REDIS_CLUSTER_HOST, REDIS_CLUSTER_PORT }: Config) => new IORedis(REDIS_CLUSTER_PORT, REDIS_CLUSTER_HOST);

--- a/lib/middlewares/index.ts
+++ b/lib/middlewares/index.ts
@@ -2,9 +2,11 @@ import { routeWrapper } from '@/lib/utils';
 import { Config, MiddlewareGroup } from '@/types';
 
 import { FullServiceMap } from '../services';
+import RateLimit from './rateLimit';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface MiddlewareMap {}
+export interface MiddlewareMap {
+  rateLimit: RateLimit;
+}
 
 export interface MiddlewareClass<T = MiddlewareGroup> {
   new (services: FullServiceMap, config: Config): T;
@@ -13,9 +15,10 @@ export interface MiddlewareClass<T = MiddlewareGroup> {
 /**
  * Build all middlewares
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const buildMiddleware = (_services: FullServiceMap, _config: Config) => {
-  const middlewares = {} as MiddlewareMap;
+const buildMiddleware = (services: FullServiceMap, config: Config) => {
+  const middlewares: MiddlewareMap = {
+    rateLimit: new RateLimit(services, config),
+  };
 
   // everything before this will be route-wrapped
   routeWrapper(middlewares);

--- a/lib/middlewares/rateLimit.ts
+++ b/lib/middlewares/rateLimit.ts
@@ -5,7 +5,11 @@ import { AbstractMiddleware } from './utils';
 
 class RateLimit extends AbstractMiddleware {
   async verify(req: Request<{}>, _res: Response, next: NextFunction) {
-    if (!this.config.PROJECT_SOURCE && req.headers.origin !== this.config.CREATOR_APP_ORIGIN && !req.headers.authorization)
+    if (
+      !this.config.PROJECT_SOURCE &&
+      (!this.config.CREATOR_APP_ORIGIN || req.headers.origin !== this.config.CREATOR_APP_ORIGIN) &&
+      !req.headers.authorization
+    )
       throw new VError('Auth Key Required', VError.HTTP_STATUS.UNAUTHORIZED);
 
     next();

--- a/lib/middlewares/rateLimit.ts
+++ b/lib/middlewares/rateLimit.ts
@@ -1,0 +1,21 @@
+import VError from '@voiceflow/verror';
+import { NextFunction, Request, Response } from 'express';
+
+import { AbstractMiddleware } from './utils';
+
+class RateLimit extends AbstractMiddleware {
+  async verify(req: Request<{}>, _res: Response, next: NextFunction) {
+    if (!this.config.PROJECT_SOURCE && req.headers.origin !== this.config.CREATOR_APP_ORIGIN && !req.headers.authorization)
+      throw new VError('Auth Key Required', VError.HTTP_STATUS.UNAUTHORIZED);
+
+    next();
+  }
+
+  async consume(req: Request<{}>, res: Response, next: NextFunction) {
+    await this.services.rateLimit.consume(req, res);
+
+    return next();
+  }
+}
+
+export default RateLimit;

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -5,6 +5,7 @@ import ASR from './asr';
 import Chips from './chips';
 import Dialog from './dialog';
 import NLU from './nlu';
+import RateLimit from './rateLimit';
 import Runtime from './runtime';
 import State from './state';
 import TTS from './tts';
@@ -17,6 +18,7 @@ export interface ServiceMap {
   dialog: Dialog;
   tts: TTS;
   chips: Chips;
+  rateLimit: RateLimit;
 }
 
 export interface FullServiceMap extends ClientMap, ServiceMap {}
@@ -36,6 +38,7 @@ const buildServices = (config: Config, clients: ClientMap): FullServiceMap => {
   services.tts = new TTS(services, config);
   services.dialog = new Dialog(services, config);
   services.chips = new Chips(services, config);
+  services.rateLimit = new RateLimit(services, config);
 
   return services;
 };

--- a/lib/services/rateLimit.ts
+++ b/lib/services/rateLimit.ts
@@ -1,0 +1,31 @@
+import VError from '@voiceflow/verror';
+import { Request, Response } from 'express';
+import { RateLimiterRes } from 'rate-limiter-flexible';
+
+import { AbstractManager } from './utils';
+
+class RateLimit extends AbstractManager {
+  setHeaders(res: Response, rateLimiterRes: RateLimiterRes) {
+    res.setHeader('X-RateLimit-Limit', this.config.RATE_LIMITER_POINTS);
+    res.setHeader('X-RateLimit-Remaining', rateLimiterRes.remainingPoints);
+    res.setHeader('X-RateLimit-Reset', new Date(Date.now() + rateLimiterRes.msBeforeNext).toString());
+  }
+
+  async consume(req: Request, res: Response) {
+    try {
+      // rate limit by auth key
+      if (req.headers.authorization) {
+        const rateLimiterRes = await this.services.rateLimiterClient.consume(req.headers.authorization);
+        this.services.rateLimit.setHeaders(res, rateLimiterRes);
+      }
+    } catch (rateLimiterRes) {
+      res.setHeader('Retry-After', Math.floor(rateLimiterRes.msBeforeNext / 1000));
+
+      this.services.rateLimit.setHeaders(res, rateLimiterRes);
+
+      throw new VError('Too Many Request', VError.HTTP_STATUS.TOO_MANY_REQUESTS);
+    }
+  }
+}
+
+export default RateLimit;

--- a/lib/services/rateLimit.ts
+++ b/lib/services/rateLimit.ts
@@ -20,11 +20,11 @@ class RateLimit extends AbstractManager {
     try {
       const rateLimiterRes = await rateLimiterClient.consume(resource!);
 
-      this.services.rateLimit.setHeaders(res, rateLimiterRes, maxPoints);
+      this.setHeaders(res, rateLimiterRes, maxPoints);
     } catch (rateLimiterRes) {
       res.setHeader('Retry-After', Math.floor(rateLimiterRes.msBeforeNext / 1000));
 
-      this.services.rateLimit.setHeaders(res, rateLimiterRes, maxPoints);
+      this.setHeaders(res, rateLimiterRes, maxPoints);
 
       throw new VError('Too Many Request', VError.HTTP_STATUS.TOO_MANY_REQUESTS);
     }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "express": "^4.17.1",
     "express-validator": "^6.3.0",
     "helmet": "^3.21.2",
+    "ioredis": "^4.22.0",
     "lodash": "^4.17.15",
+    "rate-limiter-flexible": "^2.2.1",
     "regenerator-runtime": "^0.13.3",
     "talisman": "^1.1.3",
     "words-to-numbers": "^1.5.1"
@@ -52,6 +54,7 @@
     "@types/deep-equal-in-any-order": "^1.0.1",
     "@types/express": "^4.17.2",
     "@types/helmet": "^0.0.45",
+    "@types/ioredis": "^4.22.0",
     "@types/jsonwebtoken": "^8.3.5",
     "@types/lodash": "^4.14.149",
     "@types/mocha": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@voiceflow/logger": "^1.4.2",
     "@voiceflow/natural-language-commander": "^0.5.1",
     "@voiceflow/runtime": "1.24.1",
+    "@voiceflow/verror": "^1.1.0",
     "axios": "^0.19.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.0",

--- a/tests/lib/clients/rateLimiter.unit.ts
+++ b/tests/lib/clients/rateLimiter.unit.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import _ from 'lodash';
+import sinon from 'sinon';
+
+import { RateLimiterClient } from '@/lib/clients/rateLimiter';
+
+describe('rateLimiter client unit tests', () => {
+  beforeEach(() => {
+    sinon.restore();
+  });
+
+  it('constructor', async () => {
+    const redis = 'redis-client';
+    const config = {
+      RATE_LIMITER_POINTS_PUBLIC: 1000,
+      RATE_LIMITER_DURATION_PUBLIC: 60,
+      RATE_LIMITER_POINTS_PRIVATE: 500,
+      RATE_LIMITER_DURATION_PRIVATE: 60,
+    };
+
+    const limiter = RateLimiterClient(redis as any, config as any);
+
+    expect(_.get(limiter.public, '_client')).to.eql(redis);
+    expect(_.get(limiter.public, '_points')).to.eql(config.RATE_LIMITER_POINTS_PUBLIC);
+    expect(_.get(limiter.public, '_duration')).to.eql(config.RATE_LIMITER_DURATION_PUBLIC);
+    expect(_.get(limiter.public, '_keyPrefix')).to.eql('general-runtime-rate-limiter-public');
+
+    expect(_.get(limiter.private, '_client')).to.eql(redis);
+    expect(_.get(limiter.private, '_points')).to.eql(config.RATE_LIMITER_POINTS_PRIVATE);
+    expect(_.get(limiter.private, '_duration')).to.eql(config.RATE_LIMITER_DURATION_PRIVATE);
+    expect(_.get(limiter.private, '_keyPrefix')).to.eql('general-runtime-rate-limiter-private');
+  });
+});

--- a/tests/lib/middlewares/rateLimit.unit.ts
+++ b/tests/lib/middlewares/rateLimit.unit.ts
@@ -1,0 +1,84 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import RateLimit from '@/lib/middlewares/rateLimit';
+
+describe('rateLimit middleware unit tests', () => {
+  describe('verify', () => {
+    describe('next called', async () => {
+      it('has auth', async () => {
+        const middleware = new RateLimit({} as any, {} as any);
+        const req = { headers: { authorization: 'auth-key' } };
+        const next = sinon.stub();
+
+        await middleware.verify(req as any, null as any, next);
+
+        expect(next.callCount).to.eql(1);
+      });
+
+      it('origin matches', async () => {
+        const middleware = new RateLimit({} as any, { CREATOR_APP_ORIGIN: 'creator-app' } as any);
+        const req = { headers: { origin: 'creator-app' } };
+        const next = sinon.stub();
+
+        await middleware.verify(req as any, null as any, next);
+
+        expect(next.callCount).to.eql(1);
+      });
+
+      it('project source set', async () => {
+        const middleware = new RateLimit({} as any, { PROJECT_SOURCE: 'project-sources' } as any);
+        const req = { headers: {} };
+        const next = sinon.stub();
+
+        await middleware.verify(req as any, null as any, next);
+
+        expect(next.callCount).to.eql(1);
+      });
+    });
+
+    describe('throws', () => {
+      it('no origin set and no auth', async () => {
+        const middleware = new RateLimit({} as any, {} as any);
+        const req = { headers: {} };
+
+        await expect(middleware.verify(req as any, null as any, null as any)).to.eventually.rejectedWith('Auth Key Required');
+      });
+
+      it('origin doesnt match and no auth', async () => {
+        const middleware = new RateLimit({} as any, {} as any);
+        const req = { headers: {} };
+
+        await expect(middleware.verify(req as any, null as any, null as any)).to.eventually.rejectedWith('Auth Key Required');
+      });
+    });
+  });
+
+  describe('consume', () => {
+    it('next called', async () => {
+      const rateLimit = { consume: sinon.stub() };
+      const middleware = new RateLimit({ rateLimit } as any, {} as any);
+
+      const req = 'req';
+      const res = 'res';
+      const next = sinon.stub();
+
+      await middleware.consume(req as any, res as any, next);
+
+      expect(rateLimit.consume.args).to.eql([[req, res]]);
+      expect(next.callCount).to.eql(1);
+    });
+
+    it('throws', async () => {
+      const rateLimit = { consume: sinon.stub().throws(new Error('custom err')) };
+      const middleware = new RateLimit({ rateLimit } as any, {} as any);
+
+      const req = 'req';
+      const res = 'res';
+
+      await expect(middleware.consume(req as any, res as any, null as any)).to.eventually.rejectedWith('custom err');
+
+      expect(rateLimit.consume.args).to.eql([[req, res]]);
+    });
+  });
+});

--- a/tests/lib/services/rateLimit.unit.ts
+++ b/tests/lib/services/rateLimit.unit.ts
@@ -1,0 +1,91 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import RateLimit from '@/lib/services/rateLimit';
+
+describe('rateLimit manager unit tests', () => {
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers(Date.now()); // fake Date.now
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    clock.restore();
+  });
+
+  describe('setHeaders', () => {
+    it('works', () => {
+      const service = new RateLimit({} as any, {} as any);
+      const res = { setHeader: sinon.stub() };
+      const rateLimiterRes = {
+        remainingPoints: 100,
+        msBeforeNext: 50000,
+      };
+      const maxPoints = 1000;
+
+      service.setHeaders(res as any, rateLimiterRes as any, maxPoints);
+
+      expect(res.setHeader.args).to.eql([
+        ['X-RateLimit-Limit', maxPoints],
+        ['X-RateLimit-Remaining', rateLimiterRes.remainingPoints],
+        ['X-RateLimit-Reset', new Date(clock.now + rateLimiterRes.msBeforeNext).toString()],
+      ]);
+    });
+  });
+
+  describe('consume', () => {
+    it('private', async () => {
+      const config = { RATE_LIMITER_POINTS_PRIVATE: 1000 };
+      const rateLimiterRes = { foo: 'bar' };
+      const services = { rateLimiterClient: { private: { consume: sinon.stub().resolves(rateLimiterRes) } } };
+      const service = new RateLimit(services as any, config as any);
+      const setHeadersStub = sinon.stub();
+      service.setHeaders = setHeadersStub;
+
+      const req = { headers: { authorization: 'auth-key' } };
+      const res = 'response';
+
+      await service.consume(req as any, res as any);
+
+      expect(services.rateLimiterClient.private.consume.args).to.eql([[req.headers.authorization]]);
+      expect(setHeadersStub.args).to.eql([[res, rateLimiterRes, config.RATE_LIMITER_POINTS_PRIVATE]]);
+    });
+
+    it('public', async () => {
+      const config = { RATE_LIMITER_POINTS_PUBLIC: 1000 };
+      const rateLimiterRes = { foo: 'bar' };
+      const services = { rateLimiterClient: { public: { consume: sinon.stub().resolves(rateLimiterRes) } } };
+      const service = new RateLimit(services as any, config as any);
+      const setHeadersStub = sinon.stub();
+      service.setHeaders = setHeadersStub;
+
+      const req = { headers: {}, params: { versionID: 'version-id' } };
+      const res = 'response';
+
+      await service.consume(req as any, res as any);
+
+      expect(services.rateLimiterClient.public.consume.args).to.eql([[req.params.versionID]]);
+      expect(setHeadersStub.args).to.eql([[res, rateLimiterRes, config.RATE_LIMITER_POINTS_PUBLIC]]);
+    });
+
+    it('throws', async () => {
+      const config = { RATE_LIMITER_POINTS_PUBLIC: 1000 };
+      const rateLimiterRes = { msBeforeNext: 50000 };
+      const services = { rateLimiterClient: { public: { consume: sinon.stub().throws(rateLimiterRes) } } };
+      const service = new RateLimit(services as any, config as any);
+      const setHeadersStub = sinon.stub();
+      service.setHeaders = setHeadersStub;
+
+      const req = { headers: {}, params: { versionID: 'version-id' } };
+      const res = { setHeader: sinon.stub() };
+
+      await expect(service.consume(req as any, res as any)).to.eventually.rejectedWith('Too Many Request');
+
+      expect(services.rateLimiterClient.public.consume.args).to.eql([[req.params.versionID]]);
+      expect(res.setHeader.args).to.eql([['Retry-After', Math.floor(rateLimiterRes.msBeforeNext / 1000)]]);
+      expect(setHeadersStub.args).to.eql([[res, rateLimiterRes, config.RATE_LIMITER_POINTS_PUBLIC]]);
+    });
+  });
+});

--- a/tests/server/interact.unit.ts
+++ b/tests/server/interact.unit.ts
@@ -15,7 +15,12 @@ const tests = [
           state: 1,
         },
       },
-      middlewares: {},
+      middlewares: {
+        rateLimit: {
+          verify: 1,
+          consume: 1,
+        },
+      },
       validations: {},
     },
   },
@@ -28,7 +33,12 @@ const tests = [
           handler: 1,
         },
       },
-      middlewares: {},
+      middlewares: {
+        rateLimit: {
+          verify: 1,
+          consume: 1,
+        },
+      },
       validations: {},
     },
   },

--- a/types.ts
+++ b/types.ts
@@ -42,6 +42,12 @@ export interface Config {
 
   PROJECT_SOURCE: string | null;
   SESSIONS_SOURCE: string | null;
+
+  REDIS_CLUSTER_HOST: string;
+  REDIS_CLUSTER_PORT: number;
+
+  RATE_LIMITER_POINTS: number;
+  RATE_LIMITER_DURATION: number;
 }
 
 export interface Request<P extends {} = {}> extends Express.Request<P> {

--- a/types.ts
+++ b/types.ts
@@ -46,8 +46,10 @@ export interface Config {
   REDIS_CLUSTER_HOST: string;
   REDIS_CLUSTER_PORT: number;
 
-  RATE_LIMITER_POINTS: number;
-  RATE_LIMITER_DURATION: number;
+  RATE_LIMITER_POINTS_PUBLIC: number;
+  RATE_LIMITER_DURATION_PUBLIC: number;
+  RATE_LIMITER_POINTS_PRIVATE: number;
+  RATE_LIMITER_DURATION_PRIVATE: number;
 }
 
 export interface Request<P extends {} = {}> extends Express.Request<P> {

--- a/typings/voiceflow__verror.d.ts
+++ b/typings/voiceflow__verror.d.ts
@@ -1,0 +1,24 @@
+declare module '@voiceflow/verror' {
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  import httpStatus, { HttpStatus } from 'http-status';
+
+  class VError {
+    constructor(message: string, code?: number | string, data?: any);
+
+    static HTTP_STATUS: HttpStatus;
+
+    public name: string;
+
+    public code: number | string;
+
+    public message: string;
+
+    public data: any;
+
+    public dateTime: Date;
+  }
+
+  export { httpStatus as HTTP_STATUS };
+
+  export default VError;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -643,6 +643,13 @@
   dependencies:
     "@types/express" "*"
 
+"@types/ioredis@^4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-4.22.0.tgz#b07cc3405d98bae50a642b20790471b4c3c390a9"
+  integrity sha512-BhgyAqt+CIFj/ejdYpWSGYUQzoQr7sFOBYLL8yEExa1tSTi2cy2D3a952zF8Tm4Q1cY3srn8xXZfb2riX6hWjw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/json-schema@^7.0.3":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
@@ -1801,6 +1808,11 @@ clj-fuzzy@^0.3.2:
   resolved "https://registry.yarnpkg.com/clj-fuzzy/-/clj-fuzzy-0.3.3.tgz#b1e5343091c5202dbc52532863e1c4a78457f03d"
   integrity sha1-seU0MJHFIC28UlMoY+HEp4RX8D0=
 
+cluster-key-slot@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
+  integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -2337,6 +2349,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+denque@^1.1.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz#773de0686ff2d8ec2ff92914316a47b73b1c73de"
+  integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
 
 depcheck@^1.3.1:
   version "1.3.1"
@@ -3959,6 +3976,22 @@ io-ts@^2.2.8:
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.10.tgz#447d02df51717464a90712b146ec8dbc21b4a74b"
   integrity sha512-WHx5jJe7hPpc6JoSIVbD+Xn6tYqe3cRvNpX24d8Wi15/kxhRWa8apo0Gzag6Xg99sCNY9OHKylw/Vhv0JAbNPQ==
 
+ioredis@^4.22.0:
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.22.0.tgz#a2e18a29300ffb759670d7ed7023fcf6592031a2"
+  integrity sha512-mtC+jNFMPRxReWx0HodDbcwj34Gj5pK/P4+aE6Nh0pdqgtZKvxUh4z2lVtLjqnRIvMhKaBnIgMYFR8qH/xtttA==
+  dependencies:
+    cluster-key-slot "^1.1.0"
+    debug "^4.1.1"
+    denque "^1.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.flatten "^4.4.0"
+    p-map "^2.1.0"
+    redis-commands "1.7.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.0.1"
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -4547,6 +4580,16 @@ lodash.camelcase@4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
@@ -5374,6 +5417,11 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+p-map@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
 p-map@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-3.0.0.tgz#d704d9af8a2ba684e2600d9a215983d4141a979d"
@@ -5802,6 +5850,11 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
+rate-limiter-flexible@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/rate-limiter-flexible/-/rate-limiter-flexible-2.2.1.tgz#acb81a3d92a0f26bf7e9767e0f96de3a89ecb3a6"
+  integrity sha512-rxCP6kDDdn0cZmVqVlF06yLU+mG3TuwaHV/fUIw3OQyYhza7pzVBtdMhUmfXbBzMS+O464XP+x33pfTDGRGYVA==
+
 raw-body@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332"
@@ -5906,6 +5959,23 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redis-commands@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.7.0.tgz#15a6fea2d58281e27b1cd1acfb4b293e278c3a89"
+  integrity sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+  dependencies:
+    redis-errors "^1.0.0"
 
 referrer-policy@1.2.0:
   version "1.2.0"
@@ -6489,6 +6559,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+standard-as-callback@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.0.1.tgz#ed8bb25648e15831759b6023bdb87e6b60b38126"
+  integrity sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg==
 
 static-extend@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-5291**

### Brief description. What is this change?

Rate limit requests for sdk users

### Implementation details. How do you make this change?

using rate-limiter-flexible and redis as storage (to support multiple instance of this service running in the cluster). 
public limiter - for limiting creator-app or users trying to fake creator-app's origin without auth key (limits by versionID)
private limiter - for limiting auth keys

⚠️⚠️⚠️ NEW ENV VARS TO ADD ⚠️⚠️⚠️
```
  REDIS_CLUSTER_HOST # required
  REDIS_CLUSTER_PORT # required

  // 1000 request per minute
  RATE_LIMITER_POINTS_PUBLIC
  RATE_LIMITER_DURATION_PUBLIC
  // 500 requests per minute
  RATE_LIMITER_POINTS_PRIVATE
  RATE_LIMITER_DURATION_PRIVATE
```
Defaults are arbitrary and open to change. As a scale, currently our prod alexa-runtime is handling an average of 400 requests/min.


### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [x] appropriate tests have been written
- [x] all the dependendencies are upgraded