### PR TITLE
fix: undefined code step keys (VF-2654)

### DIFF
--- a/runtime/lib/Handlers/code/utils.ts
+++ b/runtime/lib/Handlers/code/utils.ts
@@ -99,3 +99,5 @@ export const vmExecute = (
     return acc;
   }, {});
 };
+
+export const getUndefinedKeys = (variables: Record<string, unknown>) => Object.keys(variables).filter((key) => variables[key] === undefined);

--- a/tests/runtime/lib/Handlers/code/index.unit.ts
+++ b/tests/runtime/lib/Handlers/code/index.unit.ts
@@ -40,7 +40,7 @@ describe('codeHandler unit tests', () => {
         const variables = { keys: sinon.stub().returns([]), getState: sinon.stub().returns({}) };
         const result = await codeHandler.handle(node as any, runtime as any, variables as any, null as any);
         expect(result).to.eql(null);
-        expect(axiosPost.args).to.eql([['foo', { code: node.code, variables: {} }]]);
+        expect(axiosPost.args).to.eql([['foo', { code: node.code, variables: {}, keys: [] }]]);
         expect(runtime.trace.debug.args).to.eql([[`unable to resolve code  \n\`${safeJSONStringify(err.response.data)}\``, Node.NodeType.CODE]]);
       });
 
@@ -54,7 +54,7 @@ describe('codeHandler unit tests', () => {
         const variables = { keys: sinon.stub().returns([]), getState: sinon.stub().returns({}) };
         const result = await codeHandler.handle(node as any, runtime as any, variables as any, null as any);
         expect(result).to.eql(node.fail_id);
-        expect(axiosPost.args).to.eql([['foo', { code: node.code, variables: {} }]]);
+        expect(axiosPost.args).to.eql([['foo', { code: node.code, variables: {}, keys: [] }]]);
         expect(runtime.trace.debug.args).to.eql([[`unable to resolve code  \n\`"${error.toString()}"\``, Node.NodeType.CODE]]);
       });
     });
@@ -76,7 +76,7 @@ describe('codeHandler unit tests', () => {
         };
         const result = await codeHandler.handle(node as any, runtime as any, variables as any, null as any);
         expect(result).to.eql(node.success_id);
-        expect(axiosPost.args).to.eql([['foo', { code: node.code, variables: { var1: 1, var2: 2, var3: 3 } }]]);
+        expect(axiosPost.args).to.eql([['foo', { code: node.code, variables: { var1: 1, var2: 2, var3: 3 }, keys: [] }]]);
         expect(runtime.trace.debug.args).to.eql([
           [
             'evaluating code - changes:  \n`{var1}`: `1` => `1.1`  \n`{var2}`: `2` => `2.2`  \n`{var3}`: `3` => `undefined`  \n`{newVar}`: `undefined` => `5`  \n',
@@ -87,13 +87,13 @@ describe('codeHandler unit tests', () => {
 
       it('with undefined keys', async () => {
         const codeHandler = CodeHandler({ endpoint: 'foo' });
-        const axiosPost = sinon.stub(axios, 'post').resolves({ data: { var1: undefined, var2: undefined, newVar: 5 } });
+        const axiosPost = sinon.stub(axios, 'post').resolves({ data: { var1: 1.1, var2: 2.2, newVar: 5 } });
 
         const node = { code: 'var1(); var2(); var3();', success_id: 'success-id' };
         const runtime = { trace: { debug: sinon.stub() } };
         const variables = {
           merge: sinon.stub(),
-          getState: sinon.stub().returns({ var1: 1, var2: 2, var3: 3 }),
+          getState: sinon.stub().returns({ var1: undefined, var2: undefined, var3: 3 }),
         };
         const result = await codeHandler.handle(node as any, runtime as any, variables as any, null as any);
         expect(result).to.eql(node.success_id);
@@ -102,7 +102,7 @@ describe('codeHandler unit tests', () => {
         ]);
         expect(runtime.trace.debug.args).to.eql([
           [
-            'evaluating code - changes:  \n`{var1}`: `1` => `1.1`  \n`{var2}`: `2` => `2.2`  \n`{var3}`: `3` => `undefined`  \n`{newVar}`: `undefined` => `5`  \n',
+            'evaluating code - changes:  \n`{var1}`: `undefined` => `1.1`  \n`{var2}`: `undefined` => `2.2`  \n`{var3}`: `3` => `undefined`  \n`{newVar}`: `undefined` => `5`  \n',
             Node.NodeType.CODE,
           ],
         ]);
@@ -117,7 +117,7 @@ describe('codeHandler unit tests', () => {
         const variables = { merge: sinon.stub(), getState: sinon.stub().returns({ var1: 1 }) };
         const result = await codeHandler.handle(node as any, runtime as any, variables as any, null as any);
         expect(result).to.eql(null);
-        expect(axiosPost.args).to.eql([['foo', { code: node.code, variables: { var1: 1 } }]]);
+        expect(axiosPost.args).to.eql([['foo', { code: node.code, variables: { var1: 1 }, keys: [] }]]);
         expect(runtime.trace.debug.args).to.eql([['evaluating code - no variable changes', Node.NodeType.CODE]]);
       });
     });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2654**

### Brief description. What is this change?

so when a variable is undefined on Voiceflow, and we want to change it on the code step,
in the http request we sent all undefined values are just dropped altogether when being sent to the code step. So when we try to actually modify it in the code-block microservice it is unreferenced and doesn't get sent back.

This was actually uncovered by connor's work on the API block, because now the API block is local and actually maps undefined to keys, but it is not the API block's fault, it is fine to set something to undefined.

This is because we need the something to be referenced as a key in order for it to be sent back:
https://github.com/voiceflow/general-runtime/blob/ee432fed620cb9be76fa4fa7aa426351c11fa24f/runtime/lib/Handlers/code/utils.ts#L94-L100

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
