### PR TITLE
feat: dialog manager api key support (VF-2429)

### DIFF
--- a/backend/api/routers/interact.ts
+++ b/backend/api/routers/interact.ts
@@ -10,6 +10,10 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
   router.use(middlewares.rateLimit.verify);
 
+  router.get('/state', middlewares.rateLimit.consume, middlewares.project.attachID, controllers.interact.state);
+
+  router.post('/', middlewares.rateLimit.consume, middlewares.project.attachID, controllers.interact.handler);
+
   router.get('/:versionID/state', middlewares.rateLimit.consume, controllers.interact.state);
 
   router.post('/:versionID', middlewares.rateLimit.consume, controllers.interact.handler);

--- a/backend/api/routers/state.ts
+++ b/backend/api/routers/state.ts
@@ -10,6 +10,18 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
   router.use(middlewares.rateLimit.verify);
 
+  router.post('/user/:userID/interact', middlewares.rateLimit.consume, middlewares.project.attachID, controllers.stateManagement.interact);
+
+  router.get('/user/:userID', middlewares.rateLimit.consume, middlewares.project.attachID, controllers.stateManagement.get);
+
+  router.put('/user/:userID', middlewares.rateLimit.consume, middlewares.project.attachID, controllers.stateManagement.update);
+
+  router.delete('/user/:userID', middlewares.rateLimit.consume, middlewares.project.attachID, controllers.stateManagement.delete);
+
+  router.post('/user/:userID', middlewares.rateLimit.consume, middlewares.project.attachID, controllers.stateManagement.reset);
+
+  router.patch('/user/:userID/variables', middlewares.rateLimit.consume, middlewares.project.attachID, controllers.stateManagement.updateVariables);
+
   router.post('/:versionID/user/:userID/interact', middlewares.rateLimit.consume, middlewares.project.attachID, controllers.stateManagement.interact);
 
   router.get('/:versionID/user/:userID', middlewares.rateLimit.consume, middlewares.project.attachID, controllers.stateManagement.get);

--- a/lib/middlewares/project.ts
+++ b/lib/middlewares/project.ts
@@ -46,7 +46,7 @@ class Project extends AbstractMiddleware {
 
         const project = await api.getProjectUsingAuthorization(req.headers.authorization);
         req.headers.project_id = project._id.toString();
-        req.params.versionID = project.liveVersion?.toString() ?? project.devVersion?.toString();
+        req.params.versionID = project.devVersion!.toString();
         return next();
       }
 

--- a/lib/middlewares/project.ts
+++ b/lib/middlewares/project.ts
@@ -3,6 +3,7 @@ import VError from '@voiceflow/verror';
 import { NextFunction, Request, Response } from 'express';
 
 import { validate } from '@/lib/utils';
+import { CreatorDataApi } from '@/runtime';
 
 import { AbstractMiddleware } from './utils';
 
