### PR TITLE
fix: expand custom variables (VF-2727)

### DIFF
--- a/lib/services/runtime/handlers/_v1.ts
+++ b/lib/services/runtime/handlers/_v1.ts
@@ -11,7 +11,6 @@ import { findEventMatcher } from './event';
 const utilsObj = {
   commandHandler: CommandHandler(),
   findEventMatcher,
-  replaceVariables,
 };
 
 export const _V1Handler: HandlerFactory<Node._v1.Node, typeof utilsObj> = (utils) => ({
@@ -41,9 +40,12 @@ export const _V1Handler: HandlerFactory<Node._v1.Node, typeof utilsObj> = (utils
     }
 
     const variablesMap = variables.getState();
+    const type = replaceVariables(node.type, variablesMap);
+    const payload = typeof node.payload === 'string' ? replaceVariables(node.payload, variablesMap) : node.payload;
+
     runtime.trace.addTrace<Node.Utils.BaseTraceFrame<unknown>>({
-      type: utils.replaceVariables(node.type, variablesMap),
-      payload: node.payload === 'string' ? utils.replaceVariables(node.payload, variablesMap) : node.payload,
+      type,
+      payload,
       defaultPath: node.defaultPath,
       paths: node.paths.map((path) => ({ label: path.label, event: path.event! })),
     });

--- a/lib/services/runtime/handlers/_v1.ts
+++ b/lib/services/runtime/handlers/_v1.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 import { Node } from '@voiceflow/base-types';
+import { replaceVariables } from '@voiceflow/common';
 
 import { Action, HandlerFactory } from '@/runtime';
 
@@ -10,6 +11,7 @@ import { findEventMatcher } from './event';
 const utilsObj = {
   commandHandler: CommandHandler(),
   findEventMatcher,
+  replaceVariables,
 };
 
 export const _V1Handler: HandlerFactory<Node._v1.Node, typeof utilsObj> = (utils) => ({
@@ -38,9 +40,10 @@ export const _V1Handler: HandlerFactory<Node._v1.Node, typeof utilsObj> = (utils
       return null;
     }
 
+    const variablesMap = variables.getState();
     runtime.trace.addTrace<Node.Utils.BaseTraceFrame<unknown>>({
-      type: node.type,
-      payload: node.payload,
+      type: utils.replaceVariables(node.type, variablesMap),
+      payload: node.payload === 'string' ? utils.replaceVariables(node.payload, variablesMap) : node.payload,
       defaultPath: node.defaultPath,
       paths: node.paths.map((path) => ({ label: path.label, event: path.event! })),
     });

--- a/tests/lib/services/runtime/handlers/_v1.unit.ts
+++ b/tests/lib/services/runtime/handlers/_v1.unit.ts
@@ -23,9 +23,9 @@ describe('_v1 handler unit tests', () => {
         it('works', () => {
           const node = {
             id: 'node-id',
-            type: 'trace',
+            type: 'trace {var1}',
             stop: true,
-            payload: { foo: 'bar' },
+            payload: "{ foo: 'bar {var1}' }",
             paths: [
               { event: {}, label: 'label1', nextID: '1' },
               { event: {}, nextID: '2' },
@@ -37,13 +37,14 @@ describe('_v1 handler unit tests', () => {
             turn: { get: sinon.stub().returns(null) },
           };
           const handler = _V1Handler({} as any);
+          const variables = { getState: sinon.stub().returns({ var1: 'variable1' }) };
 
-          expect(handler.handle(node as any, runtime as any, null as any, null as any)).to.eql(node.id);
+          expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.id);
           expect(runtime.trace.addTrace.args).to.eql([
             [
               {
-                type: node.type,
-                payload: node.payload,
+                type: 'trace variable1',
+                payload: "{ foo: 'bar variable1' }",
                 paths: [
                   { event: {}, label: 'label1' },
                   { event: {}, label: undefined },
@@ -72,8 +73,9 @@ describe('_v1 handler unit tests', () => {
             turn: { get: sinon.stub().returns(['type1', 'the trace block', 'type3']) },
           };
           const handler = _V1Handler({} as any);
+          const variables = { getState: sinon.stub().returns({}) };
 
-          expect(handler.handle(node as any, runtime as any, null as any, null as any)).to.eql(node.id);
+          expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.id);
           expect(runtime.trace.addTrace.args).to.eql([
             [
               {
@@ -109,8 +111,9 @@ describe('_v1 handler unit tests', () => {
             turn: { get: sinon.stub().returns(undefined) },
           };
           const handler = _V1Handler({} as any);
+          const variables = { getState: sinon.stub().returns({}) };
 
-          expect(handler.handle(node as any, runtime as any, null as any, null as any)).to.eql(null);
+          expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
           expect(runtime.trace.addTrace.args).to.eql([
             [
               {
@@ -145,8 +148,9 @@ describe('_v1 handler unit tests', () => {
             turn: { get: sinon.stub().returns(null) },
           };
           const handler = _V1Handler({} as any);
+          const variables = { getState: sinon.stub().returns({}) };
 
-          expect(handler.handle(node as any, runtime as any, null as any, null as any)).to.eql(null);
+          expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
           expect(runtime.trace.addTrace.args).to.eql([
             [
               {
@@ -181,8 +185,9 @@ describe('_v1 handler unit tests', () => {
             turn: { get: sinon.stub().returns(false) },
           };
           const handler = _V1Handler({} as any);
+          const variables = { getState: sinon.stub().returns({}) };
 
-          expect(handler.handle(node as any, runtime as any, null as any, null as any)).to.eql('2');
+          expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql('2');
           expect(runtime.trace.addTrace.args).to.eql([
             [
               {
@@ -235,7 +240,7 @@ describe('_v1 handler unit tests', () => {
           getAction: sinon.stub().returns(Action.REQUEST),
           trace: { addTrace: sinon.stub() },
         };
-        const variables = { var1: 'val1' };
+        const variables = { getState: sinon.stub().returns({ var1: 'val1' }) };
         const handler = _V1Handler({ commandHandler, findEventMatcher } as any);
 
         expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql('command-id');
@@ -266,7 +271,7 @@ describe('_v1 handler unit tests', () => {
           getAction: sinon.stub().returns(Action.REQUEST),
           trace: { addTrace: sinon.stub() },
         };
-        const variables = { var1: 'val1' };
+        const variables = { getState: sinon.stub().returns({ var1: 'val1' }) };
         const handler = _V1Handler({ findEventMatcher } as any);
 
         expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql('next-id2');
@@ -296,7 +301,7 @@ describe('_v1 handler unit tests', () => {
           getAction: sinon.stub().returns(Action.REQUEST),
           trace: { addTrace: sinon.stub() },
         };
-        const variables = { var1: 'val1' };
+        const variables = { getState: sinon.stub().returns({ var1: 'val1' }) };
         const handler = _V1Handler({ findEventMatcher } as any);
 
         expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2727**

### Brief description. What is this change?
Although it is possible to infer the value of a variable from the variable state, it's a lot easier to consume for anyone using the API if it gets done directly on the runtime.
Uses the same `replaceVariables` used throughout the runtime for other fields.

So given a step like this
![Screen Shot 2022-01-20 at 1 17 10 AM](https://user-images.githubusercontent.com/5643574/150284158-275fb00f-b0b4-4074-9e11-307b9a46284d.png)

It will now produce this trace:
![Screen Shot 2022-01-20 at 1 18 31 AM](https://user-images.githubusercontent.com/5643574/150284246-c34e93c8-1870-48e3-aa86-4fd19451c0be.png)

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written
