### PR TITLE
fix: stop all (CORE-000)

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1000,6 +1000,10 @@ components:
           type: boolean
           default: true
           description: remove all SSML tags in the response message
+        stopAll:
+          type: boolean
+          default: true
+          description: stop on all custom traces
         stopTypes:
           type: array
           description: 'which trace types to return prematurely on, define your own path'

--- a/lib/services/runtime/handlers/_v1.ts
+++ b/lib/services/runtime/handlers/_v1.ts
@@ -50,7 +50,7 @@ export const _V1Handler: HandlerFactory<Node, typeof utilsObj> = (utils) => ({
 
     const stopTypes = runtime.turn.get<string[]>(TurnType.STOP_TYPES) || [];
 
-    const stop = stopTypes.includes(node.type) || node.stop;
+    const stop = runtime.turn.get(TurnType.STOP_ALL) || stopTypes.includes(node.type) || node.stop;
     // if !stop continue to defaultPath otherwise
     // quit cycleStack without ending session by stopping on itself
     return !stop ? defaultPath : node.id;

--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -58,6 +58,9 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
     if (context.data.config?.stopTypes) {
       runtime.turn.set(TurnType.STOP_TYPES, context.data.config.stopTypes);
     }
+    if (context.data.config?.stopAll) {
+      runtime.turn.set(TurnType.STOP_ALL, true);
+    }
 
     await runtime.update();
 

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -83,6 +83,7 @@ export enum TurnType {
   REPROMPT = 'reprompt',
   NEW_STACK = 'newStack',
   PREVIOUS_OUTPUT = 'lastOutput',
+  STOP_ALL = 'stopAll',
   STOP_TYPES = 'stopTypes',
 }
 

--- a/tests/lib/services/runtime/handlers/_v1.unit.ts
+++ b/tests/lib/services/runtime/handlers/_v1.unit.ts
@@ -49,7 +49,7 @@ describe('Trace handler unit tests', () => {
               },
             ],
           ]);
-          expect(runtime.turn.get.args).to.eql([[TurnType.STOP_TYPES]]);
+          expect(runtime.turn.get.args).to.eql([[TurnType.STOP_TYPES], [TurnType.STOP_ALL]]);
         });
 
         it('works with stop types', () => {
@@ -81,7 +81,7 @@ describe('Trace handler unit tests', () => {
               },
             ],
           ]);
-          expect(runtime.turn.get.args).to.eql([[TurnType.STOP_TYPES]]);
+          expect(runtime.turn.get.args).to.eql([[TurnType.STOP_TYPES], [TurnType.STOP_ALL]]);
         });
       });
 
@@ -115,7 +115,7 @@ describe('Trace handler unit tests', () => {
               },
             ],
           ]);
-          expect(runtime.turn.get.args).to.eql([[TurnType.STOP_TYPES]]);
+          expect(runtime.turn.get.args).to.eql([[TurnType.STOP_TYPES], [TurnType.STOP_ALL]]);
         });
 
         it('no port for default path', () => {
@@ -148,7 +148,7 @@ describe('Trace handler unit tests', () => {
               },
             ],
           ]);
-          expect(runtime.turn.get.args).to.eql([[TurnType.STOP_TYPES]]);
+          expect(runtime.turn.get.args).to.eql([[TurnType.STOP_TYPES], [TurnType.STOP_ALL]]);
         });
 
         it('return default port', () => {
@@ -181,7 +181,7 @@ describe('Trace handler unit tests', () => {
               },
             ],
           ]);
-          expect(runtime.turn.get.args).to.eql([[TurnType.STOP_TYPES]]);
+          expect(runtime.turn.get.args).to.eql([[TurnType.STOP_TYPES], [TurnType.STOP_ALL]]);
         });
       });
     });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-000**

### Brief description. What is this change?

For the prototype tool, if we want to stop on all trace/action blocks - there's no way to do it because we actually don't know all the types beforehand. So we actually need a separate command.

The other way we could do this is to have a special keyword like `any` in the stopTypes.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to undertand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] API documention is up to date
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependendencies are upgraded