@@ -10,10 +11,13 @@ const { param, header } = Validator;
 const VALIDATIONS = {
   PARAMS: {
     VERSION_ID: param('versionID')
-      .exists()
+      .optional()
       .isString(),
   },
   HEADERS: {
+    VERSION_ID: header('versionID')
+      .optional()
+      .isString(),
     AUTHORIZATION: header('authorization')
       .exists()
       .isString(),
@@ -22,10 +26,30 @@ const VALIDATIONS = {
 class Project extends AbstractMiddleware {
   static VALIDATIONS = VALIDATIONS;
 
-  @validate({ PARAMS_VERSION_ID: VALIDATIONS.PARAMS.VERSION_ID, HEADERS_AUTHORIZATION: VALIDATIONS.HEADERS.AUTHORIZATION })
+  @validate({
+    PARAMS_VERSION_ID: VALIDATIONS.PARAMS.VERSION_ID,
+    HEADERS_VERSION_ID: VALIDATIONS.HEADERS.VERSION_ID,
+    HEADERS_AUTHORIZATION: VALIDATIONS.HEADERS.AUTHORIZATION,
+  })
   async attachID(req: Request<{ versionID: string }>, _res: Response, next: NextFunction) {
     const api = await this.services.dataAPI.get(req.headers.authorization);
     try {
+      // Version ID can be provided as a header in newer endpoints
+      req.params.versionID = (req.headers.versionID as string) ?? req.params.versionID;
+
+      // Facilitate supporting routes that require a versionID but do not have to supply one.
+      // We can use the provided API key to look up the project and grab the latest version.
+      if (!req.params.versionID && typeof req.headers.authorization === 'string') {
+        if (!(api instanceof CreatorDataApi)) {
+          throw new VError('Only supported via Creator Data API');
+        }
+
+        const project = await api.getProjectUsingAuthorization(req.headers.authorization);
+        req.headers.project_id = project._id.toString();
+        req.params.versionID = project.liveVersion?.toString() ?? project.devVersion?.toString();
+        return next();
+      }
+
       const { projectID } = await api.getVersion(req.params.versionID);
       req.headers.project_id = projectID;
       return next();

--- a/lib/services/interact.ts
+++ b/lib/services/interact.ts
@@ -39,7 +39,7 @@ class Interact extends AbstractManager {
     }
 
     metrics.generalRequest();
-    if (authorization?.match(/^VF[A-Z]{0,2}\./)) {
+    if (authorization?.startsWith('VF.')) {
       metrics.sdkRequest();
     }
 

--- a/lib/services/interact.ts
+++ b/lib/services/interact.ts
@@ -39,7 +39,7 @@ class Interact extends AbstractManager {
     }
 
     metrics.generalRequest();
-    if (authorization?.startsWith('VF.')) {
+    if (authorization?.match(/^VF[A-Z]{0,2}\./)) {
       metrics.sdkRequest();
     }
 

--- a/runtime/lib/DataAPI/creatorDataAPI.ts
+++ b/runtime/lib/DataAPI/creatorDataAPI.ts
@@ -55,6 +55,16 @@ class CreatorDataAPI<
   public getProject = async (projectID: string) => {
     return (await this.client.project.get(projectID)) as PJ;
   };
+
+  public getProjectUsingAuthorization = async (apiKey: string): Promise<PJ> => {
+    // Extract the model _id from the key: VF.<type>.<id>.<hash>
+    // Legacy workspace keys do not have a type, so we need to pad the split by one.
+    const split = apiKey.split('.');
+    const [, , _id] = split.length === 4 ? split : ['', ...split];
+
+    const project = await this.client.fetch.get(`/api-keys/${_id}/project`);
+    return project.data as PJ;
+  };
 }
 
 export default CreatorDataAPI;

--- a/tests/server/state.unit.ts
+++ b/tests/server/state.unit.ts
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
+import { Express } from 'express';
 import sinon from 'sinon';
-import request from 'supertest';
+import request, { SuperTest } from 'supertest';
+
+import Server from '@/server';
 
 import GetApp from '../getAppForTest';
 import fixtures from './fixture';
@@ -29,6 +32,7 @@ const tests = [
           project: {
             attachID: {
               PARAMS_VERSION_ID: 1,
+              HEADERS_VERSION_ID: 1,
               HEADERS_AUTHORIZATION: 1,
             },
           },
@@ -74,6 +78,7 @@ const tests = [
           project: {
             attachID: {
               PARAMS_VERSION_ID: 1,
+              HEADERS_VERSION_ID: 1,
               HEADERS_AUTHORIZATION: 1,
             },
           },
@@ -112,6 +117,7 @@ const tests = [
           project: {
             attachID: {
               PARAMS_VERSION_ID: 1,
+              HEADERS_VERSION_ID: 1,
               HEADERS_AUTHORIZATION: 1,
             },
           },
@@ -142,6 +148,7 @@ const tests = [
           project: {
             attachID: {
               PARAMS_VERSION_ID: 1,
+              HEADERS_VERSION_ID: 1,
               HEADERS_AUTHORIZATION: 1,
             },
           },
@@ -179,6 +186,7 @@ const tests = [
           project: {
             attachID: {
               PARAMS_VERSION_ID: 1,
+              HEADERS_VERSION_ID: 1,
               HEADERS_AUTHORIZATION: 1,
             },
           },
@@ -224,6 +232,7 @@ const tests = [
           project: {
             attachID: {
               PARAMS_VERSION_ID: 1,
+              HEADERS_VERSION_ID: 1,
               HEADERS_AUTHORIZATION: 1,
             },
           },
@@ -234,8 +243,8 @@ const tests = [
 ];
 
 describe('state route unit tests', () => {
-  let app;
-  let server;
+  let app: Express | null;
+  let server: Server;
 
   afterEach(async () => {
     sinon.restore();


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2429**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Adds support for the new API key format. New routes to interact with the API without providing a `versionID`. This is supported by using the API key to look up the latest version.
