### PR TITLE
fix: rate limit origin (VF-000)

### DIFF
--- a/lib/middlewares/rateLimit.ts
+++ b/lib/middlewares/rateLimit.ts
@@ -3,11 +3,13 @@ import { NextFunction, Request, Response } from 'express';
 
 import { AbstractMiddleware } from './utils';
 
+const LOCAL_DEVELOPEMENT = 'https://creator-local.development.voiceflow.com:3002';
+
 class RateLimit extends AbstractMiddleware {
   async verify(req: Request<{}>, _res: Response, next: NextFunction) {
     if (
       !this.config.PROJECT_SOURCE &&
-      (!this.config.CREATOR_APP_ORIGIN || req.headers.origin !== this.config.CREATOR_APP_ORIGIN) &&
+      ![this.config.CREATOR_APP_ORIGIN, LOCAL_DEVELOPEMENT].includes(req.headers.origin || 'no-origin') &&
       !req.headers.authorization
     ) {
       throw new VError('Auth Key Required', VError.HTTP_STATUS.UNAUTHORIZED);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

So the problem is that with vfcli is origin on dev is naturally set to `https://creator-dev-<NAME>.development.voiceflow.com/`.

However if you are doing any kind of frontend work you are going to run it locally: `https://creator-local.development.voiceflow.com:3002`. So now we have two origins to account for. This is a temporary hack, but if you think there is a cleaner way of doing this @leartgjoni-voiceflow let me know.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to undertand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] API documention is up to date
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
