### PR TITLE
docs(openapi): fix security scheme name (VF-1871)

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -381,7 +381,7 @@ paths:
         Each trace gets produced by a particular block on your Voiceflow project.
       operationId: stateInteract
       security:
-        - API Key:
+        - APIKey:
             - ''
       parameters:
         - name: versionID
@@ -535,7 +535,7 @@ paths:
       tags:
         - State API
       security:
-        - API Key:
+        - APIKey:
             - ''
       responses:
         '200':
@@ -565,7 +565,7 @@ paths:
         - State API
       operationId: postState
       security:
-        - API Key:
+        - APIKey:
             - ''
       responses:
         '200':
@@ -614,7 +614,7 @@ paths:
         - State API
       operationId: deleteState
       security:
-        - API Key:
+        - APIKey:
             - ''
       responses:
         '200':
@@ -641,7 +641,7 @@ paths:
       tags:
         - State API
       security:
-        - API Key:
+        - APIKey:
             - ''
       responses:
         '200':
@@ -690,7 +690,7 @@ paths:
         - Stateless API
       operationId: statelessInteract
       security:
-        - API Key:
+        - APIKey:
             - ''
       description: |
         The stateless API receives a request with `action` + `state`, and responds with a new `state` + `trace`. Here's what it looks like from the Voiceflow creator app prototype tool:
@@ -911,7 +911,7 @@ paths:
       tags:
         - Stateless API
       security:
-        - API Key:
+        - APIKey:
             - ''
       responses:
         '200':


### PR DESCRIPTION
**Fixes or implements VF-1871**

### Brief description. What is this change?

fixes an incomplete refactoring from #244

our security scheme was renamed from `API Key` to `APIKey`, but the references weren't updated which causes validation errors

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written