### PR TITLE
feat: Set user_id to UserId for state api calls (VF-2153)

### DIFF
--- a/lib/services/interact.ts
+++ b/lib/services/interact.ts
@@ -1,6 +1,6 @@
 import { Request } from '@voiceflow/base-types';
 
-import { RuntimeRequest } from '@/lib/services/runtime/types';
+import { RuntimeRequest, Variables } from '@/lib/services/runtime/types';
 import { State, TurnBuilder } from '@/runtime';
 import { Context } from '@/types';
 
@@ -14,7 +14,7 @@ class Interact extends AbstractManager {
   }
 
   async handler(req: {
-    params: { versionID: string };
+    params: { versionID: string; userID?: string };
     body: { state?: State; request?: RuntimeRequest; config?: Request.RequestConfig };
     query: { locale?: string };
     headers: { authorization?: string; origin?: string; sessionid?: string };
@@ -36,6 +36,11 @@ class Interact extends AbstractManager {
       state.stack = [];
       state.storage = {};
       request = null;
+      // if this is a state API call, set the user_id variable to userID
+      // This is more for backwards compatibility for users that are already created to be able to access user_id
+      if (req.params.userID) {
+        state.variables = { ...state.variables, [Variables.USER_ID]: req.params.userID };
+      }
     }
 
     metrics.generalRequest();

--- a/lib/services/interact.ts
+++ b/lib/services/interact.ts
@@ -7,10 +7,10 @@ import { Context } from '@/types';
 import { AbstractManager } from './utils';
 
 class Interact extends AbstractManager {
-  async state(data: { headers: { authorization?: string; origin?: string }; params: { versionID: string; userID?: string } }) {
+  async state(data: { headers: { authorization?: string; origin?: string }; params: { versionID: string } }) {
     const api = await this.services.dataAPI.get(data.headers.authorization);
     const version = await api.getVersion(data.params.versionID);
-    return this.services.state.generate(version, undefined, data.params.userID);
+    return this.services.state.generate(version);
   }
 
   async handler(req: {
@@ -23,7 +23,7 @@ class Interact extends AbstractManager {
 
     const {
       body: { state, config = {} },
-      params: { versionID },
+      params: { versionID, userID },
       query: { locale },
       headers: { authorization, origin, sessionid: sessionId },
     } = req;
@@ -36,11 +36,6 @@ class Interact extends AbstractManager {
       state.stack = [];
       state.storage = {};
       request = null;
-      // if this is a state API call, set the user_id variable to userID
-      // This is more for backwards compatibility for users that are already created to be able to access user_id
-      if (req.params.userID) {
-        state.variables = { ...state.variables, [Variables.USER_ID]: req.params.userID };
-      }
     }
 
     metrics.generalRequest();
@@ -59,7 +54,13 @@ class Interact extends AbstractManager {
 
     turn.addHandlers(speak, filter);
 
-    return turn.resolve({ state, request, versionID, data: { locale, config, reqHeaders: { authorization, origin, sessionid: sessionId } } });
+    return turn.resolve({
+      state,
+      request,
+      userID,
+      versionID,
+      data: { locale, config, reqHeaders: { authorization, origin, sessionid: sessionId } },
+    });
   }
 }
 

--- a/lib/services/interact.ts
+++ b/lib/services/interact.ts
@@ -1,6 +1,6 @@
 import { Request } from '@voiceflow/base-types';
 
-import { RuntimeRequest, Variables } from '@/lib/services/runtime/types';
+import { RuntimeRequest } from '@/lib/services/runtime/types';
 import { State, TurnBuilder } from '@/runtime';
 import { Context } from '@/types';
 

--- a/lib/services/interact.ts
+++ b/lib/services/interact.ts
@@ -7,10 +7,10 @@ import { Context } from '@/types';
 import { AbstractManager } from './utils';
 
 class Interact extends AbstractManager {
-  async state(data: { headers: { authorization?: string; origin?: string }; params: { versionID: string } }) {
+  async state(data: { headers: { authorization?: string; origin?: string }; params: { versionID: string; userID?: string } }) {
     const api = await this.services.dataAPI.get(data.headers.authorization);
     const version = await api.getVersion(data.params.versionID);
-    return this.services.state.generate(version);
+    return this.services.state.generate(version, undefined, data.params.userID);
   }
 
   async handler(req: {

--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -42,7 +42,7 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
     return client;
   }
 
-  public async handle({ versionID, state, request, ...context }: Context): Promise<Context> {
+  public async handle({ versionID, userID, state, request, ...context }: Context): Promise<Context> {
     if (!isRuntimeRequest(request)) throw new Error(`invalid runtime request type: ${JSON.stringify(request)}`);
 
     const runtime = this.createClient(context.data.api).createRuntime(versionID, state, request);
@@ -67,6 +67,11 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
     }
 
     runtime.variables.set(Variables.TIMESTAMP, Math.floor(Date.now() / 1000));
+
+    // if state API call, set the variable user_id to be userID in the param
+    if (userID) {
+      runtime.variables.set(Variables.USER_ID, userID);
+    }
 
     // skip runtime for the action request, since it do not have any effects
     if (!isActionRequest(request)) {

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -99,4 +99,5 @@ export enum Variables {
   TIMESTAMP = 'timestamp',
   LAST_UTTERANCE = 'last_utterance',
   INTENT_CONFIDENCE = 'intent_confidence',
+  USER_ID = 'user_id',
 }

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -22,7 +22,7 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
    * generate a context for a new session
    * @param versionID - project version to generate the context for
    */
-  generate({ prototype, rootDiagramID }: Version<any>, state?: State, userID?: string): State {
+  generate({ prototype, rootDiagramID }: Version<any>, state?: State): State {
     const DEFAULT_STACK = [{ programID: rootDiagramID, storage: {}, variables: {} }];
 
     const stack =
@@ -35,8 +35,6 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
     return {
       stack,
       variables: {
-        // if userID is passed in as an argument from a state API call, set variable user_id to it
-        ...(userID && { [Variables.USER_ID]: userID }),
         ...prototype?.context.variables,
         ...state?.variables,
       },

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -1,6 +1,7 @@
 import { Version } from '@voiceflow/api-sdk';
 import { Trace } from '@voiceflow/base-types';
 
+import { Variables } from '@/lib/services/runtime/types';
 import { PartialContext, State } from '@/runtime';
 import { Context, InitContextHandler } from '@/types';
 
@@ -21,7 +22,7 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
    * generate a context for a new session
    * @param versionID - project version to generate the context for
    */
-  generate({ prototype, rootDiagramID }: Version<any>, state?: State): State {
+  generate({ prototype, rootDiagramID }: Version<any>, state?: State, userID?: string): State {
     const DEFAULT_STACK = [{ programID: rootDiagramID, storage: {}, variables: {} }];
 
     const stack =
@@ -34,6 +35,8 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
     return {
       stack,
       variables: {
+        // if userID is passed in as an argument from a state API call, set variable user_id to it
+        ...(userID && { [Variables.USER_ID]: userID }),
         ...prototype?.context.variables,
         ...state?.variables,
       },

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -1,7 +1,6 @@
 import { Version } from '@voiceflow/api-sdk';
 import { Trace } from '@voiceflow/base-types';
 
-import { Variables } from '@/lib/services/runtime/types';
 import { PartialContext, State } from '@/runtime';
 import { Context, InitContextHandler } from '@/types';
 

--- a/runtime/lib/Context/types.ts
+++ b/runtime/lib/Context/types.ts
@@ -9,6 +9,7 @@ export type Context<R = Record<string, unknown>, T = Node.Utils.BaseTraceFrame, 
   trace?: T[];
   end?: boolean;
   data: D;
+  userID?: string;
 };
 
 export type ContextHandle<C extends Context<any, any, any>> = (request: C) => C | Promise<C>;

--- a/tests/lib/services/interact.unit.ts
+++ b/tests/lib/services/interact.unit.ts
@@ -33,6 +33,7 @@ describe('interact service unit tests', () => {
         state: data.body.state,
         request: data.body.request,
         versionID: data.params.versionID,
+        userID: undefined,
         data: {
           locale: data.query.locale,
           config: {
@@ -83,6 +84,7 @@ describe('interact service unit tests', () => {
         state: { ...data.body.state, stack: [], storage: {} },
         request: null,
         versionID: data.params.versionID,
+        userID: undefined,
         data: {
           locale: data.query.locale,
           config: {
@@ -125,7 +127,13 @@ describe('interact service unit tests', () => {
         params: { versionID: 'versionID' },
         query: { locale: 'locale' },
       };
-      const context = { state: data.body.state, request: data.body.request, versionID: data.params.versionID, data: { locale: data.query.locale } };
+      const context = {
+        state: data.body.state,
+        userID: undefined,
+        request: data.body.request,
+        versionID: data.params.versionID,
+        data: { locale: data.query.locale },
+      };
 
       const services = buildServices(context);
 
@@ -149,7 +157,13 @@ describe('interact service unit tests', () => {
       params: { versionID: 'versionID' },
       query: { locale: 'locale' },
     };
-    const context = { state: data.body.state, request: data.body.request, versionID: data.params.versionID, data: { locale: data.query.locale } };
+    const context = {
+      state: data.body.state,
+      userID: undefined,
+      request: data.body.request,
+      versionID: data.params.versionID,
+      data: { locale: data.query.locale },
+    };
 
     const services = buildServices(context);
 
@@ -169,7 +183,13 @@ describe('interact service unit tests', () => {
       params: { versionID: 'versionID' },
       query: { locale: 'locale' },
     };
-    const context = { state: data.body.state, request: data.body.request, versionID: data.params.versionID, data: { locale: data.query.locale } };
+    const context = {
+      state: data.body.state,
+      userID: undefined,
+      request: data.body.request,
+      versionID: data.params.versionID,
+      data: { locale: data.query.locale },
+    };
 
     const services = buildServices(context);
 

--- a/tests/lib/services/runtime/index.unit.ts
+++ b/tests/lib/services/runtime/index.unit.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import RuntimeManager, { utils as defaultUtils } from '@/lib/services/runtime';
-import { TurnType } from '@/lib/services/runtime/types';
+import { TurnType, Variables } from '@/lib/services/runtime/types';
 
 const VERSION_ID = 'version_id';
 
@@ -220,6 +220,56 @@ describe('runtime manager unit tests', () => {
         ['last_utterance', 'hello world'],
         ['timestamp', timestamp],
       ]);
+    });
+
+    it('sets user_id variable if userID passed in', async () => {
+      const rawState = { foo: 'bar' };
+      const trace = { foo1: 'bar1' };
+
+      const runtime = {
+        update: sinon.stub(),
+        getRawState: sinon.stub().returns(rawState),
+        trace: { get: sinon.stub().returns(trace), addTrace: sinon.stub() },
+        getFinalState: sinon.stub().returns(rawState),
+        variables: { set: sinon.stub() },
+      };
+
+      const client = {
+        setEvent: sinon.stub(),
+        createRuntime: sinon.stub().returns(runtime),
+      };
+
+      const services = {
+        dataAPI: { getProgram: 'service-api' },
+        analyticsClient: { track: sinon.stub().resolves() },
+      };
+
+      const utils = {
+        Client: sinon.stub().returns(client),
+        Handlers: () => 'foo',
+      };
+
+      const config = {};
+
+      const runtimeManager = new RuntimeManager({ ...services, utils: { ...defaultUtils, ...utils } } as any, config as any);
+
+      const state = { foo2: 'bar2' };
+      const request = {
+        type: Request.RequestType.INTENT,
+        payload: {},
+      };
+      const context = { state, userID: 'someUserId', request, versionID: VERSION_ID, data: { api: { getProgram: 'api' } } } as any;
+      expect(await runtimeManager.handle(context)).to.eql({
+        state: rawState,
+        trace,
+        request,
+        versionID: VERSION_ID,
+        data: { api: { getProgram: 'api' } },
+      });
+      expect(utils.Client.firstCall.args[0].api).to.eql({ getProgram: 'api' });
+      expect(client.createRuntime.args).to.eql([[VERSION_ID, state, request]]);
+      expect(runtime.update.callCount).to.eql(1);
+      expect(runtime.variables.set.args).to.eql([[Variables.USER_ID, 'someUserId']]);
     });
   });
 });

--- a/tests/lib/services/runtime/index.unit.ts
+++ b/tests/lib/services/runtime/index.unit.ts
@@ -269,7 +269,10 @@ describe('runtime manager unit tests', () => {
       expect(utils.Client.firstCall.args[0].api).to.eql({ getProgram: 'api' });
       expect(client.createRuntime.args).to.eql([[VERSION_ID, state, request]]);
       expect(runtime.update.callCount).to.eql(1);
-      expect(runtime.variables.set.args).to.eql([[Variables.USER_ID, 'someUserId']]);
+      expect(runtime.variables.set.args).to.eql([
+        [Variables.TIMESTAMP, 0],
+        [Variables.USER_ID, 'someUserId'],
+      ]);
     });
   });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2153**

### Brief description. What is this change?

Made user_id variable reflect the UserID passed in the network request for state api requests 
(see: https://www.voiceflow.com/api/dialog-manager#operation/stateInteract ).

### Implementation details. How do you make this change?

For first time UserIDs, the `user_id` variable is set in the initial generation of the context. 
See lib/services/state/index.ts -> StateManager -> generate.

For existing userIds to be able to access the `user_id`, the addition of the variable is done in the case of a `LAUNCH` request. I thought it would be overkill to set it for every state api request, so a reset for any user will add the ability to use the `user_id` variable.

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
