### PR TITLE
fix: dm analytics (VF-1593)

### DIFF
--- a/lib/services/analytics.ts
+++ b/lib/services/analytics.ts
@@ -1,0 +1,20 @@
+import { Event } from '@/lib/clients/ingest-client';
+import log from '@/logger';
+import { Context, ContextHandler } from '@/types';
+
+import { AbstractManager } from './utils';
+
+class Analytics extends AbstractManager implements ContextHandler {
+  handle = (context: Context) => {
+    const { versionID } = context;
+
+    // eslint-disable-next-line no-unused-expressions
+    this.services.analyticsClient?.track({ versionID, event: Event.TURN, metadata: context, timestamp: new Date() }).catch((error) => {
+      log.error(`[analytics] failed to track ${log.vars({ versionID, error })}`);
+    });
+
+    return context;
+  };
+}
+
+export default Analytics;

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -3,7 +3,7 @@ import { RateLimitManager } from '@voiceflow/backend-utils';
 import { Config } from '@/types';
 
 import { ClientMap } from '../clients';
-import Analytics from './Analytics';
+import Analytics from './analytics';
 import ASR from './asr';
 import Dialog from './dialog';
 import Filter from './filter';

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -3,6 +3,7 @@ import { RateLimitManager } from '@voiceflow/backend-utils';
 import { Config } from '@/types';
 
 import { ClientMap } from '../clients';
+import Analytics from './Analytics';
 import ASR from './asr';
 import Dialog from './dialog';
 import Filter from './filter';
@@ -30,6 +31,7 @@ export interface ServiceMap {
   filter: Filter;
   session: Session;
   interact: Interact;
+  analytics: Analytics;
   stateManagement: StateManagement;
 }
 
