### PR TITLE
fix: improve formatting of `trace.payload.message` (VF-2478)

### DIFF
--- a/lib/services/runtime/utils.ts
+++ b/lib/services/runtime/utils.ts
@@ -4,7 +4,7 @@ import cuid from 'cuid';
 import _cloneDeepWith from 'lodash/cloneDeepWith';
 import _isString from 'lodash/isString';
 import _uniqBy from 'lodash/uniqBy';
-import { Text as SlateText } from 'slate';
+import * as Slate from 'slate';
 
 import { Runtime, Store } from '@/runtime';
 
@@ -127,8 +127,11 @@ export const addButtonsIfExists = <N extends Request.NodeButton>(node: N, runtim
 
 export const getReadableConfidence = (confidence?: number): string => ((confidence ?? 1) * 100).toFixed(2);
 
-export const slateToPlaintext = (content: Text.SlateTextValue = []): string =>
-  content.reduce<string>((acc, node) => acc + (SlateText.isText(node) ? node.text : slateToPlaintext(node.children)), '');
+export const slateToPlaintext = (content: Readonly<Text.SlateTextValue> = []): string =>
+  content
+    .map((n) => Slate.Node.string(n))
+    .join('\n')
+    .trim();
 
 export const removeEmptyPrompts = (prompts: Array<Text.SlateTextValue | string>): Array<Text.SlateTextValue | string> =>
   prompts.filter((prompt) => prompt != null && (_isString(prompt) ? prompt !== EMPTY_AUDIO_STRING : !!slateToPlaintext(prompt)));

--- a/tests/lib/services/runtime/utils.unit.ts
+++ b/tests/lib/services/runtime/utils.unit.ts
@@ -103,13 +103,13 @@ describe('runtime utils service unit tests', () => {
   describe('slateToPlaintext', () => {
     it('works', () => {
       const content = [
-        { text: 'one', underline: true, property: 'property' },
+        { text: 'one ', underline: true, property: 'property' },
         { text: 'two' },
         { text: ' ' },
-        { children: [{ children: [{ text: 'three' }] }, { text: ' four ' }, { text: 'five' }] },
+        { children: [{ children: [{ text: ' three' }] }, { text: ' four ' }, { text: 'five ' }] },
       ];
 
-      expect(slateToPlaintext(content as any)).to.eql('onetwo three four five');
+      expect(slateToPlaintext(content as any)).to.eql(['one ', 'two', ' ', ' three four five'].join('\n'));
     });
   });
 


### PR DESCRIPTION
**Fixes or implements VF-2478**

### Brief description. What is this change?

replace our (not good) Slate -> plain formatter with the Slate recommended method for serializing to plain text

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written