### PR TITLE
fix: declare user agent (VF-000)

### DIFF
--- a/runtime/lib/Handlers/api/index.ts
+++ b/runtime/lib/Handlers/api/index.ts
@@ -12,6 +12,9 @@ export type IntegrationsOptions = {
   customAPIEndpoint?: string | null;
 };
 
+const USER_AGENT_KEY = 'User-Agent';
+const USER_AGENT = 'voiceflow-custom-api';
+
 const APIHandler: HandlerFactory<Node.Integration.Node, IntegrationsOptions | void> = ({ customAPIEndpoint } = {}) => ({
   canHandle: (node) => node.type === Node.NodeType.INTEGRATIONS && node.selected_integration === Node.Utils.IntegrationType.CUSTOM_API,
   handle: async (node, runtime, variables) => {
@@ -19,6 +22,11 @@ const APIHandler: HandlerFactory<Node.Integration.Node, IntegrationsOptions | vo
 
     try {
       const actionBodyData = deepVariableSubstitution(_.cloneDeep(node.action_data), variables.getState()) as APINodeData;
+
+      // override user agent
+      if (!actionBodyData.headers?.some(({ key }) => key === USER_AGENT_KEY)) {
+        actionBodyData.headers = [...actionBodyData.headers, { key: USER_AGENT_KEY, val: USER_AGENT }];
+      }
 
       const data = customAPIEndpoint
         ? (await axios.post(`${customAPIEndpoint}/custom/make_api_call`, actionBodyData)).data

--- a/runtime/lib/Handlers/api/index.ts
+++ b/runtime/lib/Handlers/api/index.ts
@@ -13,8 +13,7 @@ export type IntegrationsOptions = {
 };
 
 export const USER_AGENT_KEY = 'User-Agent';
-export const USER_AGENT = 'voiceflow-custom-api';
-
+export const USER_AGENT = 'Voiceflow/1.0.0 (+https://voiceflow.com)';
 const APIHandler: HandlerFactory<Node.Integration.Node, IntegrationsOptions | void> = ({ customAPIEndpoint } = {}) => ({
   canHandle: (node) => node.type === Node.NodeType.INTEGRATIONS && node.selected_integration === Node.Utils.IntegrationType.CUSTOM_API,
   handle: async (node, runtime, variables) => {

--- a/runtime/lib/Handlers/api/index.ts
+++ b/runtime/lib/Handlers/api/index.ts
@@ -12,8 +12,8 @@ export type IntegrationsOptions = {
   customAPIEndpoint?: string | null;
 };
 
-const USER_AGENT_KEY = 'User-Agent';
-const USER_AGENT = 'voiceflow-custom-api';
+export const USER_AGENT_KEY = 'User-Agent';
+export const USER_AGENT = 'voiceflow-custom-api';
 
 const APIHandler: HandlerFactory<Node.Integration.Node, IntegrationsOptions | void> = ({ customAPIEndpoint } = {}) => ({
   canHandle: (node) => node.type === Node.NodeType.INTEGRATIONS && node.selected_integration === Node.Utils.IntegrationType.CUSTOM_API,
@@ -24,8 +24,9 @@ const APIHandler: HandlerFactory<Node.Integration.Node, IntegrationsOptions | vo
       const actionBodyData = deepVariableSubstitution(_.cloneDeep(node.action_data), variables.getState()) as APINodeData;
 
       // override user agent
-      if (!actionBodyData.headers?.some(({ key }) => key === USER_AGENT_KEY)) {
-        actionBodyData.headers = [...actionBodyData.headers, { key: USER_AGENT_KEY, val: USER_AGENT }];
+      const headers = actionBodyData.headers || [];
+      if (!headers.some(({ key }) => key === USER_AGENT_KEY)) {
+        actionBodyData.headers = [...headers, { key: USER_AGENT_KEY, val: USER_AGENT }];
       }
 
       const data = customAPIEndpoint

--- a/tests/runtime/lib/Handlers/api.unit.ts
+++ b/tests/runtime/lib/Handlers/api.unit.ts
@@ -3,10 +3,12 @@ import axios from 'axios';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import APIHandler from '@/runtime/lib/Handlers/api';
+import APIHandler, { USER_AGENT, USER_AGENT_KEY } from '@/runtime/lib/Handlers/api';
 import * as APIUtils from '@/runtime/lib/Handlers/api/utils';
 
 const DEFAULT_OPTIONS = { customAPIEndpoint: 'https://foo' };
+const ACTION_DATA = { foo: 'bar' };
+const AGENT_ACTION_DATA = { foo: 'bar', headers: [{ key: USER_AGENT_KEY, val: USER_AGENT }] };
 
 describe('API Handler unit tests', () => {
   describe('canHandle', () => {
@@ -43,13 +45,17 @@ describe('API Handler unit tests', () => {
       const resultVariables = { data: { variables: { foo: 'bar' }, response: { status: 200 } } };
       const axiosPost = sinon.stub(axios, 'post').resolves(resultVariables);
 
-      const node = { selected_integration: Node.Utils.IntegrationType.CUSTOM_API, selected_action: 'Make a GET Request' };
+      const node = {
+        selected_integration: Node.Utils.IntegrationType.CUSTOM_API,
+        selected_action: 'Make a GET Request',
+        action_data: ACTION_DATA,
+      };
       const runtime = { trace: { debug: sinon.stub() } };
       const variables = { getState: sinon.stub().returns({}), merge: sinon.stub() };
 
       expect(await apiHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
       expect(runtime.trace.debug.args).to.eql([['API call successfully triggered', Node.NodeType.API]]);
-      expect(axiosPost.args).to.eql([[`${customAPIEndpoint}/custom/make_api_call`, undefined]]);
+      expect(axiosPost.args).to.eql([[`${customAPIEndpoint}/custom/make_api_call`, AGENT_ACTION_DATA]]);
       expect(variables.merge.args).to.eql([[resultVariables.data.variables]]);
     });
 
@@ -59,13 +65,17 @@ describe('API Handler unit tests', () => {
       const axiosPost = sinon.stub(axios, 'post').resolves(resultVariables);
       const local = sinon.stub(APIUtils, 'makeAPICall').resolves(resultVariables.data as any);
 
-      const node = { selected_integration: Node.Utils.IntegrationType.CUSTOM_API, selected_action: 'Make a GET Request', action_data: 'actionData' };
+      const node = {
+        selected_integration: Node.Utils.IntegrationType.CUSTOM_API,
+        selected_action: 'Make a GET Request',
+        action_data: ACTION_DATA,
+      };
       const runtime = { trace: { debug: sinon.stub() } };
       const variables = { getState: sinon.stub().returns({}), merge: sinon.stub() };
 
       expect(await apiHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
       expect(runtime.trace.debug.args).to.eql([['API call successfully triggered', Node.NodeType.API]]);
-      expect(local.args).to.eql([[node.action_data]]);
+      expect(local.args).to.eql([[AGENT_ACTION_DATA]]);
       expect(axiosPost.callCount).to.eql(0);
       expect(variables.merge.args).to.eql([[resultVariables.data.variables]]);
     });
@@ -75,7 +85,7 @@ describe('API Handler unit tests', () => {
       const resultVariables = { data: { variables: {}, response: { status: 401 } } };
       sinon.stub(axios, 'post').resolves(resultVariables);
 
-      const node = { selected_integration: 'Custom API', selected_action: 'Make a GET Request' };
+      const node = { selected_integration: 'Custom API', selected_action: 'Make a GET Request', action_data: ACTION_DATA };
       const runtime = { trace: { debug: sinon.stub() } };
       const variables = { getState: sinon.stub().returns({}), merge: sinon.stub() };
 
@@ -88,7 +98,7 @@ describe('API Handler unit tests', () => {
       const resultVariables = { data: { variables: {}, response: { status: 401 } } };
       sinon.stub(axios, 'post').resolves(resultVariables);
 
-      const node = { fail_id: 'fail-id', selected_integration: 'Custom API', selected_action: 'Make a GET Request' };
+      const node = { fail_id: 'fail-id', selected_integration: 'Custom API', selected_action: 'Make a GET Request', action_data: ACTION_DATA };
       const runtime = { trace: { debug: sinon.stub() } };
       const variables = { getState: sinon.stub().returns({}), merge: sinon.stub() };
 
@@ -102,25 +112,25 @@ describe('API Handler unit tests', () => {
         const axiosErr = { response: { data: 'http call error' } };
         const axiosPost = sinon.stub(axios, 'post').throws(axiosErr);
 
-        const node = { selected_integration: 'Zapier', selected_action: 'Start a Zap' };
+        const node = { selected_integration: 'Zapier', selected_action: 'Start a Zap', action_data: ACTION_DATA };
         const runtime = { trace: { debug: sinon.stub() } };
         const variables = { getState: sinon.stub().returns({}) };
 
         expect(await apiHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
         expect(runtime.trace.debug.args).to.eql([[`API call failed - Error: \n"${axiosErr.response.data}"`, Node.NodeType.API]]);
-        expect(axiosPost.args).to.eql([[`${DEFAULT_OPTIONS.customAPIEndpoint}/custom/make_api_call`, undefined]]);
+        expect(axiosPost.args).to.eql([[`${DEFAULT_OPTIONS.customAPIEndpoint}/custom/make_api_call`, AGENT_ACTION_DATA]]);
       });
 
       it('with fail_id', async () => {
         const apiHandler = APIHandler(DEFAULT_OPTIONS);
         const axiosPost = sinon.stub(axios, 'post').throws('error5');
 
-        const node = { fail_id: 'fail-id', selected_integration: 'Zapier', selected_action: 'Start a Zap' };
+        const node = { fail_id: 'fail-id', selected_integration: 'Zapier', selected_action: 'Start a Zap', action_data: ACTION_DATA };
         const runtime = { trace: { debug: sinon.stub() } };
         const variables = { getState: sinon.stub().returns({}) };
 
         expect(await apiHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.fail_id);
-        expect(axiosPost.args).to.eql([[`${DEFAULT_OPTIONS.customAPIEndpoint}/custom/make_api_call`, undefined]]);
+        expect(axiosPost.args).to.eql([[`${DEFAULT_OPTIONS.customAPIEndpoint}/custom/make_api_call`, AGENT_ACTION_DATA]]);
         expect(runtime.trace.debug.args).to.eql([['API call failed - Error: \n{"name":"error5"}', Node.NodeType.API]]);
       });
     });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

Trying to have consistency on local runtimes vs custom-api server.
We added this headers thing to custom-api awhile back: https://github.com/voiceflow/custom-api/pull/55
but it is not the case for calling axios directly from the runtime. To maintain consistency and make debugging easier, I decided to wrap it here.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
