### PR TITLE
feat: unhashVersionID in dataAPI (VF-1685)

### DIFF
--- a/lib/services/state/cacheDataAPI.ts
+++ b/lib/services/state/cacheDataAPI.ts
@@ -33,7 +33,7 @@ class CacheDataAPI implements DataAPI<Program.GeneralProgram, Version.GeneralVer
     await this.api.init();
   }
 
-  async unhashVersionID(versionID: string) {
+  async unhashVersionID(versionID: string): Promise<string> {
     return this.api.unhashVersionID(versionID);
   }
 

--- a/lib/services/state/cacheDataAPI.ts
+++ b/lib/services/state/cacheDataAPI.ts
@@ -33,6 +33,10 @@ class CacheDataAPI implements DataAPI<Program.GeneralProgram, Version.GeneralVer
     await this.api.init();
   }
 
+  async unhashVersionID(versionID: string) {
+    return this.api.unhashVersionID(versionID);
+  }
+
   async fetchDisplayById(displayId: number) {
     return this.api.fetchDisplayById(displayId);
   }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ioredis": "^4.22.0",
     "lodash": "^4.17.21",
     "mathjs": "^6.5.0",
+    "moize": "^6.1.0",
     "mongodb": "^3.6.5",
     "regenerator-runtime": "^0.13.3",
     "require-from-url": "^3.1.3",

--- a/runtime/lib/DataAPI/creatorDataAPI.ts
+++ b/runtime/lib/DataAPI/creatorDataAPI.ts
@@ -46,6 +46,8 @@ class CreatorDataAPI<P extends Program<any, any>, V extends Version<any>, PJ ext
     return (await this.client.version.get(versionID)) as V;
   };
 
+  public unhashVersionID = async (versionID: string) => versionID;
+
   public getProject = async (projectID: string) => {
     return (await this.client.project.get(projectID)) as PJ;
   };

--- a/runtime/lib/DataAPI/localDataAPI.ts
+++ b/runtime/lib/DataAPI/localDataAPI.ts
@@ -28,6 +28,8 @@ class LocalDataAPI<P extends Program<any, any>, V extends Version<any>, PJ exten
 
   public getVersion = async () => this.version;
 
+  public unhashVersionID = async (versionID: string) => versionID;
+
   public getProgram = async (programID: string) => this.programs[programID];
 
   public getProject = async () => this.project;

--- a/runtime/lib/DataAPI/serverDataAPI.ts
+++ b/runtime/lib/DataAPI/serverDataAPI.ts
@@ -1,5 +1,7 @@
 import { BasePlatformData, Program, Project, Version } from '@voiceflow/api-sdk';
 import { AxiosInstance, AxiosStatic } from 'axios';
+import moize from 'moize';
+import { ObjectId } from 'mongodb';
 
 import { DataAPI, Display } from './types';
 
@@ -57,6 +59,17 @@ class ServerDataAPI<P extends Program<any, any>, V extends Version<any>, PJ exte
 
     return data;
   };
+
+  public unhashVersionID = moize(
+    async (versionID: string) => {
+      if (versionID.length === 24 && ObjectId.isValid(versionID)) return versionID;
+
+      const { data } = await this.client.get<string>(`/version/convert/${versionID}`);
+
+      return data;
+    },
+    { maxSize: 1000 }
+  );
 
   public getProject = async (projectID: string) => {
     const { data } = await this.client.get<PJ>(`/project/${projectID}`);

--- a/runtime/lib/DataAPI/serverDataAPI.ts
+++ b/runtime/lib/DataAPI/serverDataAPI.ts
@@ -60,11 +60,15 @@ class ServerDataAPI<P extends Program<any, any>, V extends Version<any>, PJ exte
     return data;
   };
 
