### PR TITLE
feat: smarter default filters (VF-723)

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1059,6 +1059,10 @@ components:
             type: string
             example: Pay Credit Card
             default: '[]'
+        excludeTypes:
+          type: array
+          default: [block, debug, flow]
+          description: trace types to not include in the response
       x-examples:
         example-1:
           tts: false

--- a/lib/services/filter/index.ts
+++ b/lib/services/filter/index.ts
@@ -22,24 +22,29 @@ class Filter extends AbstractManager<{ utils: typeof utils }> implements Context
       data: { config = {} },
     } = context;
 
-    if (config.stripSSML) {
-      context = {
-        ...context,
-        trace: context.trace?.map((trace) =>
-          !(trace.type === TraceType.SPEAK && (trace.payload.type === SpeakType.MESSAGE || trace.payload.type === SpeakType.AUDIO))
-            ? trace
-            : {
-                ...trace,
-                payload: {
-                  ...trace.payload,
-                  message: sanitizeSSML(trace.payload.message),
-                },
-              }
-        ),
-      };
+    let traces = context.trace || [];
+
+    const excludeTypes = config.excludeTypes || [TraceType.BLOCK, TraceType.DEBUG, TraceType.FLOW];
+    traces = traces.filter((trace) => !excludeTypes.includes(trace.type));
+
+    if (config.stripSSML !== false) {
+      traces = traces?.map((trace) =>
+        !(trace.type === TraceType.SPEAK && (trace.payload.type === SpeakType.MESSAGE || trace.payload.type === SpeakType.AUDIO))
+          ? trace
+          : {
+              ...trace,
+              payload: {
+                ...trace.payload,
+                message: sanitizeSSML(trace.payload.message),
+              },
+            }
+      );
     }
 
-    return context;
+    return {
+      ...context,
+      trace: traces,
+    };
   }
 }
 

--- a/tests/lib/services/filter/index.unit.ts
+++ b/tests/lib/services/filter/index.unit.ts
@@ -21,7 +21,7 @@ describe('filter manager unit tests', () => {
 
     expect(result).to.eql({
       ...input,
-      trace: [BLOCK_TRACE_START, DEBUG_TRACE, BLOCK_TRACE_MIDDLE, SPEAK_TRACE_NO_SSML, SPEAK_TRACE_SSML, CHOICE_TRACE],
+      trace: [SPEAK_TRACE_NO_SSML, SPEAK_TRACE_NO_SSML, CHOICE_TRACE],
     });
   });
 
@@ -36,7 +36,7 @@ describe('filter manager unit tests', () => {
 
     expect(result).to.eql({
       ...input,
-      trace: [BLOCK_TRACE_START, DEBUG_TRACE, BLOCK_TRACE_MIDDLE, SPEAK_TRACE_NO_SSML, SPEAK_TRACE_SSML, CHOICE_TRACE],
+      trace: [SPEAK_TRACE_NO_SSML, SPEAK_TRACE_NO_SSML, CHOICE_TRACE],
     });
   });
 
@@ -46,6 +46,36 @@ describe('filter manager unit tests', () => {
     const input = {
       ...context,
       data: { config: { stripSSML: true } },
+    };
+    const result = filter.handle(input as any);
+
+    expect(result).to.eql({
+      ...input,
+      trace: [SPEAK_TRACE_NO_SSML, SPEAK_TRACE_NO_SSML, CHOICE_TRACE],
+    });
+  });
+
+  it('keeps ssml', () => {
+    const filter = new Filter({} as any, {} as any);
+
+    const input = {
+      ...context,
+      data: { config: { stripSSML: false } },
+    };
+    const result = filter.handle(input as any);
+
+    expect(result).to.eql({
+      ...input,
+      trace: [SPEAK_TRACE_NO_SSML, SPEAK_TRACE_SSML, CHOICE_TRACE],
+    });
+  });
+
+  it('no exclude types', () => {
+    const filter = new Filter({} as any, {} as any);
+
+    const input = {
+      ...context,
+      data: { config: { excludeTypes: [] } },
     };
     const result = filter.handle(input as any);
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-723**

### Brief description. What is this change?

Add excludeTypes config that by default filters out debugging types that only the prototype tool needs.
stripSSML is also "true" by default, unless explicitly false.

Going to update creator-app to have these parameters filled out.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to undertand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] API documention is up to date
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependendencies are upgraded
