### PR TITLE
feat: rename request to action (VF-2492)

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -54,7 +54,7 @@ info:
         const userInput = 'Hello world!'; // User's message to your Voiceflow project
 
         const body = {
-          request: {
+          action: {
             type: 'text',
             payload: userInput,
           },
@@ -85,16 +85,15 @@ info:
         import requests
 
         api_key = "VF.xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-        version_id = "xxxxxxxxxxxxxxxxxxxxxxxx"
 
         user_id = "user_123"  # Unique ID used to track conversation state
         user_input = "Hello world!"  # User's message to your Voiceflow project
 
-        body = {"request": {"type": "text", "payload": "Hello world!"}}
+        body = {"action": {"type": "text", "payload": "Hello world!"}}
 
         # Start a conversation
         response = requests.post(
-            f"https://general-runtime.voiceflow.com/state/{version_id}/user/{user_id}/interact",
+            f"https://general-runtime.voiceflow.com/state/user/{user_id}/interact",
             json=body,
             headers={"Authorization": api_key},
         )
@@ -136,7 +135,7 @@ tags:
 
       ### Nomenclature
       - `state` is the user metadata - what block they are currently on, what flow they are on, their variables
-      - `request` is an object representing a user's action or event
+      - `action` is an object representing a user's action or event
       - `trace` is an array of actions to take based on the request that the user made
   - name: Stateless API
     description: |
@@ -150,7 +149,7 @@ tags:
 
       ### Nomenclature
       - `state` is the user metadata - what block they are currently on, what flow they are on, their variables
-      - `request` is an object representing a user's action or event
+      - `action` is an object representing a user's action or event
       - `trace` is an array of actions to take based on the request that the user made
   - name: Custom Actions
     description: |
@@ -165,7 +164,7 @@ tags:
       In your request body call, you can specific which Custom Actions to **stop** on in the `config.stopTypes` field:
       ```
       {
-        "request": { "type": "text", "payload": "hello!" } // any request type here,
+        "action": { "type": "text", "payload": "hello!" } // any request type here,
         "config": {
           "stopTypes": ["Pay Credit Card"]
         }
@@ -195,7 +194,7 @@ tags:
 
       ```
       {
-        "request": { "type": "success" }
+        "action": { "type": "success" }
       }
       ```
 
@@ -215,7 +214,7 @@ tags:
       **Example Text Request:**
       ```
       {
-        "request": {
+        "action": {
           "type": "text", "payload": "can I get a pepperoni pizza?"
         }
       }
@@ -224,7 +223,7 @@ tags:
       **NLP Resolved Intent Request:**
       ```
       {
-        "request": {
+        "action": {
           "type": "intent",
           "payload": {
             "query": "can I get a pepperoni pizza?", // (optional) original raw string of user input
@@ -292,7 +291,7 @@ tags:
       In which case, the next `request` is simply `null` to denote that the user has no replied, and the API will handle the following logic:
       ```
       {
-        request: {
+        action: {
           type: "no-reply" // Request.RequestType.NO_REPLY
         },
         // state, config, and other metadata here
@@ -329,7 +328,7 @@ paths:
         ```
         // -> request body, send user intention or event
         {
-          "request": {
+          "action": {
             "type": "text",
             "payload": "can I order a large pepperoni pizza"
           }
@@ -415,7 +414,7 @@ paths:
             schema:
               type: object
               properties:
-                request:
+                action:
                   $ref: '#/components/schemas/Request'
                 config:
                   $ref: '#/components/schemas/Config'
@@ -424,15 +423,15 @@ paths:
             examples:
               Text Request:
                 value:
-                  request:
+                  action:
                     type: text
                     payload: can I order a large pepperoni pizza
               Empty Request:
                 value:
-                  request: null
+                  action: null
               Intent Request:
                 value:
-                  request:
+                  action:
                     type: intent
                     payload:
                       query: I want a large pepperoni pizza
@@ -446,11 +445,11 @@ paths:
                       confidence: 0.5
               Launch Request:
                 value:
-                  request:
+                  action:
                     type: launch
               With Config:
                 value:
-                  request:
+                  action:
                     type: text
                     payload: I would like to order a huge pepperoni pizza
                   config:
@@ -472,7 +471,7 @@ paths:
                         $ref: '#/components/schemas/Trace'
                       state:
                         $ref: '#/components/schemas/State'
-                      request:
+                      action:
                         $ref: '#/components/schemas/Request'
                     required:
                       - trace
@@ -695,7 +694,7 @@ paths:
         - API Key:
             - ''
       description: |
-        The stateless API receives a request with `request` + `state`, and responds with a new `state` + `trace`. Here's what it looks like from the Voiceflow creator app prototype tool:
+        The stateless API receives a request with `action` + `state`, and responds with a new `state` + `trace`. Here's what it looks like from the Voiceflow creator app prototype tool:
 
         1. User says/types something, take user's text request and current `state` and sends it via webhook to the Dialog Management API.
         2. Dialog Management goes through each block/flow and updates the user `state`.
@@ -711,7 +710,7 @@ paths:
 
         ```
         {
-          "request": {
+          "action": {
             "type": "text",
             "payload": "What is the balance in my chequing account"
           },
@@ -760,8 +759,8 @@ paths:
         Notice that the `type: text` request got processed by the NLP handler to become an `type: intent` request.
         The `state` is updated, and a `trace` is generated in the API response.
 
-        To move the conversation forward, you can create a request object and pass it in the response body to `/interact` along with the state and optionally a `config` object.
-        This will return an updated `state`, an updated `request` (not shown in examples), and the trace array containing the traces to display.
+        To move the conversation forward, you can create an action object and pass it in the response body to `/interact` along with the state and optionally a `config` object.
+        This will return an updated `state`, an updated `action` (not shown in examples), and the trace array containing the traces to display.
 
         if `state` is undefined/empty, it will automatically use the **default state** (starting from the first block).
       requestBody:
@@ -770,7 +769,7 @@ paths:
             schema:
               type: object
               properties:
-                request:
+                action:
                   $ref: '#/components/schemas/Request'
                 state:
                   $ref: '#/components/schemas/State'
@@ -781,7 +780,7 @@ paths:
             examples:
               Text Request:
                 value:
-                  request:
+                  action:
                     type: text
                     payload: I would like to order a huge pepperoni pizza
                   state:
@@ -797,11 +796,11 @@ paths:
                     variables: {}
               Launch Request:
                 value:
-                  request:
+                  action:
                     type: launch
               With Config:
                 value:
-                  request:
+                  action:
                     type: text
                     payload: I would like to order a huge pepperoni pizza
                   state:
@@ -832,7 +831,7 @@ paths:
                     $ref: '#/components/schemas/Trace'
                   state:
                     $ref: '#/components/schemas/State'
-                  request:
+                  action:
                     $ref: '#/components/schemas/Request'
                 required:
                   - trace

--- a/lib/controllers/interact.ts
+++ b/lib/controllers/interact.ts
@@ -17,7 +17,12 @@ class InteractController extends AbstractController {
   }
 
   async handler(
-    req: Request<{ versionID: string }, null, { state?: State; request?: RuntimeRequest; config?: BaseRequest.RequestConfig }, { locale?: string }>
+    req: Request<
+      { versionID: string },
+      null,
+      { state?: State; action?: RuntimeRequest; request?: RuntimeRequest; config?: BaseRequest.RequestConfig },
+      { locale?: string }
+    >
   ) {
     return this.services.interact.handler(req);
   }

--- a/lib/services/interact.ts
+++ b/lib/services/interact.ts
@@ -15,14 +15,14 @@ class Interact extends AbstractManager {
 
   async handler(req: {
     params: { versionID: string; userID?: string };
-    body: { state?: State; request?: RuntimeRequest; config?: Request.RequestConfig };
+    body: { state?: State; action?: RuntimeRequest; request?: RuntimeRequest; config?: Request.RequestConfig };
     query: { locale?: string };
     headers: { authorization?: string; origin?: string; sessionid?: string };
   }) {
     const { analytics, runtime, metrics, nlu, tts, dialog, asr, speak, slots, state: stateManager, filter } = this.services;
 
     const {
-      body: { state, config = {} },
+      body: { action = null, state, config = {} },
       params: { versionID, userID },
       query: { locale },
       headers: { authorization, origin, sessionid: sessionId },
@@ -31,6 +31,9 @@ class Interact extends AbstractManager {
     let {
       body: { request = null },
     } = req;
+    // `request` prop is deprecated, replaced with `action`
+    // Internally the name request is still used
+    request = action ?? request;
 
     if (request?.type === Request.RequestType.LAUNCH && state) {
       state.stack = [];

--- a/lib/services/stateManagement.ts
+++ b/lib/services/stateManagement.ts
@@ -9,7 +9,7 @@ import { AbstractManager } from './utils';
 class StateManagement extends AbstractManager {
   async interact(data: {
     params: { versionID: string; userID: string };
-    body: { state?: State; request?: RuntimeRequest; config?: Request.RequestConfig };
+    body: { state?: State; action?: RuntimeRequest; request?: RuntimeRequest; config?: Request.RequestConfig };
     query: { locale?: string; verbose?: boolean };
     headers: { authorization: string; project_id: string };
   }) {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2492**

### Brief description. What is this change?

The `request` key has been a source of confusion, this renames in to `action` in a first step to hopefully clarifying how to use this API.