### PR TITLE
feat: hydrate nomenclature (VF-000)

### DIFF
--- a/runtime/lib/Runtime/Stack/Frame/index.ts
+++ b/runtime/lib/Runtime/Stack/Frame/index.ts
@@ -34,7 +34,7 @@ export interface Options {
 }
 
 class Frame {
-  private initialized = false;
+  private hydrated = false;
 
   private nodeID?: string | null;
 
@@ -74,12 +74,12 @@ class Frame {
     };
   }
 
-  public initialize(program: ProgramModel): void {
-    if (this.initialized) {
+  public hydrate(program: ProgramModel): void {
+    if (this.hydrated) {
       return;
     }
 
-    this.initialized = true;
+    this.hydrated = true;
 
     this.name = program.getName();
     this.commands = program.getCommands();
@@ -136,6 +136,10 @@ class Frame {
 
   public getName(): string | undefined {
     return this.name;
+  }
+
+  public isHydrated(): boolean {
+    return this.hydrated;
   }
 
   public setProgramID(programID: string): void {

--- a/runtime/lib/Runtime/cycleStack.ts
+++ b/runtime/lib/Runtime/cycleStack.ts
@@ -24,8 +24,8 @@ const cycleStack = async (runtime: Runtime, depth = 0): Promise<void> => {
 
   const program = await runtime.getProgram(currentFrame.getProgramID());
 
-  // initialize frame with program properties
-  currentFrame.initialize(program);
+  // hydrate frame with program properties
+  currentFrame.hydrate(program);
 
   // generate combined variable state (global/local)
   const combinedVariables = createCombinedVariables(runtime.variables, currentFrame.variables);

--- a/runtime/lib/Runtime/index.ts
+++ b/runtime/lib/Runtime/index.ts
@@ -177,6 +177,18 @@ class Runtime<R extends any = any, DA extends DataAPI = DataAPI> extends Abstrac
     };
   }
 
+  public async hydrateStack(): Promise<void> {
+    await this.injectBaseProgram();
+    await Promise.all(
+      this.stack.getFrames().map(async (frame) => {
+        if (frame.isHydrated()) return;
+
+        const program = await this.getProgram(frame.getProgramID());
+        frame.hydrate(program);
+      })
+    );
+  }
+
   public getHandlers<T extends Handler = Handler>(): T[] {
     return this.handlers as T[];
   }

--- a/tests/runtime/lib/Runtime/Stack/Frame/index.unit.ts
+++ b/tests/runtime/lib/Runtime/Stack/Frame/index.unit.ts
@@ -55,11 +55,11 @@ describe('Runtime Stack Frame unit tests', () => {
     expect(frame.getCommands()).to.eql(commands);
   });
 
-  describe('initialize', () => {
-    it('already initialized', () => {
+  describe('hydrate', () => {
+    it('already hydrated', () => {
       const frame = new Frame({} as any);
-      _.set(frame, 'initialized', true);
-      frame.initialize(null as any);
+      _.set(frame, 'hydrated', true);
+      frame.hydrate(null as any);
       expect(frame.getNodeID()).to.eql(undefined);
     });
 
@@ -76,7 +76,7 @@ describe('Runtime Stack Frame unit tests', () => {
         getVariables: sinon.stub().returns(variables),
       };
 
-      frame.initialize(program as any);
+      frame.hydrate(program as any);
 
       expect(frame.getName()).to.eql(name);
       expect(frame.getNodeID()).to.eql(startNodeID);
@@ -95,7 +95,7 @@ describe('Runtime Stack Frame unit tests', () => {
         getVariables: sinon.stub().returns([]),
       };
 
-      frame.initialize(program as any);
+      frame.hydrate(program as any);
 
       expect(frame.getNodeID()).to.eql(nodeID);
       expect(_.get(frame, 'startNodeID')).to.eql(startNodeID);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

wanted to change the nomenclature to better describe what's going on.
So in the actual state, we obviously don't save the ENTIRE program/diagram into the stack.

https://stackoverflow.com/questions/6991135/what-does-it-mean-to-hydrate-an-object

When a request comes in, we only fetch the program for the top frame in the stack. This way we don't have to make it redundant. The actual stack frame in the state when saved to the DB is just a reference to the program.

So a better word is instead of "initializing" a frame when we do this, we are actually "hydrating" it with all the program data.

I've added a non-optimal function to hydrate the entire stack, its used only in very niche cases.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
