### PR TITLE
feat: reduce immer use (VF-000)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -26,11 +26,11 @@ const CONFIG: Config = {
   DYNAMO_ENDPOINT: getOptionalProcessEnv('DYNAMO_ENDPOINT'),
 
   // code block
-  CODE_HANDLER_ENDPOINT: null,
+  CODE_HANDLER_ENDPOINT: getOptionalProcessEnv('CODE_HANDLER_ENDPOINT'),
   // integrations block
   INTEGRATIONS_HANDLER_ENDPOINT: getOptionalProcessEnv('INTEGRATIONS_HANDLER_ENDPOINT') || 'none',
   // api-block
-  API_HANDLER_ENDPOINT: null,
+  API_HANDLER_ENDPOINT: getOptionalProcessEnv('API_HANDLER_ENDPOINT'),
 
   PROJECT_SOURCE: getOptionalProcessEnv('PROJECT_SOURCE'),
 

--- a/config.ts
+++ b/config.ts
@@ -26,11 +26,11 @@ const CONFIG: Config = {
   DYNAMO_ENDPOINT: getOptionalProcessEnv('DYNAMO_ENDPOINT'),
 
   // code block
-  CODE_HANDLER_ENDPOINT: getOptionalProcessEnv('CODE_HANDLER_ENDPOINT'),
+  CODE_HANDLER_ENDPOINT: null,
   // integrations block
   INTEGRATIONS_HANDLER_ENDPOINT: getOptionalProcessEnv('INTEGRATIONS_HANDLER_ENDPOINT') || 'none',
   // api-block
-  API_HANDLER_ENDPOINT: getOptionalProcessEnv('API_HANDLER_ENDPOINT'),
+  API_HANDLER_ENDPOINT: null,
 
   PROJECT_SOURCE: getOptionalProcessEnv('PROJECT_SOURCE'),
 

--- a/runtime/lib/Runtime/Store/index.ts
+++ b/runtime/lib/Runtime/Store/index.ts
@@ -82,7 +82,7 @@ class Store {
   }
 
   public merge<S extends State>(payload: Partial<S>): void {
-    this.update({ ...this.store, payload });
+    this.update({ ...this.store, ...payload });
   }
 
   public set<T extends unknown>(key: string, value: T): void {

--- a/runtime/lib/Runtime/Store/index.ts
+++ b/runtime/lib/Runtime/Store/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-expressions */
 
 import produce, { Draft } from 'immer';
+import { values } from 'lodash';
 
 export type State = { readonly [k: string]: any };
 
@@ -81,19 +82,16 @@ class Store {
   }
 
   public merge<S extends State>(payload: Partial<S>): void {
-    this.produce((draft: Draft<S>) => Object.assign(draft, payload));
+    this.update({ ...this.store, payload });
   }
 
   public set<T extends unknown>(key: string, value: T): void {
-    this.produce((draft: Draft<State>) => {
-      draft[key] = value;
-    });
+    this.update({ ...this.store, [key]: value });
   }
 
   public delete(key: string): void {
-    this.produce((draft: Draft<State>) => {
-      delete draft[key];
-    });
+    const { [key]: _key, ...newState } = this.store;
+    this.update(newState);
   }
 
   public keys(): string[] {

--- a/runtime/lib/Runtime/Store/index.ts
+++ b/runtime/lib/Runtime/Store/index.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-expressions */
 
 import produce, { Draft } from 'immer';
-import { values } from 'lodash';
 
 export type State = { readonly [k: string]: any };
 

--- a/runtime/lib/Runtime/utils/variables.ts
+++ b/runtime/lib/Runtime/utils/variables.ts
@@ -24,9 +24,10 @@ export const saveCombinedVariables = (combined: Store, global: Store, local: Sto
 };
 
 export const mapStores = (map: [string, string][], from: Store, to: Store): void => {
-  to.produce((draft) => {
-    map.forEach(([currentVal, newVal]) => {
-      draft[newVal] = from.get(currentVal);
-    });
-  });
+  to.merge(
+    map.reduce<Record<string, unknown>>((acc, [currentVal, newVal]) => {
+      acc[newVal] = from.get(currentVal);
+      return acc;
+    }, {})
+  );
 };


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?
After talking to a client, it appears that immer may cause drastic slowdowns when performing operations on very large objects.  Immer takes a lot of time and memory to create proxies for such a big object

Instead just use traditional object destructuring techniques to preserve immutability. 

We can consider removing immer entirely.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
