### PR TITLE
[Merged by Bors] - fix: remove state from transcript (VF-2873)

### DIFF
--- a/lib/clients/analytics.ts
+++ b/lib/clients/analytics.ts
@@ -80,7 +80,6 @@ export class AnalyticsSystem extends AbstractClient {
       request: {
         session_id: sessionId,
         version_id: versionID,
-        state: metadata.state,
         timestamp: timestamp.toISOString(),
         metadata: {
           end: metadata.end,

--- a/lib/clients/ingest-client.ts
+++ b/lib/clients/ingest-client.ts
@@ -1,7 +1,5 @@
 import Axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 
-import { State } from '@/runtime/lib/Runtime';
-
 export enum Event {
   INTERACT = 'interact',
   TURN = 'turn',
@@ -18,7 +16,6 @@ export interface TurnBody<T> {
   request: {
     version_id?: string;
     session_id?: string;
-    state?: State;
     timestamp?: string;
     metadata?: T;
   };


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2873**

### Brief description. What is this change?

As part of the test of removing the `state` column from `transcripts_turns` I'm deleting the entire column on my dev postgres, removing this write reference, and testing that everything still works fine.
