### PR TITLE
fix: set default timeout time to 10s (VF-1549)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -16,8 +16,7 @@ const CONFIG: Config = {
   // Configs
   NODE_ENV,
   PORT: getRequiredProcessEnv('PORT'),
-  // TODO: Change from 30s->10s
-  ERROR_RESPONSE_MS: Number(getOptionalProcessEnv('ERROR_RESPONSE_MS', (30 * 1000).toString())),
+  ERROR_RESPONSE_MS: Number(getOptionalProcessEnv('ERROR_RESPONSE_MS', (10 * 1000).toString())),
 
   CLOUD_ENV,
 


### PR DESCRIPTION
**Fixes or implements VF-1549**

### Brief description. What is this change?

Reduce the default timeout from 30s to 10s.

- voiceflow/alexa-runtime#186
- voiceflow/google-runtime#127
- voiceflow/general-runtime#164

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded