### PR TITLE
test: add flag to disable origin check for e2e tests (VF-298)

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -10,6 +10,9 @@ AWS_REGION='localhost'
 # dynamodb
 DYNAMO_ENDPOINT='http://localhost:8000'
 
+# cors
+DISABLE_ORIGIN_CHECK='true'
+
 # local configs
 VF_DATA_ENDPOINT='https://localhost:8011'
 INTEGRATIONS_HANDLER_ENDPOINT='https://localhost:8009'

--- a/backend/serviceManager.ts
+++ b/backend/serviceManager.ts
@@ -1,5 +1,3 @@
-/* eslint-disable class-methods-use-this, no-empty-function */
-
 import { buildClients, buildControllers, buildMiddleware, buildServices, ClientMap, ControllerMap, FullServiceMap, MiddlewareMap } from '@/lib';
 import { initClients, stopClients } from '@/lib/clients';
 import { Config } from '@/types';

--- a/config.ts
+++ b/config.ts
@@ -41,6 +41,7 @@ const CONFIG: Config = {
 
   // creator-app config
   CREATOR_APP_ORIGIN: getOptionalProcessEnv('CREATOR_APP_ORIGIN'),
+  DISABLE_ORIGIN_CHECK: getOptionalProcessEnv('DISABLE_ORIGIN_CHECK') === 'true',
 
   AWS_ACCESS_KEY_ID: getOptionalProcessEnv('AWS_ACCESS_KEY_ID'),
   AWS_SECRET_ACCESS_KEY: getOptionalProcessEnv('AWS_SECRET_ACCESS_KEY'),

--- a/lib/middlewares/rateLimit.ts
+++ b/lib/middlewares/rateLimit.ts
@@ -9,6 +9,7 @@ class RateLimit extends AbstractMiddleware {
   async verify(req: Request<{}>, _res: Response, next: NextFunction) {
     if (
       !this.config.PROJECT_SOURCE &&
+      !this.config.DISABLE_ORIGIN_CHECK &&
       ![this.config.CREATOR_APP_ORIGIN, LOCAL_DEVELOPEMENT].includes(req.headers.origin || 'no-origin') &&
       !req.headers.authorization
     ) {

--- a/types.ts
+++ b/types.ts
@@ -35,6 +35,7 @@ export interface Config {
   CREATOR_API_AUTHORIZATION: string | null;
 
   CREATOR_APP_ORIGIN: string | null;
+  DISABLE_ORIGIN_CHECK: boolean;
 
   ADMIN_SERVER_DATA_API_TOKEN: string | null;
   VF_DATA_ENDPOINT: string | null;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-298**

### Brief description. What is this change?

add a flag `DISABLE_ORIGIN_CHECK` to be used when running `e2e` tests

needed for https://github.com/voiceflow/creator-app/pull/3229