### PR TITLE
feat: patch variables (VF-000)

### DIFF
--- a/backend/api/routers/state.ts
+++ b/backend/api/routers/state.ts
@@ -20,5 +20,12 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
 
   router.post('/:versionID/user/:userID', middlewares.rateLimit.consume, middlewares.project.attachID, controllers.stateManagement.reset);
 
+  router.patch(
+    '/:versionID/user/:userID/variables',
+    middlewares.rateLimit.consume,
+    middlewares.project.attachID,
+    controllers.stateManagement.updateVariables
+  );
+
   return router;
 };

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -462,7 +462,7 @@ paths:
                       pizza_type: pepperoni
                       sessions: 5
                       payment: credit
-      description: "Update the user's current state, useful for externally updating the user's variables or resetting everything."
+      description: "Update the user's current state, useful for externally updating the user's state, or for resetting everything."
       requestBody:
         content:
           application/json:
@@ -494,6 +494,65 @@ paths:
         '200':
           description: OK
       description: Delete all state and session data for user.
+  '/state/{versionID}/user/{userID}/variables':
+    parameters:
+      - name: versionID
+        in: path
+        description: voiceflow project version ID
+        required: true
+        schema:
+          type: string
+          example: 5eb039bf90821520c2068cea
+      - name: userID
+        in: path
+        description: unique user ID (create this yourself)
+        required: true
+        schema:
+          type: string
+          example: user@gmail.com
+      - in: header
+        name: Authorization
+        description: voiceflow API key
+        required: true
+        schema:
+          type: string
+          example: VF.6063709377e568001c098380.XXXXXXXXX.....
+    patch:
+      summary: update variables
+      tags:
+        - State API
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/State'
+                  - type: 'null'
+              examples:
+                Example State:
+                  value:
+                    stack:
+                      - programID: 6062631246b44d80a8a345b4
+                        nodeID: 60626307fd9a230006a5e289
+                    storage: {}
+                    variables:
+                      pizza_type: pepperoni
+                      sessions: 5
+                      payment: credit
+                      score: 200
+      operationId: updateStateVariables
+      description: updates the variables in the user's state, merges the provided properties in the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                pizza_type: pepperoni
+                sessions: 5
+        description: object full of variables to update
   '/interact/{versionID}':
     parameters:
       - name: versionID

--- a/tests/lib/controllers/stateManagement.unit.ts
+++ b/tests/lib/controllers/stateManagement.unit.ts
@@ -62,4 +62,20 @@ describe('stateManagement controller unit tests', () => {
       expect(services.stateManagement.reset.args).to.eql([[req]]);
     });
   });
+
+  describe('updateVariables', () => {
+    it('works', async () => {
+      const output = { foo: 'bar', variables: { a: 1, b: 2 } };
+      const services = { session: { getFromDb: sinon.stub().resolves(output), saveToDb: sinon.stub().resolves() } };
+      const controller = new StateManagement(services as any, {} as any);
+
+      const body = { b: 3, c: 4 };
+      const req = { headers: { project_id: 'project-id' }, params: { userID: 'user-id', versionID: 'version-id' }, body };
+
+      const expectedState = { ...output, variables: { ...output.variables, ...body } };
+      expect(await controller.updateVariables(req as any)).to.eql(expectedState);
+      expect(services.session.getFromDb.args).to.eql([[req.headers.project_id, req.params.userID]]);
+      expect(services.session.saveToDb.args).to.eql([[req.headers.project_id, req.params.userID, expectedState]]);
+    });
+  });
 });

--- a/tests/server/state.unit.ts
+++ b/tests/server/state.unit.ts
@@ -193,6 +193,44 @@ const tests = [
       },
     },
   },
+  {
+    method: 'patch',
+    calledPath: '/state/:versionID/user/:userID/variables',
+    expected: {
+      controllers: {
+        stateManagement: {
+          updateVariables: 1,
+        },
+      },
+      middlewares: {
+        rateLimit: {
+          verify: 1,
+          consume: 1,
+        },
+        project: {
+          attachID: 1,
+        },
+      },
+      validations: {
+        controllers: {
+          stateManagement: {
+            updateVariables: {
+              HEADERS_PROJECT_ID: 1,
+              BODY_UPDATE_VARIABLES: 1,
+            },
+          },
+        },
+        middlewares: {
+          project: {
+            attachID: {
+              PARAMS_VERSION_ID: 1,
+              HEADERS_AUTHORIZATION: 1,
+            },
+          },
+        },
+      },
+    },
+  },
 ];
 
 describe('state route unit tests', () => {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

So several users using the State API have asked about how they can use an external service to update the user's runtime variables. Right now the only way is to GET the user's state, and then modify the variable, and then PUT it back in.

I'm just condensing this into a single endpoint. I totally understand that there is a way to atomically merge objects with the mongo syntax, and that this has a slight race condition, but it is pretty clean and should work for the time being.

I've tested it a few times - interesting edge case being if the user has no state at all, and we update the variables, the `interact` still works fine.

Looking for feedback on the endpoint and presentation of this.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
