### PR TITLE
fix: make `sanitize` function safer (VF-2479)

### DIFF
--- a/lib/services/dialog/synonym.ts
+++ b/lib/services/dialog/synonym.ts
@@ -19,8 +19,8 @@ export const comparison = (a: string, b: string) => {
 };
 
 // convert to lowercase and strip all accents: Crème Brulée => Creme Brulee
-export const sanitize = (input: string): string =>
-  input
+export const sanitize = (input: unknown): string =>
+  String(input)
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
     .toLowerCase();


### PR DESCRIPTION
**Fixes or implements VF-2479**

### Brief description. What is this change?

somewhere we're allowing invalid data to pass our validation. our code is written to work with strings but it's being given a number. in the interest of not spending 9999 hours tracking down specifically why the validator is not doing its job right i'm just guessing that making this one function more resilient will fix the issue in #235.

Fixes #235

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
