### PR TITLE
[Merged by Bors] - fix: entities not required (VF-000)

### DIFF
--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -62,10 +62,15 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
       throw new Error('context versionID not defined');
     }
 
-    if (context.request?.type === BaseRequest.RequestType.LAUNCH && context.state) {
+    if (context.request && BaseRequest.isLaunchRequest(context.request) && context.state) {
       context.state.stack = [];
       context.state.storage = {};
       context.request = null;
+    }
+
+    // sanitize incoming intents
+    if (context.request && BaseRequest.isIntentRequest(context.request) && !context.request.payload.entities) {
+      context.request.payload.entities = [];
     }
 
     // cache per interaction (save version call during request/response cycle)


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?
Zoran noticed that if you send an intent request with no `entities` array in the `payload`. 
Technically it is required, but we want to make it robust as possible for the user.

Funky behavior happens because our typeguard requires array be identified: https://github.com/voiceflow/general-runtime/blob/01446bc108b9f67e65b208a889acfd28db269329/lib/services/runtime/types.ts#L13

![image](https://user-images.githubusercontent.com/5643574/158216621-1d742717-fe65-4f9c-93b8-a7fbc9c15583.png)

I've added a quick check to sanitize the incoming request, admittedly this isn't the best spot and we could have a dedicated adapter layer to fix incoming request. But that might be a bigger overhaul.