### PR TITLE
fix: only publish build folder (VF-483)

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,9 @@
     "typedoc-plugin-sourcefile-url": "^1.0.6",
     "typescript": "^3.9.7"
   },
+  "files": [
+    "build/"
+  ],
   "homepage": "https://github.com/voiceflow/general-runtime#readme",
   "keywords": [
     "express",


### PR DESCRIPTION
**Fixes or implements VF-483**

### Brief description. What is this change?

Only publish the `build/` folder and other required files to npm.

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| https://github.com/voiceflow/common/pull/46 | [link](https://github.com/voiceflow/common/pull/46) |
| https://github.com/voiceflow/logger/pull/23     | [link](https://github.com/voiceflow/logger/pull/23) |
| https://github.com/voiceflow/libs/pull/25     | [link](https://github.com/voiceflow/libs/pull/25) |
| https://github.com/voiceflow/general-runtime/pull/137     | [link](https://github.com/voiceflow/general-runtime/pull/137) |

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
