### PR TITLE
feat: trace handler (CORE-5344)

### DIFF
--- a/lib/clients/remoteDataAPI.ts
+++ b/lib/clients/remoteDataAPI.ts
@@ -1,10 +1,10 @@
 import { Program, Version } from '@voiceflow/api-sdk';
-import { GeneralCommand, GeneralNodes, GeneralVersionData } from '@voiceflow/general-types';
+import { Command, GeneralNodes, GeneralVersionData } from '@voiceflow/general-types';
 import { ServerDataApi } from '@voiceflow/runtime';
 
-class RemoteDataAPI extends ServerDataApi<Program<GeneralNodes, GeneralCommand>, Version<GeneralVersionData>> {
+class RemoteDataAPI extends ServerDataApi<Program<GeneralNodes, Command>, Version<GeneralVersionData>> {
   public getProgram = async (programID: string) => {
-    const { data } = await this.client.get<Program<GeneralNodes, GeneralCommand>>(`/prototype-programs/${programID}`);
+    const { data } = await this.client.get<Program<GeneralNodes, Command>>(`/prototype-programs/${programID}`);
     return data;
   };
 }

--- a/lib/controllers/interact.ts
+++ b/lib/controllers/interact.ts
@@ -3,11 +3,12 @@
  * @packageDocumentation
  */
 
-import { Config, GeneralRequest } from '@voiceflow/general-types';
+import { Config } from '@voiceflow/general-types';
 import { State, TurnBuilder } from '@voiceflow/runtime';
 import { Request } from 'express';
 import _ from 'lodash';
 
+import { RuntimeRequest } from '@/lib/services/runtime/types';
 import { Context } from '@/types';
 
 import { AbstractController } from './utils';
@@ -19,7 +20,7 @@ class InteractController extends AbstractController {
     return this.services.state.generate(version);
   }
 
-  async handler(req: Request<{ versionID: string }, null, { state?: State; request?: GeneralRequest; config?: Config }, { locale?: string }>) {
+  async handler(req: Request<{ versionID: string }, null, { state?: State; request?: RuntimeRequest; config?: Config }, { locale?: string }>) {
     const { runtime, metrics, nlu, tts, chips, dialog, asr, speak, slots, state: stateManager, filter } = this.services;
 
     metrics.generalRequest();

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -69,7 +69,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     }
 
     const request = await this.predict({
-      query: context.request.payload,
+      query: (context.request.payload as unknown) as string,
       model: version.prototype?.model,
       locale: version.prototype?.data.locales[0] as Locale,
       projectID: version.projectID,

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -4,8 +4,9 @@
  */
 
 import { PrototypeModel } from '@voiceflow/api-sdk';
-import { IntentRequest, Locale, RequestType } from '@voiceflow/general-types';
+import { IntentRequest, Locale } from '@voiceflow/general-types';
 
+import { isTextRequest } from '@/lib/services/runtime/types';
 import { Context, ContextHandler } from '@/types';
 
 import { AbstractManager, injectServices } from '../utils';
@@ -50,7 +51,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
   }
 
   handle = async (context: Context) => {
-    if (context.request?.type !== RequestType.TEXT) {
+    if (!isTextRequest(context.request)) {
       return context;
     }
 
@@ -69,7 +70,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     }
 
     const request = await this.predict({
-      query: (context.request.payload as unknown) as string,
+      query: context.request.payload,
       model: version.prototype?.model,
       locale: version.prototype?.data.locales[0] as Locale,
       projectID: version.projectID,

--- a/lib/services/runtime/handlers/command.ts
+++ b/lib/services/runtime/handlers/command.ts
@@ -1,4 +1,4 @@
-import { CommandType, GeneralCommand } from '@voiceflow/general-types';
+import { Command, CommandType } from '@voiceflow/general-types';
 import { Action, extractFrameCommand, Frame, Store } from '@voiceflow/runtime';
 
 import { FrameType, GeneralRuntime } from '@/lib/services/runtime/types';
@@ -6,9 +6,9 @@ import { FrameType, GeneralRuntime } from '@/lib/services/runtime/types';
 import { findEventMatcher, hasEventMatch } from './event';
 
 export const getCommand = (runtime: GeneralRuntime, extractFrame: typeof extractFrameCommand) => {
-  const frameMatch = (command: GeneralCommand | null) => hasEventMatch(command?.event || null, runtime);
+  const frameMatch = (command: Command | null) => hasEventMatch(command?.event || null, runtime);
 
-  return extractFrame<GeneralCommand>(runtime.stack, frameMatch) || null;
+  return extractFrame<Command>(runtime.stack, frameMatch) || null;
 };
 
 const utilsObj = {

--- a/lib/services/runtime/handlers/event/index.ts
+++ b/lib/services/runtime/handlers/event/index.ts
@@ -1,17 +1,17 @@
 import { formatIntentName } from '@voiceflow/common';
-import { EventRequest, EventType, GeneralEvent, IntentEvent, IntentRequest, TraceEvent } from '@voiceflow/general-types';
+import { Event, EventType, IntentEvent, IntentRequest, Request } from '@voiceflow/general-types';
 import { Runtime, Store } from '@voiceflow/runtime';
 
-import { GeneralRuntime, isEventRequest, isIntentRequest } from '@/lib/services/runtime/types';
+import { GeneralRuntime, isGeneralRequest, isIntentRequest } from '@/lib/services/runtime/types';
 
 import { mapEntities } from '../../utils';
 
 export const intentEventMatcher = {
-  match: (context: { runtime: GeneralRuntime; event: GeneralEvent | null }): context is { runtime: Runtime<IntentRequest>; event: IntentEvent } => {
+  match: (context: { runtime: GeneralRuntime; event: Event | null }): context is { runtime: Runtime<IntentRequest>; event: IntentEvent } => {
     const request = context.runtime.getRequest();
     if (!isIntentRequest(request)) return false;
     if (context.event?.type !== EventType.INTENT) return false;
-    if (formatIntentName(context.event.intent) !== formatIntentName(request.payload.intent.name)) return false;
+    if (formatIntentName((context.event as IntentEvent).intent) !== formatIntentName(request.payload.intent.name)) return false;
     return true;
   },
   sideEffect: (context: { runtime: Runtime<IntentRequest>; event: IntentEvent; variables: Store }) => {
@@ -21,27 +21,32 @@ export const intentEventMatcher = {
   },
 };
 
-export const traceEventMatcher = {
-  match: (context: { runtime: GeneralRuntime; event: GeneralEvent | null }): context is { runtime: Runtime<EventRequest>; event: TraceEvent } => {
+type GeneralEvent = Event<string, { name: string }>;
+export const generalEventMatcher = {
+  match: (context: {
+    runtime: GeneralRuntime;
+    event: Event | null;
+  }): context is { runtime: Runtime<Request>; event: Event<string, GeneralEvent> } => {
     const request = context.runtime.getRequest();
-    if (!isEventRequest(request)) return false;
-    if (context.event?.type !== EventType.TRACE) return false;
-    if (context.event.name !== request.payload.name) return false;
+    if (!isGeneralRequest(request)) return false;
+    if (!context.event?.type) return false;
+    if ((context.event as GeneralEvent).name !== request.payload.name) return false;
+
     return true;
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  sideEffect: (_context: { runtime: Runtime<IntentRequest>; event: TraceEvent; variables: Store }) => {
+  sideEffect: (_context: { runtime: Runtime<IntentRequest>; event: GeneralEvent; variables: Store }) => {
     // to-do: trace event side effect management
   },
 };
 
-const EventMatchers = [intentEventMatcher, traceEventMatcher];
+const EventMatchers = [intentEventMatcher, generalEventMatcher];
 
-export const findEventMatcher = (context: { event: GeneralEvent | null; runtime: GeneralRuntime; variables: Store }) => {
+export const findEventMatcher = (context: { event: Event | null; runtime: GeneralRuntime; variables: Store }) => {
   const matcher = EventMatchers.find((m) => m.match(context));
 
   if (!matcher) return null;
   return { ...matcher, sideEffect: () => matcher.sideEffect(context as any) };
 };
 
-export const hasEventMatch = (event: GeneralEvent | null, runtime: GeneralRuntime) => !!EventMatchers.find((m) => m.match({ event, runtime }));
+export const hasEventMatch = (event: Event | null, runtime: GeneralRuntime) => !!EventMatchers.find((m) => m.match({ event, runtime }));

--- a/lib/services/runtime/handlers/event/index.ts
+++ b/lib/services/runtime/handlers/event/index.ts
@@ -26,7 +26,7 @@ export const traceEventMatcher = {
     const request = context.runtime.getRequest();
     if (!isEventRequest(request)) return false;
     if (context.event?.type !== EventType.TRACE) return false;
-    if (context.event.name !== request?.payload.name) return false;
+    if (context.event.name !== request.payload.name) return false;
     return true;
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/lib/services/runtime/handlers/event/index.ts
+++ b/lib/services/runtime/handlers/event/index.ts
@@ -1,8 +1,8 @@
 import { formatIntentName } from '@voiceflow/common';
-import { EventType, GeneralEvent, IntentEvent, IntentRequest } from '@voiceflow/general-types';
+import { EventRequest, EventType, GeneralEvent, IntentEvent, IntentRequest, TraceEvent } from '@voiceflow/general-types';
 import { Runtime, Store } from '@voiceflow/runtime';
 
-import { GeneralRuntime, isIntentRequest } from '@/lib/services/runtime/types';
+import { GeneralRuntime, isEventRequest, isIntentRequest } from '@/lib/services/runtime/types';
 
 import { mapEntities } from '../../utils';
 
@@ -21,7 +21,21 @@ export const intentEventMatcher = {
   },
 };
 
-const EventMatchers = [intentEventMatcher];
+export const traceEventMatcher = {
+  match: (context: { runtime: GeneralRuntime; event: GeneralEvent | null }): context is { runtime: Runtime<EventRequest>; event: TraceEvent } => {
+    const request = context.runtime.getRequest();
+    if (!isEventRequest(request)) return false;
+    if (context.event?.type !== EventType.TRACE) return false;
+    if (context.event.name !== request?.payload.name) return false;
+    return true;
+  },
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  sideEffect: (_context: { runtime: Runtime<IntentRequest>; event: TraceEvent; variables: Store }) => {
+    // to-do: trace event side effect management
+  },
+};
+
+const EventMatchers = [intentEventMatcher, traceEventMatcher];
 
 export const findEventMatcher = (context: { event: GeneralEvent | null; runtime: GeneralRuntime; variables: Store }) => {
   const matcher = EventMatchers.find((m) => m.match(context));

--- a/lib/services/runtime/handlers/index.ts
+++ b/lib/services/runtime/handlers/index.ts
@@ -19,6 +19,7 @@ import InteractionHandler from './interaction';
 import SpeakHandler from './speak';
 import StateHandlers from './state';
 import StreamHandler from './stream';
+import TraceHandler from './trace';
 import VisualHandler from './visual';
 
 export default ({ API_HANDLER_ENDPOINT, INTEGRATIONS_HANDLER_ENDPOINT, CODE_HANDLER_ENDPOINT }: Config) => [
@@ -39,4 +40,5 @@ export default ({ API_HANDLER_ENDPOINT, INTEGRATIONS_HANDLER_ENDPOINT, CODE_HAND
   StartHandler(),
   VisualHandler(),
   NextHandler(),
+  TraceHandler(),
 ];

--- a/lib/services/runtime/handlers/interaction.ts
+++ b/lib/services/runtime/handlers/interaction.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-syntax */
-import { EventType, TraceType } from '@voiceflow/general-types';
+import { EventType, IntentEvent, TraceType } from '@voiceflow/general-types';
 import { Node, TraceFrame } from '@voiceflow/general-types/build/nodes/interaction';
 import { Action, HandlerFactory } from '@voiceflow/runtime';
 
@@ -31,7 +31,7 @@ export const InteractionHandler: HandlerFactory<Node, typeof utilsObj> = (utils)
           payload: {
             choices: node.interactions.reduce<{ name: string; intent?: string }[]>((acc, interaction) => {
               if (interaction?.event?.type === EventType.INTENT) {
-                const { intent } = interaction.event;
+                const { intent } = interaction.event as IntentEvent;
                 acc.push({ intent, name: intent });
               }
               return acc;

--- a/lib/services/runtime/handlers/noMatch.ts
+++ b/lib/services/runtime/handlers/noMatch.ts
@@ -1,6 +1,6 @@
 import { Node } from '@voiceflow/api-sdk';
 import { replaceVariables, sanitizeVariables } from '@voiceflow/common';
-import { EventType, TraceType } from '@voiceflow/general-types';
+import { EventType, IntentEvent, TraceType } from '@voiceflow/general-types';
 import { Node as ChoiceNode, TraceFrame as ChoiceTrace } from '@voiceflow/general-types/build/nodes/interaction';
 import { SpeakType, TraceFrame } from '@voiceflow/general-types/build/nodes/speak';
 import { Runtime, Store } from '@voiceflow/runtime';
@@ -53,7 +53,7 @@ export const NoMatchHandler = () => ({
         payload: {
           choices: node.interactions.reduce<{ name: string; intent?: string }[]>((acc, interaction) => {
             if (interaction?.event?.type === EventType.INTENT) {
-              const { intent } = interaction.event;
+              const { intent } = interaction.event as IntentEvent;
               acc.push({ intent, name: intent });
             }
             return acc;

--- a/lib/services/runtime/handlers/trace.ts
+++ b/lib/services/runtime/handlers/trace.ts
@@ -1,0 +1,51 @@
+/* eslint-disable no-restricted-syntax */
+
+import { Node, TraceFrame } from '@voiceflow/general-types/build/nodes/trace';
+import { Action, HandlerFactory } from '@voiceflow/runtime';
+
+import CommandHandler from './command';
+import { findEventMatcher } from './event';
+
+const utilsObj = {
+  commandHandler: CommandHandler(),
+  findEventMatcher,
+};
+
+const TraceHandler: HandlerFactory<Node, typeof utilsObj> = (utils) => ({
+  canHandle: (node) => !!node._v,
+  handle: (node, runtime, variables) => {
+    const defaultPath = node.paths[node.defaultPath!]?.nextID || null;
+
+    // process req if not process before (action == REQUEST)
+    if (runtime.getAction() === Action.REQUEST) {
+      for (const traceEvent of node.paths) {
+        const { event, nextID } = traceEvent;
+
+        const matcher = utils.findEventMatcher({ event, runtime, variables });
+        if (matcher) {
+          // allow handler to apply side effects
+          matcher.sideEffect();
+          return nextID || null;
+        }
+      }
+
+      // check if there is a command in the stack that fulfills request
+      if (utils.commandHandler.canHandle(runtime)) {
+        return utils.commandHandler.handle(runtime, variables);
+      }
+
+      return null;
+    }
+
+    runtime.trace.addTrace<TraceFrame>({
+      type: node.type,
+      payload: { data: node.data, paths: node.paths },
+    });
+
+    // if !stop continue to defaultPath otherwise
+    // quit cycleStack without ending session by stopping on itself
+    return !node.stop ? defaultPath : node.id;
+  },
+});
+
+export default () => TraceHandler(utilsObj);

--- a/lib/services/runtime/handlers/trace.ts
+++ b/lib/services/runtime/handlers/trace.ts
@@ -11,13 +11,16 @@ const utilsObj = {
   findEventMatcher,
 };
 
-const TraceHandler: HandlerFactory<Node, typeof utilsObj> = (utils) => ({
+export const TraceHandler: HandlerFactory<Node, typeof utilsObj> = (utils) => ({
   canHandle: (node) => !!node._v,
   handle: (node, runtime, variables) => {
     const defaultPath = node.paths[node.defaultPath!]?.nextID || null;
 
     // process req if not process before (action == REQUEST)
     if (runtime.getAction() === Action.REQUEST) {
+      // request for this turn has been processed, set action to response
+      runtime.setAction(Action.RESPONSE);
+
       for (const traceEvent of node.paths) {
         const { event, nextID } = traceEvent;
 

--- a/lib/services/runtime/handlers/trace.ts
+++ b/lib/services/runtime/handlers/trace.ts
@@ -12,7 +12,7 @@ const utilsObj = {
 };
 
 export const TraceHandler: HandlerFactory<Node, typeof utilsObj> = (utils) => ({
-  canHandle: (node) => !!node._v,
+  canHandle: (node) => node._v === 1,
   handle: (node, runtime, variables) => {
     const defaultPath = node.paths[node.defaultPath!]?.nextID || null;
 

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -1,7 +1,7 @@
-import { DataRequest, GeneralRequest, IntentRequest, NodeID, RequestType } from '@voiceflow/general-types';
+import { DataRequest, EventRequest, GeneralRequest, IntentRequest, NodeID, RequestType } from '@voiceflow/general-types';
 import { Runtime } from '@voiceflow/runtime';
 
-export type RuntimeRequest = IntentRequest | DataRequest | null;
+export type RuntimeRequest = IntentRequest | DataRequest | EventRequest | null;
 
 export type GeneralRuntime = Runtime<RuntimeRequest>;
 
@@ -10,7 +10,11 @@ export const isIntentRequest = (request: GeneralRequest): request is IntentReque
 };
 
 export const isRuntimeRequest = (request: GeneralRequest): request is RuntimeRequest => {
-  return request === null || !!([RequestType.INTENT, RequestType.DATA, RequestType.TRACE].includes(request?.type!) && request!.payload);
+  return request === null || !!([RequestType.INTENT, RequestType.DATA, RequestType.EVENT].includes(request?.type!) && request!.payload);
+};
+
+export const isEventRequest = (request: GeneralRequest | null): request is EventRequest => {
+  return request?.type === RequestType.EVENT;
 };
 
 export enum StorageType {

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -10,7 +10,7 @@ export const isIntentRequest = (request: GeneralRequest): request is IntentReque
 };
 
 export const isRuntimeRequest = (request: GeneralRequest): request is RuntimeRequest => {
-  return request === null || !!([RequestType.INTENT, RequestType.DATA].includes(request?.type!) && request!.payload);
+  return request === null || !!([RequestType.INTENT, RequestType.DATA, RequestType.TRACE].includes(request?.type!) && request!.payload);
 };
 
 export enum StorageType {

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -1,20 +1,20 @@
-import { DataRequest, EventRequest, GeneralRequest, IntentRequest, NodeID, RequestType } from '@voiceflow/general-types';
+import { IntentRequest, NodeID, Request, RequestType } from '@voiceflow/general-types';
 import { Runtime } from '@voiceflow/runtime';
 
-export type RuntimeRequest = IntentRequest | DataRequest | EventRequest | null;
+export type RuntimeRequest = Request | null;
 
 export type GeneralRuntime = Runtime<RuntimeRequest>;
 
-export const isIntentRequest = (request: GeneralRequest): request is IntentRequest => {
-  return !!(request?.type === RequestType.INTENT && request.payload?.intent?.name && Array.isArray(request.payload.entities));
+export const isIntentRequest = (request: RuntimeRequest): request is IntentRequest => {
+  return !!(request?.type === RequestType.INTENT && (request as IntentRequest).payload?.intent?.name && Array.isArray(request.payload.entities));
 };
 
-export const isRuntimeRequest = (request: GeneralRequest): request is RuntimeRequest => {
-  return request === null || !!([RequestType.INTENT, RequestType.DATA, RequestType.EVENT].includes(request?.type!) && request!.payload);
+export const isRuntimeRequest = (request: any): request is RuntimeRequest => {
+  return request === null || !!(typeof request.type === 'string' && !!request.type && request.payload);
 };
 
-export const isEventRequest = (request: GeneralRequest | null): request is EventRequest => {
-  return request?.type === RequestType.EVENT;
+export const isGeneralRequest = (request: RuntimeRequest): request is Request<string, { name: string }> => {
+  return !!request?.payload.name;
 };
 
 export enum StorageType {

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -1,12 +1,20 @@
-import { IntentRequest, NodeID, Request, RequestType } from '@voiceflow/general-types';
+import { IntentRequest, NodeID, Request, RequestType, TextRequest } from '@voiceflow/general-types';
 import { Runtime } from '@voiceflow/runtime';
 
 export type RuntimeRequest = Request | null;
 
 export type GeneralRuntime = Runtime<RuntimeRequest>;
 
+export const isTextRequest = (request: RuntimeRequest): request is TextRequest => {
+  return !!(request?.type === RequestType.TEXT && typeof request.payload === 'string');
+};
+
 export const isIntentRequest = (request: RuntimeRequest): request is IntentRequest => {
-  return !!(request?.type === RequestType.INTENT && (request as IntentRequest).payload?.intent?.name && Array.isArray(request.payload.entities));
+  return !!(
+    request?.type === RequestType.INTENT &&
+    (request as IntentRequest).payload?.intent?.name &&
+    Array.isArray((request as IntentRequest).payload.entities)
+  );
 };
 
 export const isRuntimeRequest = (request: any): request is RuntimeRequest => {
@@ -14,7 +22,7 @@ export const isRuntimeRequest = (request: any): request is RuntimeRequest => {
 };
 
 export const isGeneralRequest = (request: RuntimeRequest): request is Request<string, { name: string }> => {
-  return !!request?.payload.name;
+  return !!(request as Request<string, { name: string }>)?.payload.name;
 };
 
 export enum StorageType {

--- a/lib/services/state/cacheDataAPI.ts
+++ b/lib/services/state/cacheDataAPI.ts
@@ -1,14 +1,14 @@
 import { Program, Project, Version } from '@voiceflow/api-sdk';
-import { GeneralCommand, GeneralNodes, GeneralVersionData } from '@voiceflow/general-types';
+import { Command, GeneralNodes, GeneralVersionData } from '@voiceflow/general-types';
 import { DataAPI } from '@voiceflow/runtime';
 
 // cache any versions or project it comes across
-class CacheDataAPI implements DataAPI<Program<GeneralNodes, GeneralCommand>, Version<GeneralVersionData>> {
+class CacheDataAPI implements DataAPI<Program<GeneralNodes, Command>, Version<GeneralVersionData>> {
   private projects: Record<string, Project<any, any>> = {};
 
   private versions: Record<string, Version<GeneralVersionData>> = {};
 
-  constructor(private api: DataAPI<Program<GeneralNodes, GeneralCommand>, Version<GeneralVersionData>>) {}
+  constructor(private api: DataAPI<Program<GeneralNodes, Command>, Version<GeneralVersionData>>) {}
 
   async getProgram(programID: string) {
     return this.api.getProgram(programID);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@voiceflow/api-sdk": "1.27.1",
     "@voiceflow/backend-utils": "2.2.1",
     "@voiceflow/common": "6.5.0",
-    "@voiceflow/general-types": "1.34.1",
+    "@voiceflow/general-types": "1.34.2",
     "@voiceflow/logger": "1.5.2",
     "@voiceflow/natural-language-commander": "^0.5.1",
     "@voiceflow/runtime": "1.24.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@voiceflow/api-sdk": "1.27.1",
     "@voiceflow/backend-utils": "2.2.1",
     "@voiceflow/common": "6.5.0",
-    "@voiceflow/general-types": "1.33.0",
+    "@voiceflow/general-types": "1.34.1",
     "@voiceflow/logger": "1.5.2",
     "@voiceflow/natural-language-commander": "^0.5.1",
     "@voiceflow/runtime": "1.24.1",

--- a/tests/lib/services/runtime/handlers/capture.unit.ts
+++ b/tests/lib/services/runtime/handlers/capture.unit.ts
@@ -1,4 +1,4 @@
-import { GeneralRequest, IntentRequest, NodeType, RequestType } from '@voiceflow/general-types';
+import { IntentRequest, NodeType, Request, RequestType } from '@voiceflow/general-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -16,7 +16,7 @@ const intentRequest: IntentRequest = {
   },
 };
 
-const getMockDependencies = ({ request = intentRequest }: { request?: GeneralRequest } = {}) => ({
+const getMockDependencies = ({ request = intentRequest }: { request?: Request } = {}) => ({
   node: {
     type: NodeType.CAPTURE,
     variable: 'var',

--- a/tests/lib/services/runtime/handlers/event/index.unit.ts
+++ b/tests/lib/services/runtime/handlers/event/index.unit.ts
@@ -2,42 +2,49 @@ import { EventType, RequestType } from '@voiceflow/general-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { traceEventMatcher } from '@/lib/services/runtime/handlers/event';
+import { generalEventMatcher } from '@/lib/services/runtime/handlers/event';
 
 describe('event handlers unit tests', () => {
-  describe('traceEventMatcher', () => {
+  describe('generalEventMatcher', () => {
     describe('match', () => {
       it('no request', async () => {
         const runtime = { getRequest: sinon.stub().returns(null) };
-        expect(traceEventMatcher.match({ runtime } as any)).to.eql(false);
+        expect(generalEventMatcher.match({ runtime } as any)).to.eql(false);
       });
 
       it('not event req', async () => {
-        const runtime = { getRequest: sinon.stub().returns({ type: RequestType.INTENT }) };
-        expect(traceEventMatcher.match({ runtime } as any)).to.eql(false);
+        const runtime = {
+          getRequest: sinon.stub().returns({
+            type: 'random',
+            payload: {
+              /* no 'name' in payload */
+            },
+          }),
+        };
+        expect(generalEventMatcher.match({ runtime } as any)).to.eql(false);
       });
 
       it('no event', async () => {
-        const runtime = { getRequest: sinon.stub().returns({ type: RequestType.EVENT }) };
-        expect(traceEventMatcher.match({ runtime } as any)).to.eql(false);
+        const runtime = { getRequest: sinon.stub().returns({ type: 'event', payload: { name: 'event1' } }) };
+        expect(generalEventMatcher.match({ runtime } as any)).to.eql(false);
       });
 
-      it('event type not trace', async () => {
-        const runtime = { getRequest: sinon.stub().returns({ type: RequestType.EVENT }) };
-        const event = { type: EventType.INTENT };
-        expect(traceEventMatcher.match({ runtime, event } as any)).to.eql(false);
+      it('no event type', async () => {
+        const runtime = { getRequest: sinon.stub().returns({ type: 'event', payload: { name: 'event1' } }) };
+        const event = { type: '' };
+        expect(generalEventMatcher.match({ runtime, event } as any)).to.eql(false);
       });
 
       it('event name not match with req', () => {
-        const runtime = { getRequest: sinon.stub().returns({ type: RequestType.EVENT, payload: { name: 'event1' } }) };
-        const event = { type: EventType.TRACE, name: 'event2' };
-        expect(traceEventMatcher.match({ runtime, event } as any)).to.eql(false);
+        const runtime = { getRequest: sinon.stub().returns({ type: 'event', payload: { name: 'event1' } }) };
+        const event = { type: 'trace', name: 'event2' };
+        expect(generalEventMatcher.match({ runtime, event } as any)).to.eql(false);
       });
 
       it('full match', async () => {
-        const runtime = { getRequest: sinon.stub().returns({ type: RequestType.EVENT, payload: { name: 'event1' } }) };
-        const event = { type: EventType.TRACE, name: 'event1' };
-        expect(traceEventMatcher.match({ runtime, event } as any)).to.eql(true);
+        const runtime = { getRequest: sinon.stub().returns({ type: 'event', payload: { name: 'event1' } }) };
+        const event = { type: 'trace', name: 'event1' };
+        expect(generalEventMatcher.match({ runtime, event } as any)).to.eql(true);
       });
     });
   });

--- a/tests/lib/services/runtime/handlers/event/index.unit.ts
+++ b/tests/lib/services/runtime/handlers/event/index.unit.ts
@@ -1,0 +1,44 @@
+import { EventType, RequestType } from '@voiceflow/general-types';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { traceEventMatcher } from '@/lib/services/runtime/handlers/event';
+
+describe('event handlers unit tests', () => {
+  describe('traceEventMatcher', () => {
+    describe('match', () => {
+      it('no request', async () => {
+        const runtime = { getRequest: sinon.stub().returns(null) };
+        expect(traceEventMatcher.match({ runtime } as any)).to.eql(false);
+      });
+
+      it('not event req', async () => {
+        const runtime = { getRequest: sinon.stub().returns({ type: RequestType.INTENT }) };
+        expect(traceEventMatcher.match({ runtime } as any)).to.eql(false);
+      });
+
+      it('no event', async () => {
+        const runtime = { getRequest: sinon.stub().returns({ type: RequestType.EVENT }) };
+        expect(traceEventMatcher.match({ runtime } as any)).to.eql(false);
+      });
+
+      it('event type not trace', async () => {
+        const runtime = { getRequest: sinon.stub().returns({ type: RequestType.EVENT }) };
+        const event = { type: EventType.INTENT };
+        expect(traceEventMatcher.match({ runtime, event } as any)).to.eql(false);
+      });
+
+      it('event name not match with req', () => {
+        const runtime = { getRequest: sinon.stub().returns({ type: RequestType.EVENT, payload: { name: 'event1' } }) };
+        const event = { type: EventType.TRACE, name: 'event2' };
+        expect(traceEventMatcher.match({ runtime, event } as any)).to.eql(false);
+      });
+
+      it('full match', async () => {
+        const runtime = { getRequest: sinon.stub().returns({ type: RequestType.EVENT, payload: { name: 'event1' } }) };
+        const event = { type: EventType.TRACE, name: 'event1' };
+        expect(traceEventMatcher.match({ runtime, event } as any)).to.eql(true);
+      });
+    });
+  });
+});

--- a/tests/lib/services/runtime/handlers/interaction.unit.ts
+++ b/tests/lib/services/runtime/handlers/interaction.unit.ts
@@ -1,4 +1,4 @@
-import { GeneralRequest, IntentRequest, NodeType, RequestType } from '@voiceflow/general-types';
+import { IntentRequest, NodeType, Request, RequestType } from '@voiceflow/general-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -16,7 +16,7 @@ const intentRequest: IntentRequest = {
   },
 };
 
-const getMockDependencies = ({ request = intentRequest }: { request?: GeneralRequest } = {}) => ({
+const getMockDependencies = ({ request = intentRequest }: { request?: Request } = {}) => ({
   node: {
     type: NodeType.CAPTURE,
     interactions: [],

--- a/tests/lib/services/runtime/handlers/trace.unit.ts
+++ b/tests/lib/services/runtime/handlers/trace.unit.ts
@@ -1,0 +1,254 @@
+import { Action } from '@voiceflow/runtime';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { TraceHandler } from '@/lib/services/runtime/handlers/trace';
+
+describe('Trace handler unit tests', () => {
+  describe('canHandle', () => {
+    it('false', () => {
+      expect(TraceHandler({} as any).canHandle({} as any, null as any, null as any, null as any)).to.eql(false);
+    });
+
+    it('true', () => {
+      expect(TraceHandler({} as any).canHandle({ _v: 1 } as any, null as any, null as any, null as any)).to.eql(true);
+    });
+  });
+
+  describe('handle', () => {
+    describe('action not request', () => {
+      describe('stop true', () => {
+        it('works', () => {
+          const node = {
+            id: 'node-id',
+            type: 'trace',
+            stop: true,
+            data: { foo: 'bar' },
+            paths: [
+              { event: {}, nextID: '1' },
+              { event: {}, nextID: '2' },
+            ],
+          };
+          const runtime = {
+            getAction: sinon.stub().returns(Action.RESPONSE),
+            trace: { addTrace: sinon.stub() },
+          };
+          const handler = TraceHandler({} as any);
+
+          expect(handler.handle(node as any, runtime as any, null as any, null as any)).to.eql(node.id);
+          expect(runtime.trace.addTrace.args).to.eql([
+            [
+              {
+                type: node.type,
+                payload: { data: node.data, paths: node.paths },
+              },
+            ],
+          ]);
+        });
+      });
+
+      describe('stop false', () => {
+        it('no default path', () => {
+          const node = {
+            id: 'node-id',
+            type: 'trace',
+            stop: false,
+            data: { foo: 'bar' },
+            paths: [
+              { event: {}, nextID: '1' },
+              { event: {}, nextID: '2' },
+            ],
+          };
+          const runtime = {
+            getAction: sinon.stub().returns(Action.RESPONSE),
+            trace: { addTrace: sinon.stub() },
+          };
+          const handler = TraceHandler({} as any);
+
+          expect(handler.handle(node as any, runtime as any, null as any, null as any)).to.eql(null);
+          expect(runtime.trace.addTrace.args).to.eql([
+            [
+              {
+                type: node.type,
+                payload: { data: node.data, paths: node.paths },
+              },
+            ],
+          ]);
+        });
+
+        it('no port for default path', () => {
+          const node = {
+            id: 'node-id',
+            type: 'trace',
+            stop: false,
+            data: { foo: 'bar' },
+            defaultPath: 3,
+            paths: [
+              { event: {}, nextID: '1' },
+              { event: {}, nextID: '2' },
+            ],
+          };
+          const runtime = {
+            getAction: sinon.stub().returns(Action.RESPONSE),
+            trace: { addTrace: sinon.stub() },
+          };
+          const handler = TraceHandler({} as any);
+
+          expect(handler.handle(node as any, runtime as any, null as any, null as any)).to.eql(null);
+          expect(runtime.trace.addTrace.args).to.eql([
+            [
+              {
+                type: node.type,
+                payload: { data: node.data, paths: node.paths },
+              },
+            ],
+          ]);
+        });
+
+        it('return default port', () => {
+          const node = {
+            id: 'node-id',
+            type: 'trace',
+            stop: false,
+            data: { foo: 'bar' },
+            defaultPath: 1,
+            paths: [
+              { event: {}, nextID: '1' },
+              { event: {}, nextID: '2' },
+            ],
+          };
+          const runtime = {
+            getAction: sinon.stub().returns(Action.RESPONSE),
+            trace: { addTrace: sinon.stub() },
+          };
+          const handler = TraceHandler({} as any);
+
+          expect(handler.handle(node as any, runtime as any, null as any, null as any)).to.eql('2');
+          expect(runtime.trace.addTrace.args).to.eql([
+            [
+              {
+                type: node.type,
+                payload: { data: node.data, paths: node.paths },
+              },
+            ],
+          ]);
+        });
+      });
+    });
+
+    describe('action request', () => {
+      it('no match', () => {
+        const node = {
+          id: 'node-id',
+          type: 'trace',
+          stop: true,
+          data: { foo: 'bar' },
+          paths: [],
+        };
+        const commandHandler = { canHandle: sinon.stub().returns(false) };
+        const runtime = {
+          getAction: sinon.stub().returns(Action.REQUEST),
+          setAction: sinon.stub(),
+          trace: { addTrace: sinon.stub() },
+        };
+        const handler = TraceHandler({ commandHandler } as any);
+
+        expect(handler.handle(node as any, runtime as any, null as any, null as any)).to.eql(null);
+        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
+        expect(commandHandler.canHandle.args).to.eql([[runtime]]);
+      });
+
+      it('command match', () => {
+        const node = {
+          id: 'node-id',
+          type: 'trace',
+          stop: true,
+          data: { foo: 'bar' },
+          paths: [{ event: {}, nextID: 'next-id' }],
+        };
+        const commandHandler = { canHandle: sinon.stub().returns(true), handle: sinon.stub().returns('command-id') };
+        const findEventMatcher = sinon.stub().returns(null);
+        const runtime = {
+          getAction: sinon.stub().returns(Action.REQUEST),
+          setAction: sinon.stub(),
+          trace: { addTrace: sinon.stub() },
+        };
+        const variables = { var1: 'val1' };
+        const handler = TraceHandler({ commandHandler, findEventMatcher } as any);
+
+        expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql('command-id');
+        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
+        expect(commandHandler.canHandle.args).to.eql([[runtime]]);
+        expect(commandHandler.handle.args).to.eql([[runtime, variables]]);
+        expect(findEventMatcher.args).to.eql([[{ event: node.paths[0].event, runtime, variables }]]);
+      });
+
+      it('path match', () => {
+        const node = {
+          id: 'node-id',
+          type: 'trace',
+          stop: true,
+          data: { foo: 'bar' },
+          paths: [
+            { event: { name: 'event1' }, nextID: 'next-id' },
+            { event: { name: 'event2' }, nextID: 'next-id2' },
+          ],
+        };
+        const matcher = { sideEffect: sinon.stub() };
+        const findEventMatcher = sinon
+          .stub()
+          .onFirstCall()
+          .returns(null)
+          .onSecondCall()
+          .returns(matcher);
+        const runtime = {
+          getAction: sinon.stub().returns(Action.REQUEST),
+          setAction: sinon.stub(),
+          trace: { addTrace: sinon.stub() },
+        };
+        const variables = { var1: 'val1' };
+        const handler = TraceHandler({ findEventMatcher } as any);
+
+        expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql('next-id2');
+        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
+        expect(findEventMatcher.args).to.eql([
+          [{ event: node.paths[0].event, runtime, variables }],
+          [{ event: node.paths[1].event, runtime, variables }],
+        ]);
+        expect(matcher.sideEffect.args).to.eql([[]]);
+      });
+
+      it('path match but no nextID', () => {
+        const node = {
+          id: 'node-id',
+          type: 'trace',
+          stop: true,
+          data: { foo: 'bar' },
+          paths: [{ event: { name: 'event1' }, nextID: 'next-id' }, { event: { name: 'event2' } }],
+        };
+        const matcher = { sideEffect: sinon.stub() };
+        const findEventMatcher = sinon
+          .stub()
+          .onFirstCall()
+          .returns(null)
+          .onSecondCall()
+          .returns(matcher);
+        const runtime = {
+          getAction: sinon.stub().returns(Action.REQUEST),
+          setAction: sinon.stub(),
+          trace: { addTrace: sinon.stub() },
+        };
+        const variables = { var1: 'val1' };
+        const handler = TraceHandler({ findEventMatcher } as any);
+
+        expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
+        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
+        expect(findEventMatcher.args).to.eql([
+          [{ event: node.paths[0].event, runtime, variables }],
+          [{ event: node.paths[1].event, runtime, variables }],
+        ]);
+        expect(matcher.sideEffect.args).to.eql([[]]);
+      });
+    });
+  });
+});

--- a/tests/lib/services/runtime/handlers/trace.unit.ts
+++ b/tests/lib/services/runtime/handlers/trace.unit.ts
@@ -8,6 +8,7 @@ describe('Trace handler unit tests', () => {
   describe('canHandle', () => {
     it('false', () => {
       expect(TraceHandler({} as any).canHandle({} as any, null as any, null as any, null as any)).to.eql(false);
+      expect(TraceHandler({} as any).canHandle({ _v: 2 } as any, null as any, null as any, null as any)).to.eql(false);
     });
 
     it('true', () => {

--- a/tests/lib/services/runtime/types.unit.ts
+++ b/tests/lib/services/runtime/types.unit.ts
@@ -1,16 +1,17 @@
 import { RequestType } from '@voiceflow/general-types';
 import { expect } from 'chai';
 
-import { isEventRequest, isRuntimeRequest } from '@/lib/services/runtime/types';
+import { isGeneralRequest, isRuntimeRequest } from '@/lib/services/runtime/types';
 
 describe('runtime types unit tests', () => {
   it('isRuntimeRequest', () => {
-    expect(isRuntimeRequest({ type: RequestType.EVENT, payload: { name: 'event-name' } })).to.eql(true);
+    expect(isRuntimeRequest({ type: RequestType.INTENT, payload: { name: 'event-name' } })).to.eql(true);
   });
 
   it('isEventRequest', () => {
-    expect(isEventRequest(null)).to.eql(false);
-    expect(isEventRequest({ type: 'random' } as any)).to.eql(false);
-    expect(isEventRequest({ type: RequestType.EVENT } as any)).to.eql(true);
+    expect(isGeneralRequest(null)).to.eql(false);
+    expect(isGeneralRequest({ type: 'random', payload: {} } as any)).to.eql(false);
+    expect(isGeneralRequest({ type: 'random', payload: { name: '' } } as any)).to.eql(false);
+    expect(isGeneralRequest({ type: 'random', payload: { name: 'here' } } as any)).to.eql(true);
   });
 });

--- a/tests/lib/services/runtime/types.unit.ts
+++ b/tests/lib/services/runtime/types.unit.ts
@@ -1,0 +1,16 @@
+import { RequestType } from '@voiceflow/general-types';
+import { expect } from 'chai';
+
+import { isEventRequest, isRuntimeRequest } from '@/lib/services/runtime/types';
+
+describe('runtime types unit tests', () => {
+  it('isRuntimeRequest', () => {
+    expect(isRuntimeRequest({ type: RequestType.EVENT, payload: { name: 'event-name' } })).to.eql(true);
+  });
+
+  it('isEventRequest', () => {
+    expect(isEventRequest(null)).to.eql(false);
+    expect(isEventRequest({ type: 'random' } as any)).to.eql(false);
+    expect(isEventRequest({ type: RequestType.EVENT } as any)).to.eql(true);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -1,8 +1,9 @@
-import { Config as RequestConfig, GeneralRequest, GeneralTrace } from '@voiceflow/general-types';
+import { Config as RequestConfig, GeneralTrace } from '@voiceflow/general-types';
 import * as Runtime from '@voiceflow/runtime';
 import * as Express from 'express';
 import * as ExpressValidator from 'express-validator';
 
+import { RuntimeRequest } from '@/lib/services/runtime/types';
 import CacheDataAPI from '@/lib/services/state/cacheDataAPI';
 
 export interface Config {
@@ -89,6 +90,6 @@ export type ContextData = {
   };
 };
 
-export type Context = Runtime.Context<GeneralRequest, GeneralTrace, ContextData>;
+export type Context = Runtime.Context<RuntimeRequest, GeneralTrace, ContextData>;
 export type ContextHandler = Runtime.ContextHandler<Context>;
 export type InitContextHandler = Runtime.InitContextHandler<Context>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,10 +981,10 @@
   dependencies:
     "@voiceflow/api-sdk" "1.22.0"
 
-"@voiceflow/general-types@1.34.1":
-  version "1.34.1"
-  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.34.1.tgz#90282152babb499822aac8e7038eb6a65d1566c9"
-  integrity sha512-K2HiOZmQHC6czWtZ2wKGk4auYBhbdsEne1EH5ShRxaguUBBpAzLfNFHYz8Yy72F+9yZNN8DFeU33LZgHHMydOA==
+"@voiceflow/general-types@1.34.2":
+  version "1.34.2"
+  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.34.2.tgz#32f6a05bed35c097fffc90fdd354a81fee692d26"
+  integrity sha512-Cd9kGe0Tu5RN+ncVKMoYHFg6gg7bckYbusXqYYhqUu0Qexdu7qGJusmJElYNzXc08Bize9AFVnaFz6ZrjJq1vA==
   dependencies:
     "@voiceflow/api-sdk" "1.27.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,10 +981,10 @@
   dependencies:
     "@voiceflow/api-sdk" "1.22.0"
 
-"@voiceflow/general-types@1.33.0":
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.33.0.tgz#9b0040916bcc975512aed2b1bf3954cb94248abf"
-  integrity sha512-9PJARpjz5lGUBANuzfQr0pRsypjqVfuocJDKzGt9ImHEwv0kquSJLpuqhb94naZv64sEYbujSsKdpg4SHqNgMA==
+"@voiceflow/general-types@1.34.1":
+  version "1.34.1"
+  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.34.1.tgz#90282152babb499822aac8e7038eb6a65d1566c9"
+  integrity sha512-K2HiOZmQHC6czWtZ2wKGk4auYBhbdsEne1EH5ShRxaguUBBpAzLfNFHYz8Yy72F+9yZNN8DFeU33LZgHHMydOA==
   dependencies:
     "@voiceflow/api-sdk" "1.27.1"
 


### PR DESCRIPTION
to-test:
- import [test trace block.zip](https://github.com/voiceflow/general-runtime/files/6111400/test.trace.block.zip)


manual tests performed:
- default path (doesn't stop)
- inline events (event1, event2)
- global jump events (event3, event4)
- global push event (help)
- hit intent (travel_intent) from trace block
- hit command (second_flow) from trace block