### PR TITLE
ci: e2e manual approval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ defaults:
           branch_pattern: master
 
 orbs:
-  vfcommon: voiceflow/common@0.0.251
+  vfcommon: voiceflow/common@0.0.253
   sonarcloud: sonarsource/sonarcloud@1.0.2
 
 jobs:
@@ -162,6 +162,12 @@ workflows:
           context: dev-test
           filters:
             <<: *ignore_staging_filters
+      - e2e-approval: # <<< A job that will require manual approval in the CircleCI web application.
+          type: approval # <<< This key-value pair will set your workflow to a status of "On Hold"
+          filters:
+            branches:
+              ignore: master
+      - vfcommon/dummy_job
       - vfcommon/test_e2e:
           <<: *slack-fail-post-step
           github_username: GITHUB_USERNAME
@@ -171,7 +177,9 @@ workflows:
           vf_service_name: "general-runtime"
           vf_service_port: "8005"
           context: dev-test
-          enable: false
+          requires:
+           - e2e-approval
+           - vfcommon/dummy_job
           filters:
             <<: *ignore_staging_filters
       - vfcommon/release:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2213**

### Brief description. What is this change?

manual approval for e2e and disabled sonar on creator-app

### Implementation details. How do you make this change?

the e2e will require manual approval only for all the branches except master even if they are marked as draft.


### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
