### PR TITLE
feat: entity filling incoming intent (VF-000)

### DIFF
--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -55,7 +55,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
     const dmPrefixedResultName = dmPrefixedResult.payload.intent.name;
     log.trace(`[app] [runtime] [dm] DM-Prefixed inference result ${log.vars({ resultName: dmPrefixedResultName })}`);
 
-    if (dmPrefixedResultName.startsWith(VF_DM_PREFIX)) {
+    if (dmPrefixedResultName.startsWith(VF_DM_PREFIX) || dmPrefixedResultName === dmStateStore.intentRequest?.payload.intent.name) {
       // Remove hash prefix entity from the DM-prefixed result
       dmPrefixedResult.payload.entities = dmPrefixedResult.payload.entities.filter((entity) => !entity.name.startsWith(VF_DM_PREFIX));
       const intentEntityList = getIntentEntityList(dmStateStore.intentRequest!.payload.intent.name, languageModel);

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -55,7 +55,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
     const dmPrefixedResultName = dmPrefixedResult.payload.intent.name;
     log.trace(`[app] [runtime] [dm] DM-Prefixed inference result ${log.vars({ resultName: dmPrefixedResultName })}`);
 
-    if (dmPrefixedResultName.startsWith(VF_DM_PREFIX) || dmPrefixedResultName === dmStateStore.intentRequest?.payload.intent.name) {
+    if (dmPrefixedResultName.startsWith(VF_DM_PREFIX)) {
       // Remove hash prefix entity from the DM-prefixed result
       dmPrefixedResult.payload.entities = dmPrefixedResult.payload.entities.filter((entity) => !entity.name.startsWith(VF_DM_PREFIX));
       const intentEntityList = getIntentEntityList(dmStateStore.intentRequest!.payload.intent.name, languageModel);
@@ -72,7 +72,6 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
             storedEntity.value = entity.value; // Update entity value
           }
         });
-        // TODO: Confidence-based selection of whether to switch intents
       } else {
         // CASE-B2_2: The prefixed intent has no entities extracted (except for the hash sentinel)
         // Action:  Migrate the user to the regular intent

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -61,12 +61,8 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
       const intentEntityList = getIntentEntityList(dmStateStore.intentRequest!.payload.intent.name, languageModel);
       // Check if the dmPrefixedResult entities are a subset of the intent's entity list
       const entitySubset = dmPrefixedResult.payload.entities.filter((dmEntity) => intentEntityList?.find((entity) => entity?.name === dmEntity.name));
-      if (dmPrefixedResult.payload.entities.length === 0) {
-        // CASE-B2_2: The prefixed intent has no entities extracted (except for the hash sentinel)
-        // Action:  Migrate the user to the regular intent
-        dmStateStore.intentRequest = incomingRequest;
-      } else if (entitySubset.length) {
-        // CASE-B2_4: the prefixed intent only contains entities that are in the target intent's entity list
+      if (entitySubset.length) {
+        // CASE-B1: the prefixed intent only contains entities that are in the target intent's entity list
         // Action: Use the entities extracted from the prefixed intent to overwrite any existing filled entities
         entitySubset.forEach((entity) => {
           const storedEntity = dmStateStore.intentRequest!.payload.entities.find((stored) => stored.name === entity.name);
@@ -78,9 +74,9 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
         });
         // TODO: Confidence-based selection of whether to switch intents
       } else {
-        // (Unlikely) CASE-B2_3: The prefixed intent has entities that are not in the target intent's entity list
-        // Action: return true; Fallback intent
-        return true;
+        // CASE-B2_2: The prefixed intent has no entities extracted (except for the hash sentinel)
+        // Action:  Migrate the user to the regular intent
+        dmStateStore.intentRequest = incomingRequest;
       }
     } else if (dmPrefixedResultName === incomingRequest.payload.intent.name) {
       // CASE-A1: The prefixed and regular calls match the same (non-DM) intent that is different from the original intent

--- a/tests/lib/services/dialog/index.unit.ts
+++ b/tests/lib/services/dialog/index.unit.ts
@@ -62,18 +62,6 @@ describe('dialog manager unit tests', () => {
   describe('DM-context handler', () => {
     const dm = createDM();
 
-    describe('CASE-B2_2: no entities extracted from DM-prefixed call', () => {
-      it('Migrates DM context to the regular intent', async () => {
-        const dmState = {
-          intentRequest: mockUnfulfilledIntentRequest,
-        };
-        const result = await dm.handleDMContext(dmState, mockDMPrefixedNoEntityResult, mockRegularNoEntityResult, mockLM);
-
-        expect(result).to.be.false; // No fallback intent
-        expect(dmState.intentRequest).to.deep.equal(mockRegularNoEntityResult);
-      });
-    });
-
     describe('CASE-B1: DM-prefixed and regular calls match the same intent', () => {
       it('Upserts the DM state store with the new extracted entities', async () => {
         const dmState = {
@@ -89,7 +77,7 @@ describe('dialog manager unit tests', () => {
       });
     });
 
-    describe('CASE-B2_4: DM-prefixed call contains entities that are a strict subset of the entities of the target intent', () => {
+    describe('CASE-B1: DM-prefixed call contains entities that are a strict subset of the entities of the target intent', () => {
       it('Upserts the DM state store with the new extracted entities', async () => {
         const dmState = {
           intentRequest: mockRegularNoEntityResult,
@@ -103,14 +91,27 @@ describe('dialog manager unit tests', () => {
       });
     });
 
-    describe("CASE-B2_3: DM-prefixed call has entities that are not in the target intent's entity list", () => {
-      it('Returns FallBack intent', async () => {
+    describe('CASE-B2: no entities extracted from DM-prefixed call', () => {
+      it('Migrates DM context to the regular intent', async () => {
+        const dmState = {
+          intentRequest: mockUnfulfilledIntentRequest,
+        };
+        const result = await dm.handleDMContext(dmState, mockDMPrefixedNoEntityResult, mockRegularNoEntityResult, mockLM);
+
+        expect(result).to.be.false; // No fallback intent
+        expect(dmState.intentRequest).to.deep.equal(mockRegularNoEntityResult);
+      });
+    });
+
+    describe("CASE-B2: DM-prefixed call has entities that are not in the target intent's entity list", () => {
+      it('Returns incoming intent', async () => {
         const dmState = {
           intentRequest: mockRegularNoEntityResult,
         };
-        const result = await dm.handleDMContext(dmState, mockDMPrefixedNonSubsetEntityResult, mockRegularNoEntityResult, mockLM);
+        const result = await dm.handleDMContext(dmState, mockDMPrefixedNonSubsetEntityResult, mockRegularUnrelatedResult, mockLM);
 
-        expect(result).to.be.true; // trigger fallback intent
+        expect(result).to.be.false;
+        expect(dmState.intentRequest).to.eql(mockRegularUnrelatedResult);
       });
     });
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

After extensive testing with our dialog service (this should be renamed to entity filling), I decided to make some changes that better reflect the user's intentions.

We make too much use of the fallback intent. It should be up to the NLP to resolve something as a "None Intent", otherwise whatever else it resolves to is still valid data that can be made use of.

I've simplified the cases for entity filling. Suppose we are trying to fill out a pizza type for "pizza intent" with `size` & `type` entities: 
```
-> "what type of pizza do you want?" (Sys)
<- "help" (User)
```

* We will first send just "help" to LUIS to match, which will easily result in the "help intent". (incoming intent)
* Next, we send `${dm_prefix_hash} help`, which will more often than not, result in `${dm_prefix_hash} intent` with no entities filled out. The prefix highly biases the NLP model and will have false positives.

With this update, if the `${dm_prefix_hash} intent` contains no entities that the intent needs (i.e. `size` & `type`), we should just disregard it and use the incoming intent instead. 
This is made with the assumption that ALL `${dm_prefix_hash} intent` utterances **should** contain a relevant entity of some kind.

This results in simpler logic and more concise classification, making it easier to break out of slot filling and into other intents.

I've also updated the docs here to reflect the new states better.
https://www.notion.so/voiceflow/LUIS-Dialogue-Management-86549a90f3984f21a48ed6aebbdaa8f8

Tried it on a flow like this and it works quite as intended:
<img width="1249" alt="Screen Shot 2022-01-12 at 12 06 36 AM" src="https://user-images.githubusercontent.com/5643574/149067266-58258f49-49f3-43a4-ba0b-b558c077b646.png">


### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
