### PR TITLE
fix: nato bug fix (CORE-5346)

### DIFF
--- a/lib/services/slots/index.ts
+++ b/lib/services/slots/index.ts
@@ -86,8 +86,10 @@ class SlotsService extends AbstractManager<{ utils: typeof utils }> implements C
                 // Word was not detected by LUIS, check if it was missed and should be included
                 if (word.rawText.match(/^[0-9]+$/)) {
                   entity.value += word.rawText;
+                  word.isNatoApco = true;
                 } else if (natoApcoExceptions.has(word.rawText)) {
                   entity.value += natoApcoExceptions.get(word.rawText);
+                  word.isNatoApco = true;
                 }
               }
             });

--- a/lib/services/slots/index.ts
+++ b/lib/services/slots/index.ts
@@ -1,104 +1,13 @@
-import { SlotType } from '@voiceflow/general-types';
-import { Entity, VerboseValue } from '@voiceflow/general-types/lib';
-import _ from 'lodash';
-
 import { Context, ContextHandler } from '@/types';
 
 import { isIntentRequest } from '../runtime/types';
 import { AbstractManager, injectServices } from '../utils';
+import { natoApcoConverter } from './natoApco';
 
 export const utils = {};
 
-interface Slot {
-  type: {
-    value?: string | undefined;
-  };
-  name: string;
-}
-
-interface QueryWord {
-  rawText: string;
-  canonicalText: string;
-  startIndex: number;
-  isNatoApco: boolean;
-}
-
-const firstLetterExpections = ['00', '000'];
-const natoApcoExceptions = new Map([
-  ['to', 2],
-  ['for', 4],
-]);
-
 @injectServices({ utils })
 class SlotsService extends AbstractManager<{ utils: typeof utils }> implements ContextHandler {
-  processQuery = (query: string, entityVerboseValue: VerboseValue[]): QueryWord[] => {
-    const splitQuery = query.split(' ');
-    const processed: QueryWord[] = [];
-    let startIndex = 0;
-
-    // Parse QueryWords from string
-    for (let i = 0; i < splitQuery.length; ++i) {
-      processed.push({
-        rawText: splitQuery[i],
-        startIndex,
-        isNatoApco: false,
-        canonicalText: '',
-      });
-      startIndex += splitQuery[i].length + 1;
-    }
-
-    // Determine which QueryWords are NATO/APCO and set canonical text by comparing to entityVerboseValue
-    let i = 0;
-    for (let j = 0; j < entityVerboseValue.length; ++j) {
-      while (processed[i].startIndex !== entityVerboseValue[j].startIndex) {
-        ++i;
-      }
-      processed[i].isNatoApco = true;
-      processed[i].canonicalText = entityVerboseValue[j].canonicalText;
-    }
-
-    return processed;
-  };
-
-  // Combines the NATO/APCO words identified by LUIS together with their first letters.
-  // entity.verboseValue contains the words to parse and entity.value will store the result.
-  // The only exceptions to taking the first letter of the strings is '00' and '000'.
-  // This function also adds multi-digit numbers and other exceptions to entity.value if
-  // they are between detected NATO/APCO words.
-  natoApcoConverter = (entities: Entity[], slots: Slot[], query: string) => {
-    entities.forEach((entity) => {
-      slots.forEach((slot) => {
-        if (entity.name === slot.name && slot.type.value === SlotType.NATOAPCO) {
-          // if using regex raw value will not be populated
-          if (!Array.isArray(entity.verboseValue)) {
-            const splitValue = entity.value.split(' ').map((value) => [value]);
-            entity.value = splitValue
-              .reduce((acc, cur) => (firstLetterExpections.includes(cur[0]) ? acc + cur[0] : acc + cur[0][0]), '')
-              .toUpperCase();
-          } else {
-            const processedQuery = this.processQuery(query, entity.verboseValue);
-            entity.value = '';
-            processedQuery.forEach((word, i) => {
-              if (word.isNatoApco) {
-                // Word was detected by LUIS successfully
-                entity.value += firstLetterExpections.includes(word.canonicalText) ? word.canonicalText : word.canonicalText[0];
-              } else if ((i > 0 && processedQuery[i - 1].isNatoApco) || (i < processedQuery.length - 1 && processedQuery[i + 1].isNatoApco)) {
-                // Word was not detected by LUIS, check if it was missed and should be included
-                if (word.rawText.match(/^[0-9]+$/)) {
-                  entity.value += word.rawText;
-                  word.isNatoApco = true;
-                } else if (natoApcoExceptions.has(word.rawText)) {
-                  entity.value += natoApcoExceptions.get(word.rawText);
-                  word.isNatoApco = true;
-                }
-              }
-            });
-          }
-        }
-      });
-    });
-  };
-
   handle = async (context: Context) => {
     if (!isIntentRequest(context.request)) {
       return context;
@@ -115,7 +24,7 @@ class SlotsService extends AbstractManager<{ utils: typeof utils }> implements C
     }
 
     const payload = context.request?.payload;
-    this.natoApcoConverter(payload.entities, slots, payload.query);
+    natoApcoConverter(payload.entities, slots, payload.query);
 
     return context;
   };

--- a/lib/services/slots/natoApco.ts
+++ b/lib/services/slots/natoApco.ts
@@ -1,0 +1,88 @@
+/* eslint-disable import/prefer-default-export */
+import { Entity, SlotType, VerboseValue } from '@voiceflow/general-types';
+
+interface Slot {
+  type: {
+    value?: string | undefined;
+  };
+  name: string;
+}
+
+interface QueryWord {
+  rawText: string;
+  canonicalText: string;
+  startIndex: number;
+  isNatoApco: boolean;
+}
+
+const firstLetterExpections = ['00', '000'];
+const natoApcoExceptions = new Map([
+  ['to', 2],
+  ['for', 4],
+]);
+
+const processQuery = (query: string, entityVerboseValue: VerboseValue[]): QueryWord[] => {
+  const splitQuery = query.split(' ');
+  const processed: QueryWord[] = [];
+  let startIndex = 0;
+
+  // Parse QueryWords from string
+  for (let i = 0; i < splitQuery.length; ++i) {
+    processed.push({
+      rawText: splitQuery[i],
+      startIndex,
+      isNatoApco: false,
+      canonicalText: '',
+    });
+    startIndex += splitQuery[i].length + 1;
+  }
+
+  // Determine which QueryWords are NATO/APCO and set canonical text by comparing to entityVerboseValue
+  let i = 0;
+  for (let j = 0; j < entityVerboseValue.length; ++j) {
+    while (processed[i].startIndex !== entityVerboseValue[j].startIndex) {
+      ++i;
+    }
+    processed[i].isNatoApco = true;
+    processed[i].canonicalText = entityVerboseValue[j].canonicalText;
+  }
+
+  return processed;
+};
+
+// Combines the NATO/APCO words identified by LUIS together with their first letters.
+// entity.verboseValue contains the words to parse and entity.value will store the result.
+// The only exceptions to taking the first letter of the strings is '00' and '000'.
+// This function also adds multi-digit numbers and other exceptions to entity.value if
+// they are between detected NATO/APCO words.
+export const natoApcoConverter = (entities: Entity[], slots: Slot[], query: string) => {
+  entities.forEach((entity) => {
+    slots.forEach((slot) => {
+      if (entity.name === slot.name && slot.type.value === SlotType.NATOAPCO) {
+        // if using regex raw value will not be populated
+        if (!Array.isArray(entity.verboseValue)) {
+          const splitValue = entity.value.split(' ').map((value) => [value]);
+          entity.value = splitValue.reduce((acc, cur) => (firstLetterExpections.includes(cur[0]) ? acc + cur[0] : acc + cur[0][0]), '').toUpperCase();
+        } else {
+          const processedQuery = processQuery(query, entity.verboseValue);
+          entity.value = '';
+          processedQuery.forEach((word, i) => {
+            if (word.isNatoApco) {
+              // Word was detected by LUIS successfully
+              entity.value += firstLetterExpections.includes(word.canonicalText) ? word.canonicalText : word.canonicalText[0];
+            } else if ((i > 0 && processedQuery[i - 1].isNatoApco) || (i < processedQuery.length - 1 && processedQuery[i + 1].isNatoApco)) {
+              // Word was not detected by LUIS, check if it was missed and should be included
+              if (word.rawText.match(/^[0-9]+$/)) {
+                entity.value += word.rawText;
+                word.isNatoApco = true;
+              } else if (natoApcoExceptions.has(word.rawText)) {
+                entity.value += natoApcoExceptions.get(word.rawText);
+                word.isNatoApco = true;
+              }
+            }
+          });
+        }
+      }
+    });
+  });
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@voiceflow/api-sdk": "1.27.1",
     "@voiceflow/backend-utils": "2.2.1",
     "@voiceflow/common": "6.5.0",
-    "@voiceflow/general-types": "1.34.2",
+    "@voiceflow/general-types": "1.34.3",
     "@voiceflow/logger": "1.5.2",
     "@voiceflow/natural-language-commander": "^0.5.1",
     "@voiceflow/runtime": "1.24.1",

--- a/tests/lib/services/slots/fixture.ts
+++ b/tests/lib/services/slots/fixture.ts
@@ -117,22 +117,22 @@ export const NATO_REQUEST_2 = {
             {
               rawText: '3',
               canonicalText: '3',
-              startIndex: 49,
+              startIndex: 52,
             },
             {
               rawText: 'Bravo',
               canonicalText: 'Bravo',
-              startIndex: 51,
+              startIndex: 58,
             },
             {
               rawText: 'Charlie',
               canonicalText: 'Charlie',
-              startIndex: 60,
+              startIndex: 67,
             },
           ],
         },
       ],
