### PR TITLE
docs(openapi): fix three validation errors found in our OpenAPI spec (VF-1871) 

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -402,7 +402,6 @@ paths:
           in: query
           description: enable verbose responses
           required: false
-          default: false
           schema:
             type: boolean
             example: false
@@ -941,7 +940,7 @@ externalDocs:
   url: 'https://swagger.io/docs/specification/about/'
 components:
   securitySchemes:
-    API Key:
+    APIKey:
       type: apiKey
       in: header
       name: Authorization
@@ -1026,7 +1025,7 @@ components:
     TextRequest:
       title: Text Request
       type: object
-      requuired:
+      required:
         - type
         - payload
       properties:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Part of VF-1871**

### Brief description. What is this change?

When validating our OpenAPI spec with the openapi-generator tool, we get the following errors:
```
	- attribute components.schemas.TextRequest.requuired is unexpected
	- attribute components.securitySchemes.SecurityScheme name API Key doesn't adhere to regular
	  expression ^[a-zA-Z0-9\.-_]+$
	- attribute
	  paths.'/state/{versionID}/user/{userID}/interact'(post).parameters.[verbose].default is
	  unexpected
```

This fixes those errors.

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

- `attribute components.schemas.TextRequest.requuired is unexpected`: Typo
- `attribute components.securitySchemes.SecurityScheme name API Key doesn't adhere to regular expression ^[a-zA-Z0-9\.-_]+$`: No spaces allowed according to the spec
- `attribute  paths.'/state/{versionID}/user/{userID}/interact'(post).parameters.[verbose].default is  unexpected`: The field `default` is not part of the expected schema for parameter items.


### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
