### PR TITLE
feat: support verbose responses from state API (VF-951)

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -178,6 +178,7 @@ paths:
         Every time a request is sent you will get a unique response based on where the user is currently on in the Voiceflow project.
 
         Send out a request with a `type` and `payload`, and get back a response with a `trace` array to act on.
+        If you've enabled the verbose response parameter you will receive an object with the `trace` array and the user's state.
 
         ```
         // -> request body, send user intention or event
@@ -188,7 +189,31 @@ paths:
           }
         }
         // <- response body, an array of "traces"
+        [{
+          "type": "speak",
+          "payload": {
+            "type": "message",
+            "message": "would you like fries with that?"
+          }
+        }, {
+          "type": "visual",
+          "payload": {
+            "image": "https://voiceflow.com/pizza.png"
+          }
+        }]
+
+        // <- verbose response body
         {
+          "state": {
+            "stack": [{
+              "programID": "home flow",
+              "nodeID": "yes no choice node"
+            }],
+            "storage": {},
+            "variables": {
+              "pizza_type": "pepperoni"
+            }
+          },
           "trace": [{
             "type": "speak",
             "payload": {
@@ -225,6 +250,14 @@ paths:
           schema:
             type: string
             example: user@gmail.com
+        - name: verbose
+          in: query
+          description: enable verbose responses
+          optional: false
+          default: false
+          schema:
+            type: boolean
+            example: false
         - in: header
           name: Authorization
           description: voiceflow API key

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -178,7 +178,7 @@ paths:
         Every time a request is sent you will get a unique response based on where the user is currently on in the Voiceflow project.
 
         Send out a request with a `type` and `payload`, and get back a response with a `trace` array to act on.
-        If you've enabled the verbose response parameter you will receive an object with the `trace` array and the user's state.
+        If you've enabled the verbose response parameter you will receive the [same kind of response as the stateless interact route](https://www.voiceflow.com/api/dialog-manager#operation/statelessInteract).
 
         ```
         // -> request body, send user intention or event
@@ -202,7 +202,7 @@ paths:
           }
         }]
 