-      query: 'It is March 10 and the license plate is 12 Alpha 3 Bravo 45 Charlie 67',
+      query: 'It is March 10 and the license plate is 12 Alpha to 3 for Bravo 45 Charlie 67',
     },
   },
 };

--- a/tests/lib/services/slots/fixture.ts
+++ b/tests/lib/services/slots/fixture.ts
@@ -1,0 +1,138 @@
+import { RequestType } from '@voiceflow/general-types/build';
+import sinon from 'sinon';
+
+const version = {
+  prototype: {
+    model: {
+      slots: [
+        {
+          name: 'natoSlot',
+          type: {
+            value: 'VF.NATOAPCO',
+          },
+        },
+        {
+          name: 'otherSlot',
+          type: {
+            value: 'VF.NUMBER',
+          },
+        },
+      ],
+    },
+  },
+};
+
+export const context = {
+  data: {
+    api: {
+      getVersion: sinon.stub().resolves(version),
+    },
+  },
+};
+
+export const NATO_REQUEST_1 = {
+  request: {
+    type: RequestType.INTENT,
+    payload: {
+      intent: {
+        name: 'foo',
+      },
+      entities: [
+        {
+          name: 'natoSlot',
+          verboseValue: [
+            {
+              rawText: 'November',
+              canonicalText: 'November',
+              startIndex: 0,
+            },
+            {
+              rawText: 'Ida',
+              canonicalText: 'India',
+              startIndex: 9,
+            },
+            {
+              rawText: 'Charles',
+              canonicalText: 'Charlie',
+              startIndex: 13,
+            },
+            {
+              rawText: 'Echo',
+              canonicalText: 'Echo',
+              startIndex: 21,
+            },
+            {
+              rawText: 'Dash',
+              canonicalText: '-',
+              startIndex: 26,
+            },
+            {
+              rawText: 'One',
+              canonicalText: '1',
+              startIndex: 31,
+            },
+            {
+              rawText: 'Thousand',
+              canonicalText: '000',
+              startIndex: 35,
+            },
+            {
+              rawText: 'Point',
+              canonicalText: '.',
+              startIndex: 44,
+            },
+            {
+              rawText: 'Hundred',
+              canonicalText: '00',
+              startIndex: 50,
+            },
+          ],
+        },
+        {
+          name: 'otherSlot',
+          value: 'unchanged',
+        },
+      ],
+      query: 'November Ida Charles Echo Dash One Thousand Point Hundred',
+    },
+  },
+};
+
+export const NATO_REQUEST_2 = {
+  request: {
+    type: RequestType.INTENT,
+    payload: {
+      intent: {
+        name: 'foo',
+      },
+      entities: [
+        {
+          name: 'natoSlot',
+          verboseValue: [
+            {
+              rawText: 'Alpha',
+              canonicalText: 'Alfa',
+              startIndex: 43,
+            },
+            {
+              rawText: '3',
+              canonicalText: '3',
+              startIndex: 49,
+            },
+            {
+              rawText: 'Bravo',
+              canonicalText: 'Bravo',
+              startIndex: 51,
+            },
+            {
+              rawText: 'Charlie',
+              canonicalText: 'Charlie',
+              startIndex: 60,
+            },
+          ],
+        },
+      ],
+      query: 'It is March 10 and the license plate is 12 Alpha 3 Bravo 45 Charlie 67',
+    },
+  },
+};

