### PR TITLE
fix: loosen response timeout from 10s to 30s (VF-1399)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -16,7 +16,8 @@ const CONFIG: Config = {
   // Configs
   NODE_ENV,
   PORT: getRequiredProcessEnv('PORT'),
-  ERROR_RESPONSE_MS: Number(getOptionalProcessEnv('ERROR_RESPONSE_MS', (10 * 1000).toString())),
+  // TODO: Change from 30s->10s
+  ERROR_RESPONSE_MS: Number(getOptionalProcessEnv('ERROR_RESPONSE_MS', (30 * 1000).toString())),
 
   CLOUD_ENV,
 


### PR DESCRIPTION
**Fixes or implements VF-1399**

### Brief description. What is this change?

Loosen the response timeout from 10 seconds to 30 seconds, temporarily.

### Deployment Notes

If you really don't want to have this time increased set the `ERROR_RESPONSE_MS` variable to `10000`.

### Related PRs

- #161

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
