### PR TITLE
feat: add intent-confidence var (CORE-5398)

### DIFF
--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -48,9 +48,11 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
     const runtime = this.createClient(context.data.api).createRuntime(versionID, state, request);
 
     if (isIntentRequest(request)) {
-      runtime.trace.debug(
-        `matched intent **${request.payload.intent.name}** - confidence interval _${getReadableConfidence(request.payload.confidence)}%_`
-      );
+      const confidence = getReadableConfidence(request.payload.confidence);
+
+      runtime.trace.debug(`matched intent **${request.payload.intent.name}** - confidence interval _${confidence}%_`);
+
+      runtime.variables.set('intent_confidence', Number(confidence));
     }
 
     await runtime.update();

--- a/tests/lib/services/runtime/index.unit.ts
+++ b/tests/lib/services/runtime/index.unit.ts
@@ -156,7 +156,7 @@ describe('runtime manager unit tests', () => {
       await runtimeManager.handle(context);
 
       expect(runtime.trace.debug.args).to.eql([['matched intent **name** - confidence interval _86.12%_']]);
-      expect(runtime.variables.set.args).to.eql([[86.12]]);
+      expect(runtime.variables.set.args).to.eql([['intent_confidence', 86.12]]);
     });
   });
 });

--- a/tests/lib/services/runtime/index.unit.ts
+++ b/tests/lib/services/runtime/index.unit.ts
@@ -119,6 +119,7 @@ describe('runtime manager unit tests', () => {
         update: sinon.stub(),
         getRawState: sinon.stub().returns(rawState),
         trace: { get: sinon.stub().returns(trace), addTrace: sinon.stub(), debug: sinon.stub() },
+        variables: { set: sinon.stub() },
         getFinalState: sinon.stub().returns(rawState),
       };
 
@@ -155,6 +156,7 @@ describe('runtime manager unit tests', () => {
       await runtimeManager.handle(context);
 
       expect(runtime.trace.debug.args).to.eql([['matched intent **name** - confidence interval _86.12%_']]);
+      expect(runtime.variables.set.args).to.eql([[86.12]]);
     });
   });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-XXX**

### Brief description. What is this change?

Add a new builtin `intent_confidence` variable and update it on each intent reauest.

### Related PRs

https://github.com/voiceflow/creator-app/pull/3133