-        // <- verbose response body
+        // <- simplified verbose response body
         {
           "state": {
             "stack": [{
@@ -326,10 +326,14 @@ paths:
                   - type: object
                     description: Verbose response, only returned if you enabled the `verbose` parameter
                     properties:
-                      state:
-                        $ref: '#/components/schemas/State'
                       trace:
                         $ref: '#/components/schemas/Trace'
+                      state:
+                        $ref: '#/components/schemas/State'
+                      request:
+                        $ref: '#/components/schemas/Request'
+                    required:
+                      - trace
                   - $ref: '#/components/schemas/Trace'
               examples:
                 Dialog Example:

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -322,10 +322,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  trace:
-                    $ref: '#/components/schemas/Trace'
+                oneOf:
+                  - type: object
+                    description: Verbose response, only returned if you enabled the `verbose` parameter
+                    properties:
+                      state:
+                        $ref: '#/components/schemas/State'
+                      trace:
+                        $ref: '#/components/schemas/Trace'
+                  - $ref: '#/components/schemas/Trace'
               examples:
                 Dialog Example:
                   value:

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -16,7 +16,7 @@ info:
     1. **Create a project**. You need to first build a conversational project on *[Voiceflow Creator](https://creator.voiceflow.com)*.
     2. **Create API Key**. If you are an admin of a Voiceflow workspace, create and manage API Keys under *Workspace Settings / Developers*.
     3. **Get Version ID**. On your project, it is in the URL: `https://creator.voiceflow.com/project/{versionID}/canvas/...`
-    4. **Make a test call**. Use the examples below to make an API call. Make subsequent calls to the same endpoint, 
+    4. **Make a test call**. Use the examples below to make an API call. Make subsequent calls to the same endpoint,
       changing the `payload` to reflect what the user might say. See how the response trace changes based on where in the project the user is.<br/>
       *Make sure to replace the `{apiKey}` and `{versionID}` with what you've gathered on steps 2 and 3*.
     5. **Implement your application**. Get familiar with the API by reading the rest of this documentation, and power the next conversation with your Voiceflow project!
@@ -123,7 +123,7 @@ tags:
     description: |
       Take advantage of the Custom Action step to allow you Voiceflow project to repeatably perform any kind of integration action/side effect.
 
-      Examples can include triggering navigation your website or app, processing a credit card payment, 
+      Examples can include triggering navigation your website or app, processing a credit card payment,
       opening the windows on a car, handing off to a human on a phone call, and much much more.
 
       Let's take a look at an example Custom Action step where we want to use a third party integration like *stripe* for actually charging a credit card:
@@ -131,14 +131,14 @@ tags:
 
       In your request body call, you can specific which Custom Actions to **stop** on in the `config.stopTypes` field:
       ```
-      { 
-        "request": { "type": "text", "payload": "hello!" } // any request type here, 
+      {
+        "request": { "type": "text", "payload": "hello!" } // any request type here,
         "config": {
           "stopTypes": ["Pay Credit Card"]
         }
       }
       ```
-      This will inform the dialog manager to stop on any `Pay Credit Card` Custom Action, ensuring that the last trace is always the Custom Action. 
+      This will inform the dialog manager to stop on any `Pay Credit Card` Custom Action, ensuring that the last trace is always the Custom Action.
       By default, Custom Action steps will always go out the default port, but still leave a trace.
 
       Here's what the Custom Action `trace` for the "Pay Credit Card" block above might look like:
@@ -162,10 +162,10 @@ tags:
 
       `"request": { "type": "success" }`
 
-      Where the `type` of the request is the same as the name of the path you've labelled in Voiceflow. 
+      Where the `type` of the request is the same as the name of the path you've labelled in Voiceflow.
       If the next request is an invalid path, your project will simply behave as if there were no lines coming out of the Custom Action step.
 
-      In summary - all that is happening is we send out a request saying to stop on certain types of Custom Actions, 
+      In summary - all that is happening is we send out a request saying to stop on certain types of Custom Actions,
       we get a response stopping on it, and in the next request, we specify the path to go down.
 paths:
   '/state/{versionID}/user/{userID}/interact':
@@ -539,7 +539,7 @@ paths:
         Notice that the `type: text` request got processed by the NLP handler to become an `type: intent` request.
         The `state` is updated, and a `trace` is generated in the API response.
 
-        To move the conversation forward, you can create a request object and pass it in the response body to `/interact/{versionID}` along with the state and optionally a `config` object. 
+        To move the conversation forward, you can create a request object and pass it in the response body to `/interact/{versionID}` along with the state and optionally a `config` object.
         This will return an updated `state`, an updated `request` (not shown in examples), and the trace array containing the traces to display.
 
         if `state` is undefined/empty, it will automatically use the **default state** (starting from the first block).

--- a/lib/controllers/stateManagement/index.ts
+++ b/lib/controllers/stateManagement/index.ts
@@ -7,7 +7,7 @@ import { customAJV, validate } from '../../utils';
 import { AbstractController } from '../utils';
 import { UpdateSchema } from './requests';
 
-const { body, header } = Validator;
+const { body, header, query } = Validator;
 const VALIDATIONS = {
   BODY: {
     UPDATE_SESSION: body().custom(customAJV(UpdateSchema)),
@@ -17,13 +17,19 @@ const VALIDATIONS = {
       .exists()
       .isString(),
   },
+  QUERY: {
+    VERBOSE: query('verbose')
+      .isBoolean()
+      .optional()
+      .toBoolean(),
+  },
 };
 
 class StateManagementController extends AbstractController {
   static VALIDATIONS = VALIDATIONS;
 
-  @validate({ HEADERS_PROJECT_ID: VALIDATIONS.HEADERS.PROJECT_ID })
-  async interact(req: Request<{ userID: string; versionID: string }, any, { project_id: string; authorization: string }>) {
+  @validate({ HEADERS_PROJECT_ID: VALIDATIONS.HEADERS.PROJECT_ID, QUERY_VERBOSE: VALIDATIONS.QUERY.VERBOSE })
+  async interact(req: Request<{ userID: string; versionID: string }, any, { project_id: string; authorization: string }, { verbose?: boolean }>) {
     return this.services.stateManagement.interact(req);
   }
 

--- a/lib/services/stateManagement.ts
+++ b/lib/services/stateManagement.ts
@@ -10,7 +10,7 @@ class StateManagement extends AbstractManager {
   async interact(data: {
     params: { versionID: string; userID: string };
     body: { state?: State; request?: RuntimeRequest; config?: Config };
-    query: { locale?: string };
+    query: { locale?: string; verbose?: boolean };
     headers: { authorization: string; project_id: string };
   }) {
     let state = await this.services.session.getFromDb<State>(data.headers.project_id, data.params.userID);
@@ -24,7 +24,7 @@ class StateManagement extends AbstractManager {
 
     await this.services.session.saveToDb(data.headers.project_id, data.params.userID, updatedState);
 
-    return trace;
+    return data.query.verbose ? { state: updatedState, trace } : trace;
   }
 
   async reset(data: { headers: { authorization: string; project_id: string }; params: { versionID: string; userID: string } }) {

--- a/lib/services/stateManagement.ts
+++ b/lib/services/stateManagement.ts
@@ -20,11 +20,11 @@ class StateManagement extends AbstractManager {
 
     data.body.state = state;
 
-    const { state: updatedState, trace } = await this.services.interact.handler(data);
+    const { state: updatedState, trace, request } = await this.services.interact.handler(data);
 
     await this.services.session.saveToDb(data.headers.project_id, data.params.userID, updatedState);
 
-    return data.query.verbose ? { state: updatedState, trace } : trace;
+    return data.query.verbose ? { state: updatedState, trace, request } : trace;
   }
 
   async reset(data: { headers: { authorization: string; project_id: string }; params: { versionID: string; userID: string } }) {

--- a/tests/lib/services/stateManagement.unit.ts
+++ b/tests/lib/services/stateManagement.unit.ts
@@ -54,7 +54,7 @@ describe('stateManagement manager unit tests', () => {
 
     it('with state, verbose response', async () => {
       const session = { foo: 'bar' };
-      const handlerResult = { state: { foo: 'bar2' }, trace: ['trace1', 'trace2', 'trace3'] };
+      const handlerResult = { state: { foo: 'bar2' }, trace: ['trace1', 'trace2', 'trace3'], request: { foo: 'bar3' } };
       const services = {
         session: { getFromDb: sinon.stub().resolves(session), saveToDb: sinon.stub() },
         interact: { handler: sinon.stub().resolves(handlerResult) },
@@ -79,7 +79,7 @@ describe('stateManagement manager unit tests', () => {
     it('no state, verbose response', async () => {
       const session = {};
       const newSession = { foo: 'bar' };
-      const handlerResult = { state: { foo: 'bar2' }, trace: ['trace1', 'trace2', 'trace3'] };
+      const handlerResult = { state: { foo: 'bar2' }, trace: ['trace1', 'trace2', 'trace3'], request: { foo: 'bar3' } };
       const services = {
         session: { getFromDb: sinon.stub().resolves(session), saveToDb: sinon.stub() },
         interact: { handler: sinon.stub().resolves(handlerResult) },

--- a/tests/lib/services/stateManagement.unit.ts
+++ b/tests/lib/services/stateManagement.unit.ts
@@ -19,7 +19,7 @@ describe('stateManagement manager unit tests', () => {
       };
       const service = new StateManagement(services as any, {} as any);
 
-      const data = { params: { userID: 'user-id', versionID: 'version-id' }, body: {}, headers: { project_id: 'project-id' } };
+      const data = { params: { userID: 'user-id', versionID: 'version-id' }, body: {}, headers: { project_id: 'project-id' }, query: {} };
 
       expect(await service.interact(data as any)).to.eql(handlerResult.trace);
 
@@ -41,9 +41,61 @@ describe('stateManagement manager unit tests', () => {
       const resetStub = sinon.stub().resolves(newSession);
       service.reset = resetStub;
 
-      const data = { params: { userID: 'user-id', versionID: 'version-id' }, body: {}, headers: { project_id: 'project-id' } };
+      const data = { params: { userID: 'user-id', versionID: 'version-id' }, body: {}, headers: { project_id: 'project-id' }, query: {} };
 
       expect(await service.interact(data as any)).to.eql(handlerResult.trace);
+
+      expect(services.session.getFromDb.args).to.eql([[data.headers.project_id, data.params.userID]]);
+      expect(resetStub.args).to.eql([[data]]);
+      expect(_.get(data.body, 'state')).to.eql(newSession);
+      expect(services.interact.handler.args).to.eql([[data]]);
+      expect(services.session.saveToDb.args).to.eql([[data.headers.project_id, data.params.userID, handlerResult.state]]);
+    });
+
+    it('with state, verbose response', async () => {
+      const session = { foo: 'bar' };
+      const handlerResult = { state: { foo: 'bar2' }, trace: ['trace1', 'trace2', 'trace3'] };
+      const services = {
+        session: { getFromDb: sinon.stub().resolves(session), saveToDb: sinon.stub() },
+        interact: { handler: sinon.stub().resolves(handlerResult) },
+      };
+      const service = new StateManagement(services as any, {} as any);
+
+      const data = {
+        params: { userID: 'user-id', versionID: 'version-id' },
+        body: {},
+        headers: { project_id: 'project-id' },
+        query: { verbose: true },
+      };
+
+      expect(await service.interact(data as any)).to.eql(handlerResult);
+
+      expect(services.session.getFromDb.args).to.eql([[data.headers.project_id, data.params.userID]]);
+      expect(_.get(data.body, 'state')).to.eql(session);
+      expect(services.interact.handler.args).to.eql([[data]]);
+      expect(services.session.saveToDb.args).to.eql([[data.headers.project_id, data.params.userID, handlerResult.state]]);
+    });
+
+    it('no state, verbose response', async () => {
+      const session = {};
+      const newSession = { foo: 'bar' };
+      const handlerResult = { state: { foo: 'bar2' }, trace: ['trace1', 'trace2', 'trace3'] };
+      const services = {
+        session: { getFromDb: sinon.stub().resolves(session), saveToDb: sinon.stub() },
+        interact: { handler: sinon.stub().resolves(handlerResult) },
+      };
+      const service = new StateManagement(services as any, {} as any);
+      const resetStub = sinon.stub().resolves(newSession);
+      service.reset = resetStub;
+
+      const data = {
+        params: { userID: 'user-id', versionID: 'version-id' },
+        body: {},
+        headers: { project_id: 'project-id' },
+        query: { verbose: true },
+      };
+
+      expect(await service.interact(data as any)).to.eql(handlerResult);
 
       expect(services.session.getFromDb.args).to.eql([[data.headers.project_id, data.params.userID]]);
       expect(resetStub.args).to.eql([[data]]);

--- a/tests/server/state.unit.ts
+++ b/tests/server/state.unit.ts
@@ -37,6 +37,7 @@ const tests = [
           stateManagement: {
             interact: {
               HEADERS_PROJECT_ID: 1,
+              QUERY_VERBOSE: 1,
             },
           },
         },


### PR DESCRIPTION
**Fixes or implements [VF-951](https://voiceflow.atlassian.net/browse/VF-951?atlOrigin=eyJpIjoiMGYyYjhlN2I4MjgwNDUxMzkyOWJiZWYxNmJiMTdkNTYiLCJwIjoiaiJ9)**

### Brief description. What is this change?

Supports returning the state in addition to the trace in responses on the state API*.

\* only one route, [`POST` `/state/{versionID}/user/{userID}/interact`](https://www.voiceflow.com/api/dialog-manager#operation/stateInteract)

### Implementation details. How do you make this change?

Checks for a `verbose` boolean query parameter, and if true will return the verbose response.
Default behavior has not changed.

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [x] appropriate tests have been written
- [ ] all the dependencies are upgraded
