### PR TITLE
feat: add `last_utterance` global variable (VF-1162)

### DIFF
--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -55,6 +55,7 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
       runtime.trace.debug(`matched intent **${request.payload.intent.name}** - confidence interval _${confidence}%_`);
 
       runtime.variables.set('intent_confidence', Number(confidence));
+      runtime.variables.set(Variables.LAST_UTTERANCE, request.payload.query);
     }
 
     if (context.data.config?.stopTypes) {

--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -54,7 +54,7 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
 
       runtime.trace.debug(`matched intent **${request.payload.intent.name}** - confidence interval _${confidence}%_`);
 
-      runtime.variables.set('intent_confidence', Number(confidence));
+      runtime.variables.set(Variables.INTENT_CONFIDENCE, Number(confidence));
       runtime.variables.set(Variables.LAST_UTTERANCE, request.payload.query);
     }
 

--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -55,7 +55,10 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
       runtime.trace.debug(`matched intent **${request.payload.intent.name}** - confidence interval _${confidence}%_`);
 
       runtime.variables.set(Variables.INTENT_CONFIDENCE, Number(confidence));
-      runtime.variables.set(Variables.LAST_UTTERANCE, request.payload.query);
+
+      if (request.payload.query) {
+        runtime.variables.set(Variables.LAST_UTTERANCE, request.payload.query);
+      }
     }
 
     if (context.data.config?.stopTypes) {

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -107,4 +107,5 @@ export type FrameData = Partial<{
 
 export enum Variables {
   TIMESTAMP = 'timestamp',
+  LAST_UTTERANCE = 'last_utterance',
 }

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -108,4 +108,5 @@ export type FrameData = Partial<{
 export enum Variables {
   TIMESTAMP = 'timestamp',
   LAST_UTTERANCE = 'last_utterance',
+  INTENT_CONFIDENCE = 'intent_confidence',
 }

--- a/tests/lib/services/runtime/index.unit.ts
+++ b/tests/lib/services/runtime/index.unit.ts
@@ -202,7 +202,7 @@ describe('runtime manager unit tests', () => {
       const request = {
         type: RequestType.INTENT,
         payload: {
-          query: '',
+          query: 'hello world',
           intent: { name: 'name' },
           entities: [],
           confidence: 0.86123,
@@ -216,6 +216,7 @@ describe('runtime manager unit tests', () => {
       expect(runtime.trace.debug.args).to.eql([['matched intent **name** - confidence interval _86.12%_']]);
       expect(runtime.variables.set.args).to.eql([
         ['intent_confidence', 86.12],
+        ['last_utterance', 'hello world'],
         ['timestamp', timestamp],
       ]);
     });


### PR DESCRIPTION
**Fixes or implements VF-1162**

### Brief description. What is this change?

Add a global `last_utterance` variable.

### Related PRs

- voiceflow/google-runtime#121
- voiceflow/creator-app#3804

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded