### PR TITLE
feat: add export map (VF-000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,10 @@
     "typedoc-plugin-sourcefile-url": "^1.0.6",
     "typescript": "~4.3.5"
   },
+  "exports": {
+    ".": "./build/runtime/index.js",
+    "./ingest": "./build/lib/clients/ingest-client.js"
+  },
   "homepage": "https://github.com/voiceflow/general-runtime#readme",
   "keywords": [
     "express",


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

Add an export map to package.json for future use once we upgrade to TypeScript v4.5 ([docs](https://www.typescriptlang.org/tsconfig#moduleResolution))

```js
import * as Runtime from '@voiceflow/general-runtime';
import * as Ingest from '@voiceflow/general-runtime/ingest';
```

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