--- a/tests/lib/services/slots/fixture.ts
+++ b/tests/lib/services/slots/fixture.ts
@@ -136,3 +136,32 @@ export const NATO_REQUEST_2 = {
     },
   },
 };
+
+export const NATO_REQUEST_3 = {
+  request: {
+    type: RequestType.INTENT,
+    payload: {
+      intent: {
+        name: 'foo',
+      },
+      entities: [
+        {
+          name: 'natoSlot',
+          verboseValue: [
+            {
+              rawText: 'Alpha',
+              canonicalText: 'Alfa',
+              startIndex: 0,
+            },
+            {
+              rawText: 'Bravo',
+              canonicalText: 'Bravo',
+              startIndex: 22,
+            },
+          ],
+        },
+      ],
+      query: 'Alpha 12 to 34 for 56 Bravo',
+    },
+  },
+};

--- a/tests/lib/services/slots/index.unit.ts
+++ b/tests/lib/services/slots/index.unit.ts
@@ -25,7 +25,7 @@ describe('slots manager unit tests', () => {
       expect(newEntities[1].value).to.eql('unchanged');
     });
 
-    it('catches multi-number inputs in between LUIS-returned NATOAPCO slots', async () => {
+    it('catches multi-number inputs and exceptions in between LUIS-returned NATOAPCO slots', async () => {
       const slots = new SlotsManager({ utils: { ...defaultUtils } } as any, {} as any);
 
       const input = {
@@ -35,7 +35,7 @@ describe('slots manager unit tests', () => {
 
       const newContext = await slots.handle(input as any);
       const newEntities = (newContext.request?.payload as any).entities;
-      expect(newEntities[0].value).to.eql('12A3B45C67');
+      expect(newEntities[0].value).to.eql('12A234B45C67');
     });
   });
 });

--- a/tests/lib/services/slots/index.unit.ts
+++ b/tests/lib/services/slots/index.unit.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 
 import SlotsManager, { utils as defaultUtils } from '@/lib/services/slots';
 
-import { context, NATO_REQUEST_1, NATO_REQUEST_2 } from './fixture';
+import { context, NATO_REQUEST_1, NATO_REQUEST_2, NATO_REQUEST_3 } from './fixture';
 
 describe('slots manager unit tests', () => {
   afterEach(() => {
@@ -25,7 +25,7 @@ describe('slots manager unit tests', () => {
       expect(newEntities[1].value).to.eql('unchanged');
     });
 
-    it('catches multi-number inputs and exceptions in between LUIS-returned NATOAPCO slots', async () => {
+    it('catches multi-digit inputs and exceptions in between LUIS-returned NATOAPCO slots', async () => {
       const slots = new SlotsManager({ utils: { ...defaultUtils } } as any, {} as any);
 
       const input = {
@@ -36,6 +36,19 @@ describe('slots manager unit tests', () => {
       const newContext = await slots.handle(input as any);
       const newEntities = (newContext.request?.payload as any).entities;
       expect(newEntities[0].value).to.eql('12A234B45C67');
+    });
+
+    it('catches multiple multi-digit inputs and exceptions in a row', async () => {
+      const slots = new SlotsManager({ utils: { ...defaultUtils } } as any, {} as any);
+
+      const input = {
+        ...context,
+        ...NATO_REQUEST_3,
+      };
+
+      const newContext = await slots.handle(input as any);
+      const newEntities = (newContext.request?.payload as any).entities;
+      expect(newEntities[0].value).to.eql('A12234456B');
     });
   });
 });

--- a/tests/lib/services/slots/index.unit.ts
+++ b/tests/lib/services/slots/index.unit.ts
@@ -1,8 +1,9 @@
-import { RequestType } from '@voiceflow/general-types/build';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
 import SlotsManager, { utils as defaultUtils } from '@/lib/services/slots';
+
+import { context, NATO_REQUEST_1, NATO_REQUEST_2 } from './fixture';
 
 describe('slots manager unit tests', () => {
   afterEach(() => {
@@ -11,58 +12,30 @@ describe('slots manager unit tests', () => {
 
   describe('handle', () => {
     it('reduces NATOAPCO slot type values correctly', async () => {
-      const version = {
-        prototype: {
-          model: {
-            slots: [
-              {
-                name: 'natoSlot',
-                type: {
-                  value: 'VF.NATOAPCO',
-                },
-              },
-              {
-                name: 'otherSlot',
-                type: {
-                  value: 'VF.NUMBER',
-                },
-              },
-            ],
-          },
-        },
-      };
-
-      const context = {
-        data: {
-          api: {
-            getVersion: sinon.stub().resolves(version),
-          },
-        },
-        request: {
-          type: RequestType.INTENT,
-          payload: {
-            intent: {
-              name: 'foo',
-            },
-            entities: [
-              {
-                name: 'natoSlot',
-                rawValue: [['November'], ['India'], ['Charlie'], ['Echo'], ['-'], ['1'], ['000'], ['.'], ['00']],
-              },
-              {
-                name: 'otherSlot',
-                value: 'unchanged',
-              },
-            ],
-          },
-        },
-      };
       const slots = new SlotsManager({ utils: { ...defaultUtils } } as any, {} as any);
 
-      const newContext = await slots.handle(context as any);
+      const input = {
+        ...context,
+        ...NATO_REQUEST_1,
+      };
+
+      const newContext = await slots.handle(input as any);
       const newEntities = (newContext.request?.payload as any).entities;
       expect(newEntities[0].value).to.eql('NICE-1000.00');
       expect(newEntities[1].value).to.eql('unchanged');
+    });
+
+    it('catches multi-number inputs in between LUIS-returned NATOAPCO slots', async () => {
+      const slots = new SlotsManager({ utils: { ...defaultUtils } } as any, {} as any);
+
+      const input = {
+        ...context,
+        ...NATO_REQUEST_2,
+      };
+
+      const newContext = await slots.handle(input as any);
+      const newEntities = (newContext.request?.payload as any).entities;
+      expect(newEntities[0].value).to.eql('12A3B45C67');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,10 +981,10 @@
   dependencies:
     "@voiceflow/api-sdk" "1.22.0"
 
-"@voiceflow/general-types@1.34.2":
-  version "1.34.2"
-  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.34.2.tgz#32f6a05bed35c097fffc90fdd354a81fee692d26"
-  integrity sha512-Cd9kGe0Tu5RN+ncVKMoYHFg6gg7bckYbusXqYYhqUu0Qexdu7qGJusmJElYNzXc08Bize9AFVnaFz6ZrjJq1vA==
+"@voiceflow/general-types@1.34.3":
+  version "1.34.3"
+  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.34.3.tgz#03fda100a303c4ac0dd59c2dfe49de7429709460"
+  integrity sha512-/61H16hp0hK5lzyUJ32rz+gzd3ay8amxyap83rdbO/o7xFnUsgFvIOGmCMBVy20TbvNchJtusi+OpNNQunFUEg==
   dependencies:
     "@voiceflow/api-sdk" "1.27.1"
 


### PR DESCRIPTION
**Fixes or implements CORE-5346**

### Brief description. What is this change?
Slot Service will now parse the NATO/APCO entities against the original string and see if there are any numbers before or between them, then add those in together. It also accounts for 'to' -> 2 and 'for' -> 4 if they are near other NATO/APCO entities.

### Implementation details. How do you make this change?
- Created a function to process the query string into a list of QueryWords, which contain information for identifying undetected NATO/APCO words.
- Rewrite logic for natoApcoConverter
- Update unit tests

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| general-types | [link](https://github.com/voiceflow/general-types/pull/56) |
| general-service     | [link](https://github.com/voiceflow/general-service/pull/70) |

### Checklist

- [ ✅  ] title of PR reflects the branch name
- [ ✅  ] all commits adhere to conventional commits
- [ ✅  ] appropriate tests have been written
- [ ] all the dependendencies are upgraded