### PR TITLE
fix: handle HTTP 4xx & 5xx errors in API block (VF-2713)

### DIFF
--- a/runtime/lib/Handlers/api/utils.ts
+++ b/runtime/lib/Handlers/api/utils.ts
@@ -119,6 +119,9 @@ export const formatRequestConfig = (data: APINodeData, config: ResponseConfig) =
     maxContentLength: config?.maxContentLength ?? 1000000,
     // defines the max size of the http request content in bytes allowed
     maxBodyLength: config?.maxBodyLength ?? 1000000,
+    // Don't throw if the status code was bad (ex. a 500)
+    // This closer matches the behavior of fetch(), where only network errors will cause an exception to be thrown
+    validateStatus: null,
   };
 
   if (params && params.length > 0) {

--- a/runtime/lib/Handlers/api/utils.ts
+++ b/runtime/lib/Handlers/api/utils.ts
@@ -174,37 +174,33 @@ export const formatRequestConfig = (data: APINodeData, config: ResponseConfig) =
 };
 
 export const makeAPICall = async (nodeData: APINodeData, runtime: Runtime, config: ResponseConfig) => {
+  const hostname = validateHostname(nodeData.url);
+  await validateIP(hostname);
+
   try {
-    const hostname = validateHostname(nodeData.url);
-    await validateIP(hostname);
-
-    try {
-      if (await runtime.outgoingApiLimiter.addHostnameUseAndShouldThrottle(hostname)) {
-        // if the use of the hostname is high, delay the api call but let it happen
-        await new Promise((resolve) => setTimeout(resolve, THROTTLE_DELAY));
-      }
-    } catch (error) {
-      runtime.trace.debug(`Outgoing Api Rate Limiter failed - Error: \n${safeJSONStringify(error.response?.data || error)}`, Node.NodeType.API);
+    if (await runtime.outgoingApiLimiter.addHostnameUseAndShouldThrottle(hostname)) {
+      // if the use of the hostname is high, delay the api call but let it happen
+      await new Promise((resolve) => setTimeout(resolve, THROTTLE_DELAY));
     }
-
-    const options = formatRequestConfig(nodeData, config);
-
-    const { data, headers, status } = (await axios(options)) as AxiosResponse<{ VF_STATUS_CODE?: number; VF_HEADERS?: any }>;
-
-    if (typeof data === 'object' && data !== null && !Array.isArray(data)) {
-      data.VF_STATUS_CODE = status;
-      data.VF_HEADERS = headers;
-    }
-
-    const newVariables = Object.fromEntries((nodeData.mapping ?? []).filter((map) => map.var).map((map) => [map.var, getVariable(map.path, data)]));
-
-    // remove all undefined variables
-    Object.keys(newVariables).forEach((variable) => {
-      if (newVariables[variable] === undefined) delete newVariables[variable];
-    });
-
-    return { variables: newVariables, response: { data, headers, status } };
-  } catch (e) {
-    throw e;
+  } catch (error) {
+    runtime.trace.debug(`Outgoing Api Rate Limiter failed - Error: \n${safeJSONStringify(error.response?.data || error)}`, Node.NodeType.API);
   }
+
+  const options = formatRequestConfig(nodeData, config);
+
+  const { data, headers, status } = (await axios(options)) as AxiosResponse<{ VF_STATUS_CODE?: number; VF_HEADERS?: any }>;
+
+  if (typeof data === 'object' && data !== null && !Array.isArray(data)) {
+    data.VF_STATUS_CODE = status;
+    data.VF_HEADERS = headers;
+  }
+
+  const newVariables = Object.fromEntries((nodeData.mapping ?? []).filter((map) => map.var).map((map) => [map.var, getVariable(map.path, data)]));
+
+  // remove all undefined variables
+  Object.keys(newVariables).forEach((variable) => {
+    if (newVariables[variable] === undefined) delete newVariables[variable];
+  });
+
+  return { variables: newVariables, response: { data, headers, status } };
 };


### PR DESCRIPTION
**Fixes or implements VF-2713**

### Brief description. What is this change?

do not throw an error when the status code from a request in the API block is a 4xx or 5xx 

### Implementation details. How do you make this change?

it's like a 1liner config option
also, get rid of the useless trycatch block

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written