### PR TITLE
fix: remove origin requirement (CORE-000)

### DIFF
--- a/lib/controllers/interact.ts
+++ b/lib/controllers/interact.ts
@@ -14,7 +14,7 @@ import { AbstractController } from './utils';
 
 class InteractController extends AbstractController {
   async state(req: { headers: { authorization?: string; origin?: string }; params: { versionID: string } }) {
-    const api = await this.services.dataAPI.get(req.headers.authorization, req.headers.origin);
+    const api = await this.services.dataAPI.get(req.headers.authorization);
     const version = await api.getVersion(req.params.versionID);
     return this.services.state.generate(version);
   }

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -65,7 +65,7 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
     }
 
     // cache per interaction (save version call during request/response cycle)
-    const dataApi = await this.services.dataAPI.get(context.data?.reqHeaders?.authorization, context.data?.reqHeaders?.origin);
+    const dataApi = await this.services.dataAPI.get(context.data?.reqHeaders?.authorization);
     const api = new CacheDataAPI(dataApi);
     const version = await api.getVersion(context.versionID!);
 

--- a/tests/lib/clients/dataAPI.unit.ts
+++ b/tests/lib/clients/dataAPI.unit.ts
@@ -21,9 +21,7 @@ describe('dataAPI client unit tests', () => {
       PROJECT_SOURCE: 'cool.vf',
       ADMIN_SERVER_DATA_API_TOKEN: 'token',
       VF_DATA_ENDPOINT: 'endpoint',
-      CREATOR_API_AUTHORIZATION: 'creator auth',
       CREATOR_API_ENDPOINT: 'creator endpoint',
-      CREATOR_APP_ORIGIN: 'voiceflow.com',
     };
 
     expect(await new DataAPI(config as any, API as any).get()).to.eql({ type: 'local' });
@@ -42,14 +40,10 @@ describe('dataAPI client unit tests', () => {
     const config = {
       ADMIN_SERVER_DATA_API_TOKEN: 'token',
       VF_DATA_ENDPOINT: 'endpoint',
-      CREATOR_API_AUTHORIZATION: 'creator auth',
       CREATOR_API_ENDPOINT: 'creator endpoint',
-      CREATOR_APP_ORIGIN: 'voiceflow.com',
     };
 
-    const origin = 'voiceflow.com';
-
-    expect(await new DataAPI(config as any, API as any).get('', origin)).to.eql({ type: 'remote' });
+    expect(await new DataAPI(config as any, API as any).get()).to.eql({ type: 'remote' });
     expect(API.RemoteDataAPI.args).to.eql([
       [{ platform: 'general', adminToken: config.ADMIN_SERVER_DATA_API_TOKEN, dataEndpoint: config.VF_DATA_ENDPOINT }, { axios: Static.axios }],
     ]);
@@ -66,23 +60,20 @@ describe('dataAPI client unit tests', () => {
     };
 
     const config = {
-      ADMIN_SERVER_DATA_API_TOKEN: 'token',
       VF_DATA_ENDPOINT: 'endpoint',
       CREATOR_API_AUTHORIZATION: 'creator auth',
       CREATOR_API_ENDPOINT: 'creator endpoint',
-      CREATOR_APP_ORIGIN: 'voiceflow.com',
     };
 
-    const origin = 'other-site.com';
     const dataAPI = new DataAPI(config as any, API as any);
 
-    expect(await dataAPI.get('', origin)).to.eql({ type: 'creator', init: initStub });
+    expect(await dataAPI.get()).to.eql({ type: 'creator', init: initStub });
     expect(API.CreatorDataApi.args).to.eql([[{ endpoint: `${config.CREATOR_API_ENDPOINT}/v2`, authorization: config.CREATOR_API_AUTHORIZATION }]]);
     expect(initStub.callCount).to.eql(1);
     expect(API.LocalDataApi.callCount).to.eql(0);
-    expect(API.RemoteDataAPI.callCount).to.eql(1);
+    expect(API.RemoteDataAPI.callCount).to.eql(0);
 
-    expect(await dataAPI.get('new auth', origin)).to.eql({ type: 'creator', init: initStub });
+    expect(await dataAPI.get('new auth')).to.eql({ type: 'creator', init: initStub });
     expect(API.CreatorDataApi.secondCall.args).to.eql([{ endpoint: `${config.CREATOR_API_ENDPOINT}/v2`, authorization: 'new auth' }]);
   });
 
@@ -100,13 +91,11 @@ describe('dataAPI client unit tests', () => {
     const config = {
       CREATOR_API_AUTHORIZATION: 'creator auth',
       CREATOR_API_ENDPOINT: 'creator endpoint',
-      CREATOR_APP_ORIGIN: 'voiceflow.com',
     };
 
-    const origin = 'voiceflow.com';
     const dataAPI = new DataAPI(config as any, API as any);
 
-    expect(dataAPI.get('', origin)).to.be.rejectedWith('no remote data API env configuration set');
+    expect(dataAPI.get()).to.be.rejectedWith('no remote data API env configuration set');
   });
 
   it('fails if no PROJECT_SOURCE and origin does not match but no creator data API env configuration set', async () => {
@@ -122,9 +111,8 @@ describe('dataAPI client unit tests', () => {
       CREATOR_APP_ORIGIN: 'voiceflow.com',
     };
 
-    const origin = 'other-site.com';
     const dataAPI = new DataAPI(config as any, API as any);
 
-    expect(dataAPI.get('', origin)).to.be.rejectedWith('no creator data API env configuration set');
+    expect(dataAPI.get()).to.be.rejectedWith('no creator data API env configuration set');
   });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-000**

### Brief description. What is this change?

If we check for origin in the rate limiter middleware, there's no point to do the checkin dataAPI, since it is assume any call that comes in is already validated. Also did a cleaner pattern for `creatorDataApi` with less instance variables.

For deciding whether to use `remoteAPI` or `creatorDataApi`: if the user tries to make an authenticated call, just use `creatorDataApi`

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to undertand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependendencies are upgraded