### PR TITLE
feat: new action system (VF-000)

### DIFF
--- a/lib/services/dialog/utils.ts
+++ b/lib/services/dialog/utils.ts
@@ -97,7 +97,7 @@ export const isIntentInScope = async ({ data: { api }, versionID, state, request
   const node = program?.getNode(currentFrame.getNodeID());
   const variables = Store.merge(runtime.variables, currentFrame.variables);
 
-  if (runtime.getAction() === Action.RESPONSE || !node) return false;
+  if (runtime.getAction() === Action.RUNNING || !node) return false;
 
   // if no event handler can handle, intent req is out of scope => no dialog management required
   if (!eventHandlers.find((h) => h.canHandle(node as any, runtime, variables, program!))) return false;

--- a/lib/services/runtime/handlers/_v1.ts
+++ b/lib/services/runtime/handlers/_v1.ts
@@ -19,9 +19,6 @@ export const _V1Handler: HandlerFactory<Node._v1.Node, typeof utilsObj> = (utils
 
     // process req if not process before (action == REQUEST)
     if (runtime.getAction() === Action.REQUEST) {
-      // request for this turn has been processed, set action to response
-      runtime.setAction(Action.RESPONSE);
-
       for (const traceEvent of node.paths) {
         const { event = null, nextID } = traceEvent;
 

--- a/lib/services/runtime/handlers/capture.ts
+++ b/lib/services/runtime/handlers/capture.ts
@@ -21,15 +21,12 @@ const utilsObj = {
 export const CaptureHandler: HandlerFactory<GeneralNode.Capture.Node | ChatNode.Capture.Node, typeof utilsObj> = (utils) => ({
   canHandle: (node) => !!node.variable,
   handle: (node, runtime, variables) => {
-    if (runtime.getAction() === Action.RESPONSE) {
+    if (runtime.getAction() === Action.RUNNING) {
       utils.addRepromptIfExists(node, runtime, variables);
       utils.addButtonsIfExists(node, runtime, variables);
       // quit cycleStack without ending session by stopping on itself
       return node.id;
     }
-
-    // request for this turn has been processed, set action to response
-    runtime.setAction(Action.RESPONSE);
 
     // check if there is a command in the stack that fulfills request
     if (utils.commandHandler.canHandle(runtime)) {

--- a/lib/services/runtime/handlers/command.ts
+++ b/lib/services/runtime/handlers/command.ts
@@ -26,9 +26,6 @@ export const CommandHandler = (utils: typeof utilsObj) => ({
   handle: (runtime: GeneralRuntime, variables: Store): string | null => {
     const res = utils.getCommand(runtime);
 
-    // request for this turn has been processed, set action to response
-    runtime.setAction(Action.RESPONSE);
-
     const { command, index } = res!;
     const { event } = command;
     const { stack, trace } = runtime;

--- a/lib/services/runtime/handlers/command.ts
+++ b/lib/services/runtime/handlers/command.ts
@@ -1,7 +1,7 @@
 import { Node as BaseNode, Trace } from '@voiceflow/base-types';
 
 import { FrameType, GeneralRuntime } from '@/lib/services/runtime/types';
-import { Action, extractFrameCommand, Frame, Store } from '@/runtime';
+import { extractFrameCommand, Frame, Store } from '@/runtime';
 
 import { findEventMatcher, hasEventMatch } from './event';
 

--- a/lib/services/runtime/handlers/interaction.ts
+++ b/lib/services/runtime/handlers/interaction.ts
@@ -24,7 +24,7 @@ const utilsObj = {
 export const InteractionHandler: HandlerFactory<GeneralNode.Interaction.Node | ChatNode.Interaction.Node, typeof utilsObj> = (utils) => ({
   canHandle: (node) => !!node.interactions,
   handle: (node, runtime, variables, program) => {
-    if (runtime.getAction() === Action.RESPONSE) {
+    if (runtime.getAction() === Action.RUNNING) {
       utils.addRepromptIfExists(node, runtime, variables);
       utils.addButtonsIfExists(node, runtime, variables);
 
@@ -34,9 +34,6 @@ export const InteractionHandler: HandlerFactory<GeneralNode.Interaction.Node | C
       // quit cycleStack without ending session by stopping on itself
       return node.id;
     }
-
-    // request for this turn has been processed, set action to response
-    runtime.setAction(Action.RESPONSE);
 
     for (let i = 0; i < node.interactions.length; i++) {
       const { event, nextId } = node.interactions[i];

--- a/lib/services/runtime/handlers/state/oneShot.ts
+++ b/lib/services/runtime/handlers/state/oneShot.ts
@@ -11,7 +11,7 @@ const utilsObj = {
 
 export const OneShotIntentHandler: HandlerFactory<Node.Start.Node, typeof utilsObj> = (utils) => ({
   canHandle: (node, runtime) => {
-    return isIntentRequest(runtime.getRequest()) && runtime.stack.getSize() === 1 && node.type === Node.NodeType.START;
+    return isIntentRequest(runtime.getRequest()) && runtime.stack.getSize() <= 2 && node.type === Node.NodeType.START;
   },
   handle: (node, runtime, variables) => {
     if (utils.commandHandler.canHandle(runtime)) {

--- a/lib/services/runtime/handlers/state/oneShot.ts
+++ b/lib/services/runtime/handlers/state/oneShot.ts
@@ -1,6 +1,6 @@
 import { Node } from '@voiceflow/base-types';
 
-import { Action, HandlerFactory } from '@/runtime';
+import { HandlerFactory } from '@/runtime';
 
 import { isIntentRequest } from '../../types';
 import CommandHandler from '../command';
@@ -14,9 +14,6 @@ export const OneShotIntentHandler: HandlerFactory<Node.Start.Node, typeof utilsO
     return isIntentRequest(runtime.getRequest()) && runtime.stack.getSize() === 1 && node.type === Node.NodeType.START;
   },
   handle: (node, runtime, variables) => {
-    // request for this turn has been processed, set action to response
-    runtime.setAction(Action.RESPONSE);
-
     if (utils.commandHandler.canHandle(runtime)) {
       return utils.commandHandler.handle(runtime, variables);
     }

--- a/lib/services/runtime/handlers/state/preliminary.ts
+++ b/lib/services/runtime/handlers/state/preliminary.ts
@@ -25,8 +25,6 @@ export const PreliminaryHandler: HandlerFactory<BaseNode, typeof utilsObj> = (ut
     return !!request && runtime.getAction() === Action.REQUEST && !utils.eventHandlers.find((h) => h.canHandle(node, runtime, variables, program));
   },
   handle: (node, runtime, variables) => {
-    runtime.setAction(Action.RESPONSE);
-
     // check if there is a command in the stack that fulfills request
     if (utils.commandHandler.canHandle(runtime)) {
       return utils.commandHandler.handle(runtime, variables);

--- a/lib/services/runtime/handlers/state/stream.ts
+++ b/lib/services/runtime/handlers/state/stream.ts
@@ -3,7 +3,7 @@ import { Node } from '@voiceflow/base-types';
 import { replaceVariables } from '@voiceflow/common';
 import { Constants } from '@voiceflow/general-types';
 
-import { Action, HandlerFactory } from '@/runtime';
+import { HandlerFactory } from '@/runtime';
 
 import { isIntentRequest, StorageData, StorageType, StreamAction, StreamPauseStorage, StreamPlayStorage } from '../../types';
 import CommandHandler from '../command';

--- a/lib/services/runtime/handlers/state/stream.ts
+++ b/lib/services/runtime/handlers/state/stream.ts
@@ -19,8 +19,6 @@ export const StreamStateHandler: HandlerFactory<any, typeof utilsObj> = (utils) 
   handle: (_, runtime, variables) => {
     const streamPlay = runtime.storage.get<StreamPlayStorage>(StorageType.STREAM_PLAY)!;
 
-    // request for this turn has been processed, set action to response
-    runtime.setAction(Action.RESPONSE);
     const request = runtime.getRequest();
     const intentName = isIntentRequest(request) ? request.payload.intent.name : null;
 

--- a/runtime/lib/Runtime/cycleHandler.ts
+++ b/runtime/lib/Runtime/cycleHandler.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-await-in-loop */
 
+import { Action } from '@/runtime';
 import { EventType } from '@/runtime/lib/Lifecycle';
 import ProgramModel from '@/runtime/lib/Program';
 import Runtime from '@/runtime/lib/Runtime';
@@ -40,6 +41,11 @@ const cycleHandler = async (runtime: Runtime, program: ProgramModel, variableSta
         }
       } catch (error) {
         await runtime.callEvent(EventType.handlerDidCatch, { error });
+      }
+
+      // after the first handler, the request is processed
+      if (runtime.getAction() === Action.REQUEST) {
+        runtime.setAction(Action.RUNNING);
       }
 
       // if a node has decided to stop on itself

--- a/runtime/lib/Runtime/index.ts
+++ b/runtime/lib/Runtime/index.ts
@@ -23,8 +23,8 @@ export interface State {
 
 export enum Action {
   IDLE,
-  REQUEST,
-  RESPONSE,
+  REQUEST, // incoming user request that needs to be handled
+  RUNNING, // normal execution
   END,
 }
 
@@ -145,7 +145,9 @@ class Runtime<R extends any = any, DA extends DataAPI = DataAPI> extends Abstrac
         throw new Error('runtime updated twice');
       }
 
-      this.setAction(this.request ? Action.REQUEST : Action.RESPONSE);
+      // request coming in
+      this.setAction(Action.REQUEST);
+
       await cycleStack(this);
 
       await this.callEvent(EventType.updateDidExecute, {});

--- a/tests/lib/services/dialog/utils.unit.ts
+++ b/tests/lib/services/dialog/utils.unit.ts
@@ -81,7 +81,7 @@ describe('dialog manager utilities unit tests', () => {
         stack: { top: sinon.stub().returns(currentFrame) },
         getProgram: sinon.stub().resolves(program),
         variables: { var1: 'val1' },
-        getAction: sinon.stub().returns(RuntimeModule.Action.RESPONSE),
+        getAction: sinon.stub().returns(RuntimeModule.Action.RUNNING),
       };
       const client = { createRuntime: sinon.stub().returns(runtime) };
       const ClientStub = sinon.stub(Client, 'default');

--- a/tests/lib/services/runtime/handlers/_v1.unit.ts
+++ b/tests/lib/services/runtime/handlers/_v1.unit.ts
@@ -32,7 +32,7 @@ describe('_v1 handler unit tests', () => {
             ],
           };
           const runtime = {
-            getAction: sinon.stub().returns(Action.RESPONSE),
+            getAction: sinon.stub().returns(Action.RUNNING),
             trace: { addTrace: sinon.stub() },
             turn: { get: sinon.stub().returns(null) },
           };
@@ -67,7 +67,7 @@ describe('_v1 handler unit tests', () => {
             ],
           };
           const runtime = {
-            getAction: sinon.stub().returns(Action.RESPONSE),
+            getAction: sinon.stub().returns(Action.RUNNING),
             trace: { addTrace: sinon.stub() },
             turn: { get: sinon.stub().returns(['type1', 'the trace block', 'type3']) },
           };
@@ -104,7 +104,7 @@ describe('_v1 handler unit tests', () => {
             ],
           };
           const runtime = {
-            getAction: sinon.stub().returns(Action.RESPONSE),
+            getAction: sinon.stub().returns(Action.RUNNING),
             trace: { addTrace: sinon.stub() },
             turn: { get: sinon.stub().returns(undefined) },
           };
@@ -140,7 +140,7 @@ describe('_v1 handler unit tests', () => {
             ],
           };
           const runtime = {
-            getAction: sinon.stub().returns(Action.RESPONSE),
+            getAction: sinon.stub().returns(Action.RUNNING),
             trace: { addTrace: sinon.stub() },
             turn: { get: sinon.stub().returns(null) },
           };
@@ -176,7 +176,7 @@ describe('_v1 handler unit tests', () => {
             ],
           };
           const runtime = {
-            getAction: sinon.stub().returns(Action.RESPONSE),
+            getAction: sinon.stub().returns(Action.RUNNING),
             trace: { addTrace: sinon.stub() },
             turn: { get: sinon.stub().returns(false) },
           };
@@ -213,13 +213,11 @@ describe('_v1 handler unit tests', () => {
         const commandHandler = { canHandle: sinon.stub().returns(false) };
         const runtime = {
           getAction: sinon.stub().returns(Action.REQUEST),
-          setAction: sinon.stub(),
           trace: { addTrace: sinon.stub() },
         };
         const handler = _V1Handler({ commandHandler } as any);
 
         expect(handler.handle(node as any, runtime as any, null as any, null as any)).to.eql(null);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(commandHandler.canHandle.args).to.eql([[runtime]]);
       });
 
@@ -235,14 +233,12 @@ describe('_v1 handler unit tests', () => {
         const findEventMatcher = sinon.stub().returns(null);
         const runtime = {
           getAction: sinon.stub().returns(Action.REQUEST),
-          setAction: sinon.stub(),
           trace: { addTrace: sinon.stub() },
         };
         const variables = { var1: 'val1' };
         const handler = _V1Handler({ commandHandler, findEventMatcher } as any);
 
         expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql('command-id');
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(commandHandler.canHandle.args).to.eql([[runtime]]);
         expect(commandHandler.handle.args).to.eql([[runtime, variables]]);
         expect(findEventMatcher.args).to.eql([[{ event: node.paths[0].event, runtime, variables }]]);
@@ -268,14 +264,12 @@ describe('_v1 handler unit tests', () => {
           .returns(matcher);
         const runtime = {
           getAction: sinon.stub().returns(Action.REQUEST),
-          setAction: sinon.stub(),
           trace: { addTrace: sinon.stub() },
         };
         const variables = { var1: 'val1' };
         const handler = _V1Handler({ findEventMatcher } as any);
 
         expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql('next-id2');
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(findEventMatcher.args).to.eql([
           [{ event: node.paths[0].event, runtime, variables }],
           [{ event: node.paths[1].event, runtime, variables }],
@@ -300,14 +294,12 @@ describe('_v1 handler unit tests', () => {
           .returns(matcher);
         const runtime = {
           getAction: sinon.stub().returns(Action.REQUEST),
-          setAction: sinon.stub(),
           trace: { addTrace: sinon.stub() },
         };
         const variables = { var1: 'val1' };
         const handler = _V1Handler({ findEventMatcher } as any);
 
         expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(findEventMatcher.args).to.eql([
           [{ event: node.paths[0].event, runtime, variables }],
           [{ event: node.paths[1].event, runtime, variables }],

--- a/tests/lib/services/runtime/handlers/capture.unit.ts
+++ b/tests/lib/services/runtime/handlers/capture.unit.ts
@@ -28,7 +28,7 @@ describe('Capture handler', () => {
       const handler = CaptureHandler(utils as any);
 
       const node = { id: 'node-id' };
-      const runtime = { getAction: sinon.stub().returns(Action.RESPONSE) };
+      const runtime = { getAction: sinon.stub().returns(Action.RUNNING) };
       const variables = { var1: 'val1' };
       expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.id);
     });
@@ -45,11 +45,10 @@ describe('Capture handler', () => {
         const handler = CaptureHandler(utils as any);
 
         const node = { id: 'node-id' };
-        const runtime = { getAction: sinon.stub().returns(Action.REQUEST), setAction: sinon.stub() };
+        const runtime = { getAction: sinon.stub().returns(Action.REQUEST) };
         const variables = { var1: 'val1' };
         expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(output);
 
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
         expect(utils.commandHandler.handle.args).to.eql([[runtime, variables]]);
       });
@@ -68,11 +67,10 @@ describe('Capture handler', () => {
         const handler = CaptureHandler(utils as any);
 
         const node = { id: 'node-id' };
-        const runtime = { getAction: sinon.stub().returns(Action.REQUEST), setAction: sinon.stub() };
+        const runtime = { getAction: sinon.stub().returns(Action.REQUEST) };
         const variables = { var1: 'val1' };
         expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(output);
 
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
         expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
         expect(utils.repeatHandler.handle.args).to.eql([[runtime]]);
@@ -95,14 +93,12 @@ describe('Capture handler', () => {
             const request = { foo: 'bar' };
             const runtime = {
               getAction: sinon.stub().returns(Action.REQUEST),
-              setAction: sinon.stub(),
               getRequest: sinon.stub().returns(request),
               trace: { addTrace: sinon.stub() },
             };
             const variables = { var1: 'val1' };
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.nextId);
 
-            expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
             expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
             expect(runtime.getRequest.callCount).to.eql(1);
@@ -124,14 +120,12 @@ describe('Capture handler', () => {
             const request = { foo: 'bar' };
             const runtime = {
               getAction: sinon.stub().returns(Action.REQUEST),
-              setAction: sinon.stub(),
               getRequest: sinon.stub().returns(request),
               trace: { addTrace: sinon.stub() },
             };
             const variables = { var1: 'val1' };
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
 
-            expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
             expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
             expect(runtime.getRequest.callCount).to.eql(1);
@@ -155,14 +149,12 @@ describe('Capture handler', () => {
             const request = { type: Request.RequestType.INTENT, payload: { intent: { name: 'intent_name' }, entities: [] } };
             const runtime = {
               getAction: sinon.stub().returns(Action.REQUEST),
-              setAction: sinon.stub(),
               getRequest: sinon.stub().returns(request),
               trace: { addTrace: sinon.stub() },
             };
             const variables = { var1: 'val1' };
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
 
-            expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
             expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
             expect(runtime.getRequest.callCount).to.eql(1);
@@ -186,14 +178,12 @@ describe('Capture handler', () => {
               const request = { type: Request.RequestType.INTENT, payload: { intent: { name: 'intent_name' }, entities: [], query: 'q' } };
               const runtime = {
                 getAction: sinon.stub().returns(Action.REQUEST),
-                setAction: sinon.stub(),
                 getRequest: sinon.stub().returns(request),
                 trace: { addTrace: sinon.stub() },
               };
               const variables = { var1: 'val1', set: sinon.stub() };
               expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
 
-              expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
               expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
               expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
               expect(runtime.getRequest.callCount).to.eql(1);
@@ -218,14 +208,12 @@ describe('Capture handler', () => {
               const request = { type: Request.RequestType.INTENT, payload: { intent: { name: 'intent_name' }, entities: [], query: 'q' } };
               const runtime = {
                 getAction: sinon.stub().returns(Action.REQUEST),
-                setAction: sinon.stub(),
                 getRequest: sinon.stub().returns(request),
                 trace: { addTrace: sinon.stub() },
               };
               const variables = { var1: 'val1', set: sinon.stub() };
               expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
 
-              expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
               expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
               expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
               expect(runtime.getRequest.callCount).to.eql(1);
@@ -253,14 +241,12 @@ describe('Capture handler', () => {
               const request = { type: Request.RequestType.INTENT, payload: { intent: { name: 'intent_name' }, entities: [], query: 'q' } };
               const runtime = {
                 getAction: sinon.stub().returns(Action.REQUEST),
-                setAction: sinon.stub(),
                 getRequest: sinon.stub().returns(request),
                 trace: { addTrace: sinon.stub() },
               };
               const variables = { var1: 'val1', set: sinon.stub() };
               expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
 
-              expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
               expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
               expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
               expect(runtime.getRequest.callCount).to.eql(1);

--- a/tests/lib/services/runtime/handlers/command.unit.ts
+++ b/tests/lib/services/runtime/handlers/command.unit.ts
@@ -5,7 +5,6 @@ import sinon from 'sinon';
 
 import { CommandHandler, getCommand as GetCommand } from '@/lib/services/runtime/handlers/command';
 import { FrameType } from '@/lib/services/runtime/types';
-import { Action } from '@/runtime';
 
 const JumpPathTrace = { type: 'path', payload: { path: 'jump' } };
 const PushPathTrace = { type: 'path', payload: { path: 'push' } };
@@ -63,12 +62,11 @@ describe('Command handler', () => {
         };
         const handler = CommandHandler(utils as any);
 
-        const runtime = { setAction: sinon.stub() };
+        const runtime = {};
         const variables = { var1: 'val1' };
 
         expect(handler.handle(runtime as any, variables as any)).to.eql(null);
         expect(utils.getCommand.args).to.eql([[runtime]]);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(utils.findEventMatcher.args).to.eql([[{ event: commandObj.event, runtime, variables }]]);
         expect(sideEffectStub.callCount).to.eql(1);
       });
@@ -81,12 +79,11 @@ describe('Command handler', () => {
         };
         const handler = CommandHandler(utils as any);
 
-        const runtime = { setAction: sinon.stub() };
+        const runtime = {};
         const variables = { var1: 'val1' };
 
         expect(handler.handle(runtime as any, variables as any)).to.eql(null);
         expect(utils.getCommand.args).to.eql([[runtime]]);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(utils.findEventMatcher.args).to.eql([[{ event: commandObj.event, runtime, variables }]]);
       });
     });
@@ -104,7 +101,6 @@ describe('Command handler', () => {
 
         const setNodeID = sinon.stub();
         const runtime = {
-          setAction: sinon.stub(),
           stack: { getSize: sinon.stub().returns(3), popTo: sinon.stub(), top: sinon.stub().returns({ setNodeID }) },
           trace: { debug: sinon.stub(), addTrace: sinon.stub() },
         };
@@ -112,7 +108,6 @@ describe('Command handler', () => {
 
         expect(handler.handle(runtime as any, variables as any)).to.eql(null);
         expect(utils.getCommand.args).to.eql([[runtime]]);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(utils.findEventMatcher.args).to.eql([[{ event: commandObj.event, runtime, variables }]]);
         expect(sideEffectStub.callCount).to.eql(1);
         expect(runtime.stack.getSize.callCount).to.eql(0);
@@ -135,7 +130,6 @@ describe('Command handler', () => {
 
           const setNodeID = sinon.stub();
           const runtime = {
-            setAction: sinon.stub(),
             stack: { popTo: sinon.stub(), top: sinon.stub().returns({ setNodeID }) },
             trace: { debug: sinon.stub(), addTrace: sinon.stub() },
           };
@@ -143,7 +137,6 @@ describe('Command handler', () => {
 
           expect(handler.handle(runtime as any, variables as any)).to.eql(null);
           expect(utils.getCommand.args).to.eql([[runtime]]);
-          expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
           expect(utils.findEventMatcher.args).to.eql([[{ event: commandObj.event, runtime, variables }]]);
           expect(sideEffectStub.callCount).to.eql(1);
           expect(runtime.stack.popTo.args).to.eql([[index + 1]]);
@@ -164,7 +157,6 @@ describe('Command handler', () => {
 
           const setNodeID = sinon.stub();
           const runtime = {
-            setAction: sinon.stub(),
             stack: { popTo: sinon.stub(), top: sinon.stub().returns({ setNodeID }) },
             trace: { debug: sinon.stub(), addTrace: sinon.stub() },
           };
@@ -172,7 +164,6 @@ describe('Command handler', () => {
 
           expect(handler.handle(runtime as any, variables as any)).to.eql(null);
           expect(utils.getCommand.args).to.eql([[runtime]]);
-          expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
           expect(utils.findEventMatcher.args).to.eql([[{ event: commandObj.event, runtime, variables }]]);
           expect(sideEffectStub.callCount).to.eql(1);
           expect(runtime.stack.popTo.args).to.eql([[index + 1]]);
@@ -193,12 +184,11 @@ describe('Command handler', () => {
         };
         const handler = CommandHandler(utils as any);
 
-        const runtime = { setAction: sinon.stub() };
+        const runtime = {};
         const variables = { var1: 'val1' };
 
         expect(handler.handle(runtime as any, variables as any)).to.eql(null);
         expect(utils.getCommand.args).to.eql([[runtime]]);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(utils.findEventMatcher.args).to.eql([[{ event: commandObj.event, runtime, variables }]]);
         expect(sideEffectStub.callCount).to.eql(1);
       });
@@ -215,7 +205,6 @@ describe('Command handler', () => {
 
         const storageSetStub = sinon.stub();
         const runtime = {
-          setAction: sinon.stub(),
           stack: { top: sinon.stub().returns({ storage: { set: storageSetStub } }), push: sinon.stub() },
           trace: { debug: sinon.stub(), addTrace: sinon.stub() },
         };
@@ -223,7 +212,6 @@ describe('Command handler', () => {
 
         expect(handler.handle(runtime as any, variables as any)).to.eql(null);
         expect(utils.getCommand.args).to.eql([[runtime]]);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(utils.findEventMatcher.args).to.eql([[{ event: commandObj.event, runtime, variables }]]);
         expect(sideEffectStub.callCount).to.eql(1);
         expect(runtime.trace.debug.args).to.eql([[`matched command **${commandObj.type}** - adding command flow`, Node.NodeType.COMMAND]]);

--- a/tests/lib/services/runtime/handlers/interaction.unit.ts
+++ b/tests/lib/services/runtime/handlers/interaction.unit.ts
@@ -29,7 +29,7 @@ describe('Interaction handler', () => {
         };
 
         const node = { id: 'node-id' };
-        const runtime = { getAction: sinon.stub().returns(Action.RESPONSE), storage: { delete: sinon.stub() } };
+        const runtime = { getAction: sinon.stub().returns(Action.RUNNING), storage: { delete: sinon.stub() } };
         const variables = { var1: 'val1' };
         const handler = InteractionHandler(utils as any);
 
@@ -50,7 +50,7 @@ describe('Interaction handler', () => {
           id: 'node-id',
           interactions: [{}, { event: { type: 'random' } }, { event: { type: Node.Utils.EventType.INTENT, intent: 'intent-name' } }],
         };
-        const runtime = { getAction: sinon.stub().returns(Action.RESPONSE), storage: { delete: sinon.stub() }, trace: { addTrace: sinon.stub() } };
+        const runtime = { getAction: sinon.stub().returns(Action.RUNNING), storage: { delete: sinon.stub() }, trace: { addTrace: sinon.stub() } };
         const variables = { var1: 'val1' };
         const handler = InteractionHandler(utils as any);
 
@@ -73,13 +73,12 @@ describe('Interaction handler', () => {
           };
 
           const node = { id: 'node-id', elseId: 'else-id', interactions: [] };
-          const runtime = { getAction: sinon.stub().returns(Action.REQUEST), setAction: sinon.stub(), trace: { addTrace: sinon.stub() } };
+          const runtime = { getAction: sinon.stub().returns(Action.REQUEST), trace: { addTrace: sinon.stub() } };
           const variables = { var1: 'val1' };
           const handler = InteractionHandler(utils as any);
 
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.elseId);
           expect(runtime.getAction.callCount).to.eql(1);
-          expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
           expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.noMatchHandler.canHandle.args).to.eql([[node, runtime, variables, null]]);
@@ -95,13 +94,12 @@ describe('Interaction handler', () => {
             };
 
             const node = { id: 'node-id', interactions: [] };
-            const runtime = { getAction: sinon.stub().returns(Action.REQUEST), setAction: sinon.stub(), trace: { addTrace: sinon.stub() } };
+            const runtime = { getAction: sinon.stub().returns(Action.REQUEST), trace: { addTrace: sinon.stub() } };
             const variables = { var1: 'val1' };
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
             expect(runtime.getAction.callCount).to.eql(1);
-            expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
             expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.noMatchHandler.canHandle.args).to.eql([[node, runtime, variables, null]]);
@@ -117,13 +115,12 @@ describe('Interaction handler', () => {
             };
 
             const node = { id: 'node-id', interactions: [{ event: { foo: 'bar' } }] };
-            const runtime = { getAction: sinon.stub().returns(Action.REQUEST), setAction: sinon.stub(), trace: { addTrace: sinon.stub() } };
+            const runtime = { getAction: sinon.stub().returns(Action.REQUEST), trace: { addTrace: sinon.stub() } };
             const variables = { var1: 'val1' };
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
             expect(runtime.getAction.callCount).to.eql(1);
-            expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
             expect(utils.findEventMatcher.args).to.eql([[{ event: node.interactions[0].event, runtime, variables }]]);
             expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
@@ -141,13 +138,12 @@ describe('Interaction handler', () => {
           };
 
           const node = { id: 'node-id', interactions: [] };
-          const runtime = { getAction: sinon.stub().returns(Action.REQUEST), setAction: sinon.stub() };
+          const runtime = { getAction: sinon.stub().returns(Action.REQUEST) };
           const variables = { var1: 'val1' };
           const handler = InteractionHandler(utils as any);
 
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(output);
           expect(runtime.getAction.callCount).to.eql(1);
-          expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
           expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.commandHandler.handle.args).to.eql([[runtime, variables]]);
         });
@@ -160,13 +156,12 @@ describe('Interaction handler', () => {
           };
 
           const node = { id: 'node-id', interactions: [] };
-          const runtime = { getAction: sinon.stub().returns(Action.REQUEST), setAction: sinon.stub() };
+          const runtime = { getAction: sinon.stub().returns(Action.REQUEST) };
           const variables = { var1: 'val1' };
           const handler = InteractionHandler(utils as any);
 
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(output);
           expect(runtime.getAction.callCount).to.eql(1);
-          expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
           expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.repeatHandler.handle.args).to.eql([[runtime]]);
@@ -181,13 +176,12 @@ describe('Interaction handler', () => {
           };
 
           const node = { id: 'node-id', interactions: [] };
-          const runtime = { getAction: sinon.stub().returns(Action.REQUEST), setAction: sinon.stub() };
+          const runtime = { getAction: sinon.stub().returns(Action.REQUEST) };
           const variables = { var1: 'val1' };
           const handler = InteractionHandler(utils as any);
 
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(output);
           expect(runtime.getAction.callCount).to.eql(1);
-          expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
           expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.noMatchHandler.canHandle.args).to.eql([[node, runtime, variables, null]]);
@@ -202,13 +196,12 @@ describe('Interaction handler', () => {
             };
 
             const node = { id: 'node-id', interactions: [{ event: { foo: 'bar' }, nextId: 'next-id' }] };
-            const runtime = { getAction: sinon.stub().returns(Action.REQUEST), setAction: sinon.stub(), trace: { addTrace: sinon.stub() } };
+            const runtime = { getAction: sinon.stub().returns(Action.REQUEST), trace: { addTrace: sinon.stub() } };
             const variables = { var1: 'val1' };
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.interactions[0].nextId);
             expect(runtime.getAction.callCount).to.eql(1);
-            expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
             expect(utils.findEventMatcher.args).to.eql([[{ event: node.interactions[0].event, runtime, variables }]]);
             expect(sideEffect.callCount).to.eql(1);
             expect(runtime.trace.addTrace.args).to.eql([[{ type: 'path', payload: { path: 'choice:1' } }]]);
@@ -221,13 +214,12 @@ describe('Interaction handler', () => {
             };
 
             const node = { id: 'node-id', interactions: [{ event: { foo: 'bar', goTo: { request: 'request' } } }] };
-            const runtime = { getAction: sinon.stub().returns(Action.REQUEST), setAction: sinon.stub(), trace: { addTrace: sinon.stub() } };
+            const runtime = { getAction: sinon.stub().returns(Action.REQUEST), trace: { addTrace: sinon.stub() } };
             const variables = { var1: 'val1' };
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.id);
             expect(runtime.getAction.callCount).to.eql(1);
-            expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
             expect(utils.findEventMatcher.args).to.eql([[{ event: node.interactions[0].event, runtime, variables }]]);
             expect(sideEffect.callCount).to.eql(1);
             expect(runtime.trace.addTrace.args).to.eql([[{ type: 'goto', payload: { request: node.interactions[0].event.goTo.request } }]]);
@@ -251,13 +243,12 @@ describe('Interaction handler', () => {
                 { event: { foo: 'four' }, nextId: 'four' },
               ],
             };
-            const runtime = { getAction: sinon.stub().returns(Action.REQUEST), setAction: sinon.stub(), trace: { addTrace: sinon.stub() } };
+            const runtime = { getAction: sinon.stub().returns(Action.REQUEST), trace: { addTrace: sinon.stub() } };
             const variables = { var1: 'val1' };
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.interactions[3].nextId);
             expect(runtime.getAction.callCount).to.eql(1);
-            expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
             expect(utils.findEventMatcher.args[3]).to.eql([{ event: node.interactions[3].event, runtime, variables }]);
             expect(sideEffect.callCount).to.eql(1);
             expect(runtime.trace.addTrace.args).to.eql([[{ type: 'path', payload: { path: 'choice:4' } }]]);
@@ -270,13 +261,12 @@ describe('Interaction handler', () => {
             };
 
             const node = { id: 'node-id', interactions: [{ event: { foo: 'bar' } }] };
-            const runtime = { getAction: sinon.stub().returns(Action.REQUEST), setAction: sinon.stub(), trace: { addTrace: sinon.stub() } };
+            const runtime = { getAction: sinon.stub().returns(Action.REQUEST), trace: { addTrace: sinon.stub() } };
             const variables = { var1: 'val1' };
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
             expect(runtime.getAction.callCount).to.eql(1);
-            expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
             expect(utils.findEventMatcher.args).to.eql([[{ event: node.interactions[0].event, runtime, variables }]]);
             expect(sideEffect.callCount).to.eql(1);
             expect(runtime.trace.addTrace.args).to.eql([[{ type: 'path', payload: { path: 'choice:1' } }]]);

--- a/tests/lib/services/runtime/handlers/state/preliminary.unit.ts
+++ b/tests/lib/services/runtime/handlers/state/preliminary.unit.ts
@@ -12,7 +12,7 @@ describe('preliminary handler unit tests', () => {
     });
 
     it('action not request', () => {
-      const runtime = { getRequest: sinon.stub().returns({ payload: { name: 'event1' } }), getAction: sinon.stub().returns(Action.RESPONSE) };
+      const runtime = { getRequest: sinon.stub().returns({ payload: { name: 'event1' } }), getAction: sinon.stub().returns(Action.RUNNING) };
       expect(PreliminaryHandlerFactory({ eventHandlers: [] } as any).canHandle(null as any, runtime as any, null as any, null as any)).to.eql(false);
     });
 
@@ -39,7 +39,7 @@ describe('preliminary handler unit tests', () => {
       const runtime = { setAction: sinon.stub() };
       const variables = { var1: 'val1', var2: 'val2' };
       expect(handler.handle(null as any, runtime as any, variables as any, null as any)).to.eql(nodeID);
-      expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
+
       expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
       expect(utils.commandHandler.handle.args).to.eql([[runtime, variables]]);
     });
@@ -54,7 +54,7 @@ describe('preliminary handler unit tests', () => {
       const runtime = { setAction: sinon.stub() };
       const variables = { var1: 'val1', var2: 'val2' };
       expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.id);
-      expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
+
       expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
     });
   });

--- a/tests/lib/services/runtime/handlers/state/stream.unit.ts
+++ b/tests/lib/services/runtime/handlers/state/stream.unit.ts
@@ -5,7 +5,6 @@ import sinon from 'sinon';
 
 import { StreamStateHandler } from '@/lib/services/runtime/handlers/state/stream';
 import { StorageType, StreamAction } from '@/lib/services/runtime/types';
-import { Action } from '@/runtime';
 
 describe('stream state handler unit tests', () => {
   describe('canHandle', () => {
@@ -40,14 +39,12 @@ describe('stream state handler unit tests', () => {
         const runtime = {
           getRequest: sinon.stub().returns(null),
           storage: { get: sinon.stub().returns({}), produce: sinon.stub() },
-          setAction: sinon.stub(),
         };
         const variables = { var1: 'val1' };
         const handler = StreamStateHandler(utils as any);
 
         expect(handler.handle(null as any, runtime as any, variables as any, null as any)).to.eql(output);
         expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(runtime.getRequest.callCount).to.eql(1);
         expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
 
@@ -67,14 +64,12 @@ describe('stream state handler unit tests', () => {
         const runtime = {
           getRequest: sinon.stub().returns(null),
           storage: { get: sinon.stub().returns({}), produce: sinon.stub() },
-          setAction: sinon.stub(),
           end: sinon.stub(),
         };
         const handler = StreamStateHandler(utils as any);
 
         expect(handler.handle(null as any, runtime as any, null as any, null as any)).to.eql(null);
         expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(runtime.getRequest.callCount).to.eql(1);
 
         expect(runtime.storage.produce.callCount).to.eql(1);
@@ -96,14 +91,12 @@ describe('stream state handler unit tests', () => {
           const runtime = {
             getRequest: sinon.stub().returns(request),
             storage: { get: sinon.stub().returns(streamPlay), produce: sinon.stub(), set: sinon.stub() },
-            setAction: sinon.stub(),
           };
           const variables = { var1: 'val1' };
           const handler = StreamStateHandler(utils as any);
 
           expect(handler.handle(null as any, runtime as any, variables as any, null as any)).to.eql(streamPlay.pauseID);
           expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
           expect(runtime.getRequest.callCount).to.eql(1);
           expect(runtime.storage.set.args).to.eql([[StorageType.STREAM_PAUSE, { id: streamPlay.nodeID, offset: streamPlay.offset }]]);
 
@@ -120,7 +113,6 @@ describe('stream state handler unit tests', () => {
           const runtime = {
             getRequest: sinon.stub().returns(request),
             storage: { get: sinon.stub().returns({}), produce: sinon.stub() },
-            setAction: sinon.stub(),
             end: sinon.stub(),
           };
           const variables = { var1: 'val1' };
@@ -128,7 +120,6 @@ describe('stream state handler unit tests', () => {
 
           expect(handler.handle(null as any, runtime as any, variables as any, null as any)).to.eql(null);
           expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
           expect(runtime.getRequest.callCount).to.eql(1);
 
           expect(runtime.storage.produce.callCount).to.eql(1);
@@ -147,7 +138,6 @@ describe('stream state handler unit tests', () => {
         const runtime = {
           getRequest: sinon.stub().returns(request),
           storage: { get: sinon.stub().returns({}), produce: sinon.stub() },
-          setAction: sinon.stub(),
           end: sinon.stub(),
         };
         const variables = { var1: 'val1' };
@@ -155,7 +145,6 @@ describe('stream state handler unit tests', () => {
 
         expect(handler.handle(null as any, runtime as any, variables as any, null as any)).to.eql(null);
         expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(runtime.getRequest.callCount).to.eql(1);
 
         expect(runtime.storage.produce.callCount).to.eql(1);
@@ -173,7 +162,6 @@ describe('stream state handler unit tests', () => {
         const runtime = {
           getRequest: sinon.stub().returns(request),
           storage: { get: sinon.stub().returns({}), produce: sinon.stub() },
-          setAction: sinon.stub(),
           end: sinon.stub(),
         };
         const variables = { var1: 'val1' };
@@ -181,7 +169,6 @@ describe('stream state handler unit tests', () => {
 
         expect(handler.handle(null as any, runtime as any, variables as any, null as any)).to.eql(null);
         expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(runtime.getRequest.callCount).to.eql(1);
 
         expect(runtime.storage.produce.callCount).to.eql(1);
@@ -199,7 +186,6 @@ describe('stream state handler unit tests', () => {
         const runtime = {
           getRequest: sinon.stub().returns(request),
           storage: { get: sinon.stub().returns({}), produce: sinon.stub() },
-          setAction: sinon.stub(),
           end: sinon.stub(),
         };
         const variables = { var1: 'val1' };
@@ -207,7 +193,6 @@ describe('stream state handler unit tests', () => {
 
         expect(handler.handle(null as any, runtime as any, variables as any, null as any)).to.eql(null);
         expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(runtime.getRequest.callCount).to.eql(1);
 
         expect(runtime.storage.produce.callCount).to.eql(1);
@@ -227,14 +212,12 @@ describe('stream state handler unit tests', () => {
           const runtime = {
             getRequest: sinon.stub().returns(request),
             storage: { get: sinon.stub().returns({ nextID }), produce: sinon.stub() },
-            setAction: sinon.stub(),
           };
           const variables = { var1: 'val1' };
           const handler = StreamStateHandler(utils as any);
 
           expect(handler.handle(null as any, runtime as any, variables as any, null as any)).to.eql(nextID);
           expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
           expect(runtime.getRequest.callCount).to.eql(1);
 
           expect(runtime.storage.produce.callCount).to.eql(1);
@@ -250,14 +233,12 @@ describe('stream state handler unit tests', () => {
           const runtime = {
             getRequest: sinon.stub().returns(request),
             storage: { get: sinon.stub().returns({ action: StreamAction.NEXT }), produce: sinon.stub() },
-            setAction: sinon.stub(),
           };
           const variables = { var1: 'val1' };
           const handler = StreamStateHandler(utils as any);
 
           expect(handler.handle(null as any, runtime as any, variables as any, null as any)).to.eql(null);
           expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
           expect(runtime.getRequest.callCount).to.eql(1);
 
           expect(runtime.storage.produce.callCount).to.eql(1);
@@ -275,14 +256,12 @@ describe('stream state handler unit tests', () => {
           const runtime = {
             getRequest: sinon.stub().returns(request),
             storage: { get: sinon.stub().returns({}), produce: sinon.stub() },
-            setAction: sinon.stub(),
           };
           const variables = { var1: 'val1' };
           const handler = StreamStateHandler(utils as any);
 
           expect(handler.handle(null as any, runtime as any, variables as any, null as any)).to.eql(null);
           expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
           expect(runtime.getRequest.callCount).to.eql(1);
 
           expect(runtime.storage.produce.callCount).to.eql(1);
@@ -299,14 +278,12 @@ describe('stream state handler unit tests', () => {
           const runtime = {
             getRequest: sinon.stub().returns(request),
             storage: { get: sinon.stub().returns({ previousID }), produce: sinon.stub() },
-            setAction: sinon.stub(),
           };
           const variables = { var1: 'val1' };
           const handler = StreamStateHandler(utils as any);
 
           expect(handler.handle(null as any, runtime as any, variables as any, null as any)).to.eql(previousID);
           expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
           expect(runtime.getRequest.callCount).to.eql(1);
 
           expect(runtime.storage.produce.callCount).to.eql(1);
@@ -323,7 +300,6 @@ describe('stream state handler unit tests', () => {
         const runtime = {
           getRequest: sinon.stub().returns(request),
           storage: { get: sinon.stub().returns({}), produce: sinon.stub() },
-          setAction: sinon.stub(),
           end: sinon.stub(),
         };
         const variables = { var1: 'val1' };
@@ -331,7 +307,6 @@ describe('stream state handler unit tests', () => {
 
         expect(handler.handle(null as any, runtime as any, variables as any, null as any)).to.eql(null);
         expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-        expect(runtime.setAction.args).to.eql([[Action.RESPONSE]]);
         expect(runtime.getRequest.callCount).to.eql(1);
 
         expect(runtime.storage.produce.callCount).to.eql(1);

--- a/tests/runtime/lib/Runtime/index.unit.ts
+++ b/tests/runtime/lib/Runtime/index.unit.ts
@@ -27,14 +27,14 @@ describe('Runtime unit', () => {
 
   it('setAction', () => {
     const runtime = new Runtime(null as any, { stack: [] } as any, undefined as any, {} as any, null as any);
-    const action = Action.RESPONSE;
+    const action = Action.RUNNING;
     runtime.setAction(action as any);
     expect(_.get(runtime, 'action')).to.eql(action);
   });
 
   it('getAction', () => {
     const runtime = new Runtime(null as any, { stack: [] } as any, undefined as any, {} as any, null as any);
-    const action = Action.RESPONSE;
+    const action = Action.RUNNING;
     runtime.setAction(action as any);
     expect(runtime.getAction()).to.eql(action);
   });
@@ -107,7 +107,7 @@ describe('Runtime unit', () => {
       expect(callEventStub.args[1][1].error.message).to.eql('runtime updated twice');
     });
 
-    it('response action', async () => {
+    it('empty request', async () => {
       const cycleStackStub = sinon.stub(cycleStack, 'default');
       const runtime = new Runtime(undefined as any, { stack: [] } as any, undefined as any, {} as any, null as any);
       const callEventStub = sinon.stub();
@@ -119,7 +119,7 @@ describe('Runtime unit', () => {
         [EventType.updateWillExecute, {}],
         [EventType.updateDidExecute, {}],
       ]);
-      expect(setActionStub.args).to.eql([[Action.RESPONSE]]);
+      expect(setActionStub.args).to.eql([[Action.REQUEST]]);
       expect(cycleStackStub.args).to.eql([[runtime]]);
     });
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

Previously, there were two states: `Action.RESPONSE` and `Action.REQUEST`

When we hit a choice/interaction/prompt/capture node, if it was `Action.RESPONSE` we would stop the execution and wait for the user to give a request. If we were on the same node but it was `Action.REQUEST` we would take the user request and actually compare it against the ports/commands, update the action to `Action.RESPONSE` and continue the execution.

Some problems with that model:
1. handlers had to declare `setAction(Action.RESPONSE)` explicitly
2. https://github.com/voiceflow/general-runtime/blob/a8da9c94b2fcb72687d6ad8fe318c56c43c762e8/runtime/lib/Runtime/index.ts#L148 we've conflated `null` with a launch request. Sending `null` means it is always already handled.

The improvements I'm making:
1. it is no longer the responsibility of handlers to update the action, instead, the cycleHandler does it automatically after the first node is processed.
2. all runtime calls now start in an `Action.REQUEST` state just in case the first handler has use for it, but never after.
3. `Action.RESPONSE` is very ambiguous, `Action.RUNNING` means that it is in standard execution mode.

Explanation of Action States:
`IDLE` - runtime instance created, but hasn't been run yet
`REQUEST` - user request incoming and needs to be handled
`RUNNING` - standard execution
`END` - finished

Each instance of runtime is only allowed to call `update` once. It will only work if its state is in `IDLE`

### Checklist

- [x] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written
