### PR TITLE
fix: store the last visited node, check on interact (VF-2489)

### DIFF
--- a/lib/services/runtime/handlers/interaction.ts
+++ b/lib/services/runtime/handlers/interaction.ts
@@ -41,12 +41,13 @@ export const InteractionHandler: HandlerFactory<GeneralNode.Interaction.Node | C
       return utils.noReplyHandler.handle(node, runtime, variables);
     }
 
-    for (let i = 0; i < node.interactions.length; i++) {
-      const { event, nextId } = node.interactions[i];
+    if (runtime.storage.get(StorageType.PREVIOUS_NODE_ID) !== node.id) {
+      for (let i = 0; i < node.interactions.length; i++) {
+        const { event, nextId } = node.interactions[i];
 
-      const matcher = utils.findEventMatcher({ event, runtime, variables });
+        const matcher = utils.findEventMatcher({ event, runtime, variables });
+        if (!matcher) continue;
 
-      if (matcher) {
         // allow handler to apply side effects
         matcher.sideEffect();
 

--- a/lib/services/runtime/handlers/interaction.ts
+++ b/lib/services/runtime/handlers/interaction.ts
@@ -3,6 +3,7 @@ import { Node as ChatNode } from '@voiceflow/chat-types';
 import { Node as GeneralNode } from '@voiceflow/general-types';
 
 import { Action, HandlerFactory } from '@/runtime';
+import { Storage } from '@/runtime/lib/Constants/flags';
 
 import { StorageType } from '../types';
 import { addButtonsIfExists } from '../utils';
@@ -41,7 +42,7 @@ export const InteractionHandler: HandlerFactory<GeneralNode.Interaction.Node | C
       return utils.noReplyHandler.handle(node, runtime, variables);
     }
 
-    if (runtime.storage.get(StorageType.PREVIOUS_NODE_ID) !== node.id) {
+    if (runtime.storage.get(Storage.PREVIOUS_NODE_ID) !== node.id) {
       for (let i = 0; i < node.interactions.length; i++) {
         const { event, nextId } = node.interactions[i];
 

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -30,7 +30,6 @@ export enum StorageType {
   STREAM_FINISHED = 'streamFinished',
   NO_MATCHES_COUNTER = 'noMatchesCounter',
   NO_REPLIES_COUNTER = 'noRepliesCounter',
-  PREVIOUS_NODE_ID = 'previousNodeID',
 }
 
 export enum StreamAction {

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -30,6 +30,7 @@ export enum StorageType {
   STREAM_FINISHED = 'streamFinished',
   NO_MATCHES_COUNTER = 'noMatchesCounter',
   NO_REPLIES_COUNTER = 'noRepliesCounter',
+  PREVIOUS_NODE_ID = 'previousNodeID',
 }
 
 export enum StreamAction {

--- a/runtime/lib/Constants/flags.ts
+++ b/runtime/lib/Constants/flags.ts
@@ -1,6 +1,7 @@
 export enum Storage {
   OUTPUT_MAP = 'outputMap',
   RANDOMS = 'randoms', // used to store no-duplicate random node choices
+  PREVIOUS_NODE_ID = 'previousNodeID',
 }
 
 export enum TurnType {

--- a/runtime/lib/Runtime/cycleHandler.ts
+++ b/runtime/lib/Runtime/cycleHandler.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-await-in-loop */
 
+import { StorageType } from '@/lib/services/runtime/types';
 import { Action } from '@/runtime';
 import { EventType } from '@/runtime/lib/Lifecycle';
 import ProgramModel from '@/runtime/lib/Program';
@@ -36,6 +37,8 @@ const cycleHandler = async (runtime: Runtime, program: ProgramModel, variableSta
           await runtime.callEvent(EventType.handlerWillHandle, { node, variables: variableState });
 
           nextID = await handler.handle(_node, runtime, variableState, program);
+
+          runtime.storage.set(StorageType.PREVIOUS_NODE_ID, _node.id);
 
           await runtime.callEvent(EventType.handlerDidHandle, { node, variables: variableState });
         }

--- a/runtime/lib/Runtime/cycleHandler.ts
+++ b/runtime/lib/Runtime/cycleHandler.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 
-import { StorageType } from '@/lib/services/runtime/types';
 import { Action } from '@/runtime';
+import { Storage as StorageType } from '@/runtime/lib/Constants/flags';
 import { EventType } from '@/runtime/lib/Lifecycle';
 import ProgramModel from '@/runtime/lib/Program';
 import Runtime from '@/runtime/lib/Runtime';

--- a/tests/lib/services/runtime/handlers/interaction.unit.ts
+++ b/tests/lib/services/runtime/handlers/interaction.unit.ts
@@ -29,7 +29,7 @@ describe('Interaction handler', () => {
         const node = { id: 'node-id' };
         const runtime = {
           getAction: sinon.stub().returns(Action.RUNNING),
-          storage: { delete: sinon.stub() },
+          storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
           getRequest: sinon.stub().returns({}),
         };
         const variables = { var1: 'val1' };
@@ -54,7 +54,7 @@ describe('Interaction handler', () => {
         const runtime = {
           getAction: sinon.stub().returns(Action.RUNNING),
           getRequest: sinon.stub().returns({}),
-          storage: { delete: sinon.stub() },
+          storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
           trace: { addTrace: sinon.stub() },
         };
         const variables = { var1: 'val1' };
@@ -84,7 +84,7 @@ describe('Interaction handler', () => {
             getRequest: sinon.stub().returns({}),
             setAction: sinon.stub(),
             trace: { addTrace: sinon.stub() },
-            storage: { delete: sinon.stub() },
+            storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
           };
           const variables = { var1: 'val1' };
           const handler = InteractionHandler(utils as any);
@@ -111,7 +111,7 @@ describe('Interaction handler', () => {
               getRequest: sinon.stub().returns({}),
               setAction: sinon.stub(),
               trace: { addTrace: sinon.stub() },
-              storage: { delete: sinon.stub() },
+              storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
             };
             const variables = { var1: 'val1' };
             const handler = InteractionHandler(utils as any);
@@ -138,7 +138,7 @@ describe('Interaction handler', () => {
               setAction: sinon.stub(),
               getRequest: sinon.stub().returns({}),
               trace: { addTrace: sinon.stub() },
-              storage: { delete: sinon.stub() },
+              storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
             };
             const variables = { var1: 'val1' };
             const handler = InteractionHandler(utils as any);
@@ -166,7 +166,7 @@ describe('Interaction handler', () => {
             getAction: sinon.stub().returns(Action.REQUEST),
             setAction: sinon.stub(),
             getRequest: sinon.stub().returns({}),
-            storage: { delete: sinon.stub() },
+            storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
           };
           const variables = { var1: 'val1' };
           const handler = InteractionHandler(utils as any);
@@ -190,7 +190,7 @@ describe('Interaction handler', () => {
             getAction: sinon.stub().returns(Action.REQUEST),
             setAction: sinon.stub(),
             getRequest: sinon.stub().returns({}),
-            storage: { delete: sinon.stub() },
+            storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
           };
           const variables = { var1: 'val1' };
           const handler = InteractionHandler(utils as any);
@@ -216,7 +216,7 @@ describe('Interaction handler', () => {
             getAction: sinon.stub().returns(Action.REQUEST),
             setAction: sinon.stub(),
             getRequest: sinon.stub().returns({}),
-            storage: { delete: sinon.stub() },
+            storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
           };
           const variables = { var1: 'val1' };
           const handler = InteractionHandler(utils as any);
@@ -243,7 +243,7 @@ describe('Interaction handler', () => {
             getAction: sinon.stub().returns(Action.REQUEST),
             setAction: sinon.stub(),
             getRequest: sinon.stub().returns({}),
-            storage: { delete: sinon.stub() },
+            storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
           };
           const variables = { var1: 'val1' };
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(output);
@@ -264,7 +264,7 @@ describe('Interaction handler', () => {
               setAction: sinon.stub(),
               trace: { addTrace: sinon.stub() },
               getRequest: sinon.stub().returns({}),
-              storage: { delete: sinon.stub() },
+              storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
             };
             const variables = { var1: 'val1' };
             const handler = InteractionHandler(utils as any);
@@ -289,7 +289,7 @@ describe('Interaction handler', () => {
               setAction: sinon.stub(),
               trace: { addTrace: sinon.stub() },
               getRequest: sinon.stub().returns({}),
-              storage: { delete: sinon.stub() },
+              storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
             };
             const variables = { var1: 'val1' };
             const handler = InteractionHandler(utils as any);
@@ -325,7 +325,7 @@ describe('Interaction handler', () => {
               setAction: sinon.stub(),
               trace: { addTrace: sinon.stub() },
               getRequest: sinon.stub().returns({}),
-              storage: { delete: sinon.stub() },
+              storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
             };
             const variables = { var1: 'val1' };
             const handler = InteractionHandler(utils as any);
@@ -350,7 +350,7 @@ describe('Interaction handler', () => {
               setAction: sinon.stub(),
               trace: { addTrace: sinon.stub() },
               getRequest: sinon.stub().returns({}),
-              storage: { delete: sinon.stub() },
+              storage: { delete: sinon.stub(), get: sinon.stub(), set: sinon.stub() },
             };
             const variables = { var1: 'val1' };
             const handler = InteractionHandler(utils as any);

--- a/tests/runtime/lib/Runtime/cycleHandler.unit.ts
+++ b/tests/runtime/lib/Runtime/cycleHandler.unit.ts
@@ -49,6 +49,7 @@ describe('Runtime cycleHandler unit tests', () => {
       end: sinon.stub(),
       hasEnded: sinon.stub().returns(true),
       getAction: sinon.stub().returns(Action.RUNNING),
+      storage: { set: sinon.stub() },
     };
     const node = { id: nodeID };
     const program = { getNode: sinon.stub().returns(node) };


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2489**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

This fixes an infinite loop when a choice entity is the same as the intent it is going to.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

We store the last visited node on every runtime loop. This enables us to check that we aren't trying to handle the interaction that we just triggered a GOTO from.
