### PR TITLE
feat: upgrade to Node.js v16 (VF-2065)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ defaults:
           branch_pattern: master
 
 orbs:
-  vfcommon: voiceflow/common@0.0.249
+  vfcommon: voiceflow/common@0.0.251
   sonarcloud: sonarsource/sonarcloud@1.0.2
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12 as build  
+FROM node:16-alpine as build
 
 ARG NPM_TOKEN
 
@@ -9,9 +9,9 @@ RUN echo $NPM_TOKEN > .npmrc && \
   yarn install --ignore-scripts && \
   yarn build && \
   rm -rf build/node_modules && \
-  rm -f .npmrc 
+  rm -f .npmrc
 
-FROM node:12-alpine 
+FROM node:16-alpine
 
 RUN apk add --no-cache dumb-init
 

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM node:12-alpine 
+FROM node:16-alpine
 
 RUN apk add --no-cache dumb-init ca-certificates
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2065**

### Brief description. What is this change?

upgrade to node16 during the build process and on runtime

### Implementation details. How do you make this change?

upgrading the executors to node 16 on our orb


### Deployment Notes

deep Test this before merge


### Checklist

- [x] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