-  public unhashVersionID = moize(
-    async (versionID: string) => {
-      if (versionID.length === 24 && ObjectId.isValid(versionID)) return versionID;
+  public unhashVersionID = async (versionID: string): Promise<string> => {
+    if (versionID.length === 24 && ObjectId.isValid(versionID)) return versionID;
 
-      const { data } = await this.client.get<string>(`/version/convert/${versionID}`);
+    return this._convertSkillID(versionID);
+  };
+
+  private _convertSkillID = moize(
+    async (skillID: string) => {
+      const { data } = await this.client.get<string>(`/version/convert/${skillID}`);
 
       return data;
     },

--- a/runtime/lib/DataAPI/types.ts
+++ b/runtime/lib/DataAPI/types.ts
@@ -15,5 +15,7 @@ export interface DataAPI<
 
   getVersion(versionID: string): Promise<V>;
 
+  unhashVersionID(versionID: string): Promise<string>;
+
   getProject(projectID: string): Promise<PJ>;
 }

--- a/tests/lib/clients/dataAPI.unit.ts
+++ b/tests/lib/clients/dataAPI.unit.ts
@@ -6,7 +6,7 @@ import DataAPI from '@/lib/clients/dataAPI';
 import Static from '@/lib/clients/static';
 
 describe('dataAPI client unit tests', () => {
-  beforeEach(() => {
+  afterEach(() => {
     sinon.restore();
   });
 

--- a/tests/lib/clients/index.unit.ts
+++ b/tests/lib/clients/index.unit.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { initClients, stopClients } from '@/lib/clients';
 
 describe('clients/index', () => {
-  beforeEach(() => {
+  afterEach(() => {
     sinon.restore();
   });
 

--- a/tests/lib/clients/metrics.unit.ts
+++ b/tests/lib/clients/metrics.unit.ts
@@ -6,7 +6,7 @@ import Config from '@/config';
 import MetricsClient, { Metrics } from '@/lib/clients/metrics';
 
 describe('metrics client unit tests', () => {
-  beforeEach(() => {
+  afterEach(() => {
     sinon.restore();
   });
 

--- a/tests/lib/clients/mongodb.unit.ts
+++ b/tests/lib/clients/mongodb.unit.ts
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import MongoDb from '@/lib/clients/mongodb';
 
 describe('mongodb client unit tests', () => {
-  beforeEach(() => {
+  afterEach(() => {
     sinon.restore();
   });
 

--- a/tests/lib/clients/remoteDataAPI.unit.ts
+++ b/tests/lib/clients/remoteDataAPI.unit.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import RemoteDataAPI from '@/lib/clients/remoteDataAPI';
 
 describe('remoteDataAPI client unit tests', () => {
-  beforeEach(() => {
+  afterEach(() => {
     sinon.restore();
   });
 

--- a/tests/lib/services/analytics.unit.ts
+++ b/tests/lib/services/analytics.unit.ts
@@ -19,10 +19,11 @@ describe('analytics manager unit tests', () => {
     const context = { versionID: 1, data: '_context123' };
     expect(analytics.handle(context as any)).to.eql(context);
 
-    const now = new Date();
-    const clock = sinon.useFakeTimers(now.getTime());
+    const clock = sinon.useFakeTimers(new Date());
 
-    expect(services.analyticsClient.track.args).to.eql([[{ versionID: context.versionID, event: Event.TURN, metadata: context, timestamp: now }]]);
+    expect(services.analyticsClient.track.args).to.eql([
+      [{ versionID: context.versionID, event: Event.TURN, metadata: context, timestamp: clock.Date() }],
+    ]);
 
     clock.restore();
   });

--- a/tests/lib/services/runtime/handlers/repeat.unit.ts
+++ b/tests/lib/services/runtime/handlers/repeat.unit.ts
@@ -9,7 +9,7 @@ import { FrameType, StorageType, TurnType } from '@/lib/services/runtime/types';
 describe('repeat handler', () => {
   const intentRequest = { type: Request.RequestType.INTENT, payload: { intent: { name: Constants.IntentName.REPEAT }, entities: [] } };
 
-  beforeEach(() => {
+  afterEach(() => {
     sinon.restore();
   });
 

--- a/tests/lib/services/runtime/index.unit.ts
+++ b/tests/lib/services/runtime/index.unit.ts
@@ -13,6 +13,7 @@ describe('runtime manager unit tests', () => {
   beforeEach(() => {
     clock = sinon.useFakeTimers(Date.now()); // fake Date.now
   });
+
   afterEach(() => {
     clock.restore(); // restore Date.now
     sinon.restore();

--- a/tests/lib/services/state/cacheDataAPI.unit.ts
+++ b/tests/lib/services/state/cacheDataAPI.unit.ts
@@ -79,6 +79,18 @@ describe('cacheDataAPI unit tests', () => {
     });
   });
 
+  describe('unhashVersionID', () => {
+    it('works', async () => {
+      const unhashVersionIDStub = sinon.stub().returns('unhashVersionID-value');
+      const dataAPIStub = { unhashVersionID: unhashVersionIDStub };
+
+      const cacheDataApi = new CacheDataAPI(dataAPIStub as any);
+
+      expect(await cacheDataApi.unhashVersionID('999')).to.eql('unhashVersionID-value');
+      expect(dataAPIStub.unhashVersionID.args).to.eql([['999']]);
+    });
+  });
+
   describe('fetchDisplayById', () => {
     it('works', async () => {
       const fetchDisplayByIdStub = sinon.stub().returns('fetchDisplayById-value');

--- a/tests/runtime/lib/DataAPI/creatorDataAPI.unit.ts
+++ b/tests/runtime/lib/DataAPI/creatorDataAPI.unit.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -104,6 +105,18 @@ describe('creatorDataAPI client unit tests', () => {
 
     expect(await creatorDataAPI.getVersion(versionID)).to.eql(version);
     expect(Client.version.get.args).to.eql([[versionID]]);
+  });
+
+  it('unhashVersionID', async () => {
+    const Client = { version: { get: sinon.stub().resolves() } };
+    const VFClient = sinon.stub().returns(Client);
+    const VF = sinon.stub().returns({
+      generateClient: VFClient,
+    });
+    const versionID = 'versionID';
+    const creatorDataAPI = new CreatorDataAPI({} as any, VF as any);
+
+    expect(await creatorDataAPI.unhashVersionID(versionID)).to.eql(versionID);
   });
 
   it('getProject', async () => {

--- a/tests/runtime/lib/DataAPI/creatorDataAPI.unit.ts
+++ b/tests/runtime/lib/DataAPI/creatorDataAPI.unit.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import CreatorDataAPI from '@/runtime/lib/DataAPI/creatorDataAPI';
 
 describe('creatorDataAPI client unit tests', () => {
-  beforeEach(() => {
+  afterEach(() => {
     sinon.restore();
   });
 

--- a/tests/runtime/lib/DataAPI/creatorDataAPI.unit.ts
+++ b/tests/runtime/lib/DataAPI/creatorDataAPI.unit.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/tests/runtime/lib/DataAPI/localDataAPI.unit.ts
+++ b/tests/runtime/lib/DataAPI/localDataAPI.unit.ts
@@ -68,6 +68,25 @@ describe('localDataAPI client unit tests', () => {
     expect(await LocalDataApi.getVersion()).to.eql(content.version);
   });
 
+  it('unhashVersionID', async () => {
+    const content = {
+      version: 'version-val',
+      project: 'project-val',
+      programs: 'programs-val',
+    };
+    const stubFS = {
+      readFileSync: sinon.stub().returns('readFileSync-val'),
+    };
+    const jsonParseStub = sinon.stub(JSON, 'parse').returns(content as any);
+    const path = {
+      join: sinon.stub().returns('join-val'),
+    };
+    const versionID = 'versionID';
+    const creatorDataAPI = new LocalDataAPI({ projectSource: 'project-source' } as any, { fs: stubFS as any, path: path as any } as any);
+
+    expect(await creatorDataAPI.unhashVersionID(versionID)).to.eql(versionID);
+  });
+
   it('getProgram', async () => {
     const content = {
       version: 'version-val',

--- a/tests/runtime/lib/DataAPI/localDataAPI.unit.ts
+++ b/tests/runtime/lib/DataAPI/localDataAPI.unit.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import LocalDataAPI from '@/runtime/lib/DataAPI/localDataAPI';
 
 describe('localDataAPI client unit tests', () => {
-  beforeEach(() => {
+  afterEach(() => {
     sinon.restore();
   });
 

--- a/tests/runtime/lib/DataAPI/localDataAPI.unit.ts
+++ b/tests/runtime/lib/DataAPI/localDataAPI.unit.ts
@@ -77,7 +77,7 @@ describe('localDataAPI client unit tests', () => {
     const stubFS = {
       readFileSync: sinon.stub().returns('readFileSync-val'),
     };
-    const jsonParseStub = sinon.stub(JSON, 'parse').returns(content as any);
+    sinon.stub(JSON, 'parse').returns(content as any);
     const path = {
       join: sinon.stub().returns('join-val'),
     };

--- a/tests/runtime/lib/Handlers/if.unit.ts
+++ b/tests/runtime/lib/Handlers/if.unit.ts
@@ -21,7 +21,7 @@ describe('ifHandler unit tests', () => {
   });
 
   describe('handle', () => {
-    beforeEach(() => {
+    afterEach(() => {
       sinon.restore();
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4011,6 +4011,11 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
+fast-equals@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-2.0.3.tgz#7039b0a039909f345a2ce53f6202a14e5f392efc"
+  integrity sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA==
+
 fast-glob@^2.2.6:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
@@ -6141,6 +6146,11 @@ methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
+micro-memoize@^4.0.9:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/micro-memoize/-/micro-memoize-4.0.9.tgz#b44a38c9dffbee1cefc2fd139bc8947952268b62"
+  integrity sha512-Z2uZi/IUMGQDCXASdujXRqrXXEwSY0XffUrAOllhqzQI3wpUyZbiZTiE2JuYC0HSG2G7DbCS5jZmsEKEGZuemg==
+
 micromatch@^3.1.10:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -6323,6 +6333,14 @@ mocha@^6.2.2:
     yargs "13.3.2"
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
+
+moize@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/moize/-/moize-6.1.0.tgz#736e505d30d0ff7751005ed2c66c74cf52941b87"
+  integrity sha512-WrMcM+C2Jy+qyOC/UMhA3BCHGowxV34dhDZnDNfxsREW/8N+33SFjmc23Q61Xv1WUthUA1vYopTitP1sZ5jkeg==
+  dependencies:
+    fast-equals "^2.0.1"
+    micro-memoize "^4.0.9"
 
 moment-timezone@^0.5.14:
   version "0.5.33"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-1685**

### Brief description. What is this change?

Call server-data-api to unhash legacy skill id

### Implementation details. How do you make this change?

memoized call to avoid network call for popular skills

### Deployment Notes

Dependent on https://github.com/voiceflow/server-data-api/pull/70 getting merged first

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| alexa-runtime | [link](https://github.com/voiceflow/alexa-runtime/pull/195/files) |
| google-runtime     | [link](https://github.com/voiceflow/google-runtime/pull/135/files) |

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [x] appropriate tests have been written
- [x] all the dependencies are upgraded
