### PR TITLE
fix: entities mapping (VF-1765)

### DIFF
--- a/lib/services/runtime/handlers/event/index.ts
+++ b/lib/services/runtime/handlers/event/index.ts
@@ -5,6 +5,8 @@ import { Runtime, Store } from '@/runtime';
 
 import { mapEntities } from '../../utils';
 
+const entitiesToMappings = (entities: Request.Entity[]) => entities.map(({ name }) => ({ slot: name, variable: name }));
+
 export const intentEventMatcher = {
   match: (context: {
     runtime: GeneralRuntime;
@@ -19,7 +21,8 @@ export const intentEventMatcher = {
   sideEffect: (context: { runtime: Runtime<Request.IntentRequest>; event: Node.Utils.IntentEvent; variables: Store }) => {
     // use event slot mappings map request entities to variables
     const request = context.runtime.getRequest() as Request.IntentRequest;
-    context.variables.merge(mapEntities(context.event.mappings || [], request.payload.entities || []));
+    const entities = request.payload.entities || [];
+    context.variables.merge(mapEntities(context.event.mappings || entitiesToMappings(entities), entities));
   },
 };
 

--- a/lib/services/runtime/handlers/interaction.ts
+++ b/lib/services/runtime/handlers/interaction.ts
@@ -41,6 +41,7 @@ export const InteractionHandler: HandlerFactory<GeneralNode.Interaction.Node | C
       const { event, nextId } = node.interactions[i];
 
       const matcher = utils.findEventMatcher({ event, runtime, variables });
+
       if (matcher) {
         // allow handler to apply side effects
         matcher.sideEffect();


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-1765**

### Brief description. What is this change?

This is a really legacy issue coming to bite us in the ass. So a long time ago every single interaction step contained the specific mappings from slot to variables. (So you could choose to not map certain ones)
But that's long gone and for backwards compatibility we kept the system. (context.mappings) and they get automatically declared in the compiler in general-service.

The new buttons step compiles into an interaction step but we didn't include these implicit mappings.
I think the fix going forward if there are no mappings, is to just turn every entity/slot in the intent into a variable.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
