### PR TITLE
feat: populate timestamp on each request (VF-1278)

### DIFF
--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -6,6 +6,7 @@
 import { GeneralTrace } from '@voiceflow/general-types';
 
 import { Event } from '@/lib/clients/ingest-client';
+import { Variables } from '@/lib/services/runtime/types';
 import Client from '@/runtime';
 import { Config, Context, ContextHandler } from '@/types';
 
@@ -63,6 +64,7 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
       runtime.turn.set(TurnType.STOP_ALL, true);
     }
 
+    runtime.variables.set(Variables.TIMESTAMP, Math.floor(Date.now() / 1000));
     await runtime.update();
 
     const result = {

--- a/tests/lib/services/runtime/index.unit.ts
+++ b/tests/lib/services/runtime/index.unit.ts
@@ -28,6 +28,7 @@ describe('runtime manager unit tests', () => {
         getRawState: sinon.stub().returns(rawState),
         trace: { get: sinon.stub().returns(trace), addTrace: sinon.stub() },
         getFinalState: sinon.stub().returns(rawState),
+        variables: { set: sinon.stub() },
       };
 
       const client = {
@@ -77,6 +78,7 @@ describe('runtime manager unit tests', () => {
         getFinalState: sinon.stub().returns(rawState),
         turn: { set: sinon.stub() },
         trace: { get: sinon.stub().returns(trace) },
+        variables: { set: sinon.stub() },
       };
 
       const client = {
@@ -125,6 +127,7 @@ describe('runtime manager unit tests', () => {
         getRawState: sinon.stub().returns(rawState),
         trace: { get: sinon.stub().returns(trace), addTrace: sinon.stub() },
         getFinalState: sinon.stub().returns(rawState),
+        variables: { set: sinon.stub() },
       };
 
       const client = {
@@ -168,6 +171,7 @@ describe('runtime manager unit tests', () => {
     it('matched intent debug trace', async () => {
       const rawState = { foo: 'bar' };
       const trace = { foo1: 'bar1' };
+      const timestamp = Math.floor(Date.now() / 1000);
       const runtime = {
         update: sinon.stub(),
         getRawState: sinon.stub().returns(rawState),
@@ -210,7 +214,10 @@ describe('runtime manager unit tests', () => {
       await runtimeManager.handle(context);
 
       expect(runtime.trace.debug.args).to.eql([['matched intent **name** - confidence interval _86.12%_']]);
-      expect(runtime.variables.set.args).to.eql([['intent_confidence', 86.12]]);
+      expect(runtime.variables.set.args).to.eql([
+        ['intent_confidence', 86.12],
+        ['timestamp', timestamp],
+      ]);
     });
   });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-1278**

### Brief description. What is this change?
The built in timestamp variable was not being populated with most recent changes in the prototype test.
See behaviour:

https://user-images.githubusercontent.com/19617248/125843477-8af14baa-04ea-48f7-9aa1-bde908ce2d05.mp4


### Checklist

- [X] title of PR reflects the branch name
- [X] all commits adhere to conventional commits
- [X] appropriate tests have been written
- [X] all the dependencies are upgraded
