### PR TITLE
fix: use final trace (VF-1267)

### DIFF
--- a/lib/services/interact.ts
+++ b/lib/services/interact.ts
@@ -1,5 +1,6 @@
 import { Config, RequestType } from '@voiceflow/general-types';
 
+import { Event } from '@/lib/clients/ingest-client';
 import { RuntimeRequest } from '@/lib/services/runtime/types';
 import { State, TurnBuilder } from '@/runtime';
 import { Context } from '@/types';
@@ -53,7 +54,20 @@ class Interact extends AbstractManager {
 
     turn.addHandlers(speak, filter);
 
-    return turn.resolve({ state, request, versionID, data: { locale, config, reqHeaders: { authorization, origin, sessionid: sessionId } } });
+    // track analytics
+    turn.addHandlers({
+      handle: async (context: Context) => {
+        await this.services.analyticsClient!.track(context.versionID, Event.INTERACT, context);
+        return context;
+      },
+    });
+
+    return turn.resolve({
+      state,
+      request,
+      versionID,
+      data: { locale, config, reqHeaders: { authorization, origin, sessionid: sessionId } },
+    });
   }
 }
 

--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -5,7 +5,6 @@
 
 import { GeneralTrace } from '@voiceflow/general-types';
 
-import { Event } from '@/lib/clients/ingest-client';
 import Client from '@/runtime';
 import { Config, Context, ContextHandler } from '@/types';
 
@@ -65,15 +64,13 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
 
     await runtime.update();
 
-    const result = {
+    return {
       ...context,
       request,
       versionID,
       state: runtime.getFinalState(),
       trace: runtime.trace.get() as GeneralTrace[],
     };
-    await this.services.analyticsClient!.track(versionID, Event.INTERACT, result);
-    return result;
   }
 }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-1267**

### Brief description. What is this change?

Before we were saving the state at the end of the runtime handler, but there is still a sequence of other things before it.

Now we are ingesting it at the very end, so the format is identical to what the prototype receives. It is important to remove the MP3 waveform data so it doesnt take up storage.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
