### PR TITLE
fix: api injection (VF-000)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -31,10 +31,9 @@ const CONFIG: Config = {
   // integrations block
   INTEGRATIONS_HANDLER_ENDPOINT: getOptionalProcessEnv('INTEGRATIONS_HANDLER_ENDPOINT') || 'none',
   // api-block
-  API_HANDLER_ENDPOINT: getOptionalProcessEnv('API_HANDLER_ENDPOINT'),
-  API_MAX_TIMEOUT_MS: Number(getOptionalProcessEnv('API_MAX_TIMEOUT_MS', '20000')),
-  API_MAX_CONTENT_LENGTH_BYTES: Number(getOptionalProcessEnv('API_MAX_CONTENT_LENGTH_BYTES', '1000000')),
-  API_MAX_BODY_LENGTH_BYTES: Number(getOptionalProcessEnv('API_MAX_BODY_LENGTH_BYTES', '1000000')),
+  API_MAX_TIMEOUT_MS: Number(getOptionalProcessEnv('API_MAX_TIMEOUT_MS')) || null,
+  API_MAX_CONTENT_LENGTH_BYTES: Number(getOptionalProcessEnv('API_MAX_CONTENT_LENGTH_BYTES')) || null,
+  API_MAX_BODY_LENGTH_BYTES: Number(getOptionalProcessEnv('API_MAX_BODY_LENGTH_BYTES')) || null,
 
   PROJECT_SOURCE: getOptionalProcessEnv('PROJECT_SOURCE'),
 

--- a/documentation/env.md
+++ b/documentation/env.md
@@ -61,4 +61,3 @@ External services needed to run certain blocks (API, Zapier, Google Docs, Code)
 
 - `INTEGRATIONS_HANDLER_ENDPOINT` - cloud endpoint for zapier/google blocks - not available if `general-runtime` is ran as standalone
 - `CODE_HANDLER_ENDPOINT` - stateless cloud service endpoint to execute the code block. Leave undefined to run custom code locally
-- `API_HANDLER_ENDPOINT` - stateless cloud endpoint for the API block to make requests. Leave undefined to make requests locally

--- a/lib/services/runtime/handlers/index.ts
+++ b/lib/services/runtime/handlers/index.ts
@@ -27,7 +27,13 @@ import VisualHandler from './visual';
 
 const _v1Handler = _V1Handler();
 
-export default ({ API_HANDLER_ENDPOINT, INTEGRATIONS_HANDLER_ENDPOINT, CODE_HANDLER_ENDPOINT }: Config) => [
+export default ({
+  API_MAX_TIMEOUT_MS,
+  API_MAX_BODY_LENGTH_BYTES,
+  API_MAX_CONTENT_LENGTH_BYTES,
+  INTEGRATIONS_HANDLER_ENDPOINT,
+  CODE_HANDLER_ENDPOINT,
+}: Config) => [
   ...StateHandlers(),
   SpeakHandler(),
   InteractionHandler(),
@@ -40,7 +46,7 @@ export default ({ API_HANDLER_ENDPOINT, INTEGRATIONS_HANDLER_ENDPOINT, CODE_HAND
   FlowHandler(),
   IfHandler(),
   IfV2Handler({ _v1: _v1Handler }),
-  APIHandler({ customAPIEndpoint: API_HANDLER_ENDPOINT }),
+  APIHandler({ timeout: API_MAX_TIMEOUT_MS, maxBodyLength: API_MAX_BODY_LENGTH_BYTES, maxContentLength: API_MAX_CONTENT_LENGTH_BYTES }),
   IntegrationsHandler({ integrationsEndpoint: INTEGRATIONS_HANDLER_ENDPOINT }),
   RandomHandler(),
   SetHandler(),

--- a/runtime/lib/Handlers/api/index.ts
+++ b/runtime/lib/Handlers/api/index.ts
@@ -5,15 +5,11 @@ import safeJSONStringify from 'safe-json-stringify';
 
 import { HandlerFactory } from '@/runtime/lib/Handler';
 
-import { APINodeData, makeAPICall } from './utils';
-
-export type IntegrationsOptions = {
-  customAPIEndpoint?: string | null;
-};
+import { APINodeData, makeAPICall, ResponseConfig } from './utils';
 
 export const USER_AGENT_KEY = 'User-Agent';
 export const USER_AGENT = 'Voiceflow/1.0.0 (+https://voiceflow.com)';
-const APIHandler: HandlerFactory<Node.Integration.Node, IntegrationsOptions | void> = () => ({
+const APIHandler: HandlerFactory<Node.Integration.Node, ResponseConfig | void> = (config = {}) => ({
   canHandle: (node) => node.type === Node.NodeType.INTEGRATIONS && node.selected_integration === Node.Utils.IntegrationType.CUSTOM_API,
   handle: async (node, runtime, variables) => {
     let nextId: string | null = null;
@@ -26,7 +22,7 @@ const APIHandler: HandlerFactory<Node.Integration.Node, IntegrationsOptions | vo
         actionBodyData.headers = [...headers, { key: USER_AGENT_KEY, val: USER_AGENT }];
       }
 
-      const data = await makeAPICall(actionBodyData, runtime);
+      const data = await makeAPICall(actionBodyData, runtime, config as ResponseConfig);
 
       // add mapped variables to variables store
       variables.merge(data.variables);

--- a/runtime/lib/Handlers/api/index.ts
+++ b/runtime/lib/Handlers/api/index.ts
@@ -22,7 +22,7 @@ const APIHandler = (config: ResponseConfig = {}): Handler<Node.Integration.Node>
         actionBodyData.headers = [...headers, { key: USER_AGENT_KEY, val: USER_AGENT }];
       }
 
-      const data = await makeAPICall(actionBodyData, runtime, config as ResponseConfig);
+      const data = await makeAPICall(actionBodyData, runtime, config);
 
       // add mapped variables to variables store
       variables.merge(data.variables);

--- a/runtime/lib/Handlers/api/index.ts
+++ b/runtime/lib/Handlers/api/index.ts
@@ -3,13 +3,13 @@ import { deepVariableSubstitution } from '@voiceflow/common';
 import _ from 'lodash';
 import safeJSONStringify from 'safe-json-stringify';
 
-import { HandlerFactory } from '@/runtime/lib/Handler';
+import Handler from '@/runtime/lib/Handler';
 
 import { APINodeData, makeAPICall, ResponseConfig } from './utils';
 
 export const USER_AGENT_KEY = 'User-Agent';
 export const USER_AGENT = 'Voiceflow/1.0.0 (+https://voiceflow.com)';
-const APIHandler: HandlerFactory<Node.Integration.Node, ResponseConfig | void> = (config = {}) => ({
+const APIHandler = (config: ResponseConfig = {}): Handler<Node.Integration.Node> => ({
   canHandle: (node) => node.type === Node.NodeType.INTEGRATIONS && node.selected_integration === Node.Utils.IntegrationType.CUSTOM_API,
   handle: async (node, runtime, variables) => {
     let nextId: string | null = null;

--- a/runtime/lib/Handlers/api/utils.ts
+++ b/runtime/lib/Handlers/api/utils.ts
@@ -9,7 +9,6 @@ import querystring from 'querystring';
 import safeJSONStringify from 'safe-json-stringify';
 import validator from 'validator';
 
-import CONFIG from '@/config';
 import Runtime from '@/runtime/lib/Runtime';
 
 export type APINodeData = Node.Api.NodeData['action_data'];
@@ -101,19 +100,25 @@ const validateIP = async (hostname: string) => {
   }
 };
 
+export interface ResponseConfig {
+  timeout?: number | null;
+  maxContentLength?: number | null;
+  maxBodyLength?: number | null;
+}
+
 // eslint-disable-next-line sonarjs/cognitive-complexity
-export const formatRequestConfig = (data: APINodeData) => {
+export const formatRequestConfig = (data: APINodeData, config: ResponseConfig) => {
   const { method, bodyInputType, headers, body, params, url, content } = data;
 
   const options: AxiosRequestConfig = {
     method,
     url,
     // If the request takes longer than `timeout` in ms, the request will be aborted
-    timeout: CONFIG.API_MAX_TIMEOUT_MS,
+    timeout: config?.timeout ?? 20000,
     // defines the max size of the http response content in bytes allowed in node.js
-    maxContentLength: CONFIG.API_MAX_CONTENT_LENGTH_BYTES,
+    maxContentLength: config?.maxContentLength ?? 1000000,
     // defines the max size of the http request content in bytes allowed
-    maxBodyLength: CONFIG.API_MAX_BODY_LENGTH_BYTES,
+    maxBodyLength: config?.maxBodyLength ?? 1000000,
   };
 
   if (params && params.length > 0) {
@@ -165,7 +170,7 @@ export const formatRequestConfig = (data: APINodeData) => {
   return options;
 };
 
-export const makeAPICall = async (nodeData: APINodeData, runtime: Runtime) => {
+export const makeAPICall = async (nodeData: APINodeData, runtime: Runtime, config: ResponseConfig) => {
   try {
     const hostname = validateHostname(nodeData.url);
     await validateIP(hostname);
@@ -179,7 +184,7 @@ export const makeAPICall = async (nodeData: APINodeData, runtime: Runtime) => {
       runtime.trace.debug(`Outgoing Api Rate Limiter failed - Error: \n${safeJSONStringify(error.response?.data || error)}`, Node.NodeType.API);
     }
 
-    const options = formatRequestConfig(nodeData);
+    const options = formatRequestConfig(nodeData, config);
 
     const { data, headers, status } = (await axios(options)) as AxiosResponse<{ VF_STATUS_CODE?: number; VF_HEADERS?: any }>;
 

--- a/types.ts
+++ b/types.ts
@@ -26,10 +26,9 @@ export interface Config extends RateLimitConfig {
 
   CODE_HANDLER_ENDPOINT: string | null;
   INTEGRATIONS_HANDLER_ENDPOINT: string;
-  API_HANDLER_ENDPOINT: string | null;
-  API_MAX_TIMEOUT_MS: number;
-  API_MAX_CONTENT_LENGTH_BYTES: number;
-  API_MAX_BODY_LENGTH_BYTES: number;
+  API_MAX_TIMEOUT_MS: number | null;
+  API_MAX_CONTENT_LENGTH_BYTES: number | null;
+  API_MAX_BODY_LENGTH_BYTES: number | null;
 
   // Release information
   GIT_SHA: string | null;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

I saw this error after bumping the general-runtime package for alexa:
```
Error: env var: GENERAL_SERVICE_ENDPOINT not found
```
the alexa-runtime definitely doesn't need the `GENERAL_SERVICE_ENDPOINT` to work. Because we referenced `@/config` directly, the downstream runtimes now need the same environment variables.

Stems from: https://github.com/voiceflow/general-runtime/pull/255

Instead, they should be instantiated as the handlers get being added.
This is blocking some critical bug fixes for alexa.

`API_HANDLER_ENDPOINT` is no longer needed, this was a reference to the API microservice. It is done locally now.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