@@ -54,6 +56,7 @@ const buildServices = (config: Config, clients: ClientMap): FullServiceMap => {
   services.slots = new Slots(services, config);
   services.filter = new Filter(services, config);
   services.interact = new Interact(services, config);
+  services.analytics = new Analytics(services, config);
   services.stateManagement = new StateManagement(services, config);
 
   if (config.SESSIONS_SOURCE === Source.LOCAL) {

--- a/lib/services/interact.ts
+++ b/lib/services/interact.ts
@@ -19,7 +19,7 @@ class Interact extends AbstractManager {
     query: { locale?: string };
     headers: { authorization?: string; origin?: string; sessionid?: string };
   }) {
-    const { runtime, metrics, nlu, tts, dialog, asr, speak, slots, state: stateManager, filter } = this.services;
+    const { analytics, runtime, metrics, nlu, tts, dialog, asr, speak, slots, state: stateManager, filter } = this.services;
 
     const {
       body: { state, config = {} },
@@ -46,6 +46,7 @@ class Interact extends AbstractManager {
     const turn = new TurnBuilder<Context>(stateManager);
 
     turn.addHandlers(asr, nlu, slots, dialog, runtime);
+    turn.addHandlers(analytics);
 
     if (config.tts) {
       turn.addHandlers(tts);

--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -3,9 +3,7 @@
  * @packageDocumentation
  */
 
-import { Event } from '@/lib/clients/ingest-client';
 import { Variables } from '@/lib/services/runtime/types';
-import log from '@/logger';
 import Client from '@/runtime';
 import { Config, Context, ContextHandler } from '@/types';
 
@@ -67,25 +65,16 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
       runtime.turn.set(TurnType.STOP_ALL, true);
     }
 
-    const timestamp = new Date();
-
-    runtime.variables.set(Variables.TIMESTAMP, Math.floor(timestamp.getTime() / 1000));
+    runtime.variables.set(Variables.TIMESTAMP, Math.floor(Date.now() / 1000));
     await runtime.update();
 
-    const metadata: Context = {
+    return {
       ...context,
       request,
       versionID,
       state: runtime.getFinalState(),
       trace: runtime.trace.get(),
     };
-
-    // eslint-disable-next-line no-unused-expressions
-    this.services.analyticsClient?.track({ versionID, event: Event.TURN, metadata, timestamp }).catch((error) => {
-      log.error(`[analytics] failed to track ${log.vars({ versionID, error })}`);
-    });
-
-    return metadata;
   }
 }
 

--- a/tests/lib/services/analytics.unit.ts
+++ b/tests/lib/services/analytics.unit.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { Event } from '@/lib/clients/ingest-client';
+import AnalyticsManager from '@/lib/services/analytics';
+
+describe('analytics manager unit tests', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('works correctly', () => {
+    const services = {
+      analyticsClient: {
+        track: sinon.stub().resolves(),
+      },
+    };
+    const analytics = new AnalyticsManager(services as any, {} as any);
+    const context = { versionID: 1, data: '_context123' };
+    expect(analytics.handle(context as any)).to.eql(context);
+
+    const now = new Date();
+    const clock = sinon.useFakeTimers(now.getTime());
+
+    expect(services.analyticsClient.track.args).to.eql([[{ versionID: context.versionID, event: Event.TURN, metadata: context, timestamp: now }]]);
+
+    clock.restore();
+  });
+});

--- a/tests/lib/services/interact.unit.ts
+++ b/tests/lib/services/interact.unit.ts
@@ -14,6 +14,7 @@ const buildServices = (context: any) => ({
   tts: { handle: sinon.stub().resolves(output(context, 'tts')) },
   speak: { handle: sinon.stub().resolves(output(context, 'speak')) },
   runtime: { handle: sinon.stub().resolves(output(context, 'runtime')) },
+  analytics: { handle: sinon.stub().resolves(output(context, 'analytics')) },
   dialog: { handle: sinon.stub().resolves(output(context, 'dialog')) },
   filter: { handle: sinon.stub().resolves(output(context, 'filter', { trace: 'trace' })) },
   metrics: { generalRequest: sinon.stub() },
@@ -61,7 +62,8 @@ describe('interact service unit tests', () => {
       expect(services.slots.handle.args).to.eql([[output(context, 'nlu')]]);
       expect(services.dialog.handle.args).to.eql([[output(context, 'slots')]]);
       expect(services.runtime.handle.args).to.eql([[output(context, 'dialog')]]);
-      expect(services.tts.handle.args).to.eql([[output(context, 'runtime')]]);
+      expect(services.analytics.handle.args).to.eql([[output(context, 'runtime')]]);
+      expect(services.tts.handle.args).to.eql([[output(context, 'analytics')]]);
       expect(services.speak.handle.args).to.eql([[output(context, 'tts')]]);
       expect(services.metrics.generalRequest.callCount).to.eql(1);
     });
@@ -110,7 +112,8 @@ describe('interact service unit tests', () => {
       expect(services.slots.handle.args).to.eql([[output(context, 'nlu')]]);
       expect(services.dialog.handle.args).to.eql([[output(context, 'slots')]]);
       expect(services.runtime.handle.args).to.eql([[output(context, 'dialog')]]);
-      expect(services.tts.handle.args).to.eql([[output(context, 'runtime')]]);
+      expect(services.analytics.handle.args).to.eql([[output(context, 'runtime')]]);
+      expect(services.tts.handle.args).to.eql([[output(context, 'analytics')]]);
       expect(services.speak.handle.args).to.eql([[output(context, 'tts')]]);
       expect(services.metrics.generalRequest.callCount).to.eql(1);
     });
@@ -135,7 +138,7 @@ describe('interact service unit tests', () => {
       });
 
       expect(services.tts.handle.callCount).to.eql(0);
-      expect(services.speak.handle.args).to.eql([[output(context, 'runtime')]]);
+      expect(services.speak.handle.args).to.eql([[output(context, 'analytics')]]);
     });
   });
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-1593**

### Brief description. What is this change?

So originally the analytics was part of the runtime handler, and they would never be hit if the DM handler decided to exit early and skip the next handler in the sequence. 

Now it is in its own dedicated handler. I didn't add it at the very end because we don't want the trace to get polluted by the TTS MP3 and have too much data stored.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
