### PR TITLE
fix: use lodash get for variable retrieval (VF-000)

### DIFF
--- a/tests/runtime/lib/Handlers/api/utils.unit.ts
+++ b/tests/runtime/lib/Handlers/api/utils.unit.ts
@@ -10,6 +10,39 @@ import * as APIUtils from '@/runtime/lib/Handlers/api/utils';
 import { baseData, baseOptions } from './fixture';
 
 describe('Handlers api utils unit tests', () => {
+  describe('getVariableAtJSONPath', () => {
+    it('retrieves value at json path', () => {
+      const data = {
+        a: {
+          b: 422,
+        },
+      };
+      expect(APIUtils.getVariableAtJSONPath(data, 'a.b')).to.equal(422);
+    });
+
+    it('retrieves value at json path with array accessor', () => {
+      const data = {
+        a: {
+          b: [
+            {
+              c: '00001234',
+            },
+          ],
+        },
+      };
+      expect(APIUtils.getVariableAtJSONPath(data, 'a.b[0].c')).to.equal('00001234');
+    });
+
+    it('retrieves value at json path with random array', () => {
+      const data = {
+        a: {
+          b: ['hello'],
+        },
+      };
+      expect(APIUtils.getVariableAtJSONPath(data, 'a.b[{random}]')).to.equal('hello');
+    });
+  });
+
   describe('makeAPICall', () => {
     let validateIPStub: sinon.SinonStub;
     let axiosAdaptorStub: sinon.SinonStub;
@@ -50,11 +83,11 @@ describe('Handlers api utils unit tests', () => {
         mapping: [
           {
             var: 'var1',
-            path: 'a.b[0].c',
+            path: 'response.a.b[0].c',
           },
           {
             var: 'var2',
-            path: 'a.d',
+            path: 'response.a.d',
           },
         ],
       } as any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2272,9 +2272,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001245:
-  version "1.0.30001247"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001247.tgz#105be7a8fb30cdd303275e769a9dfb87d4b3577a"
-  integrity sha512-4rS7co+7+AoOSPRPOPUt5/GdaqZc0EsUpWk66ofE3HJTAajUK2Ss2VwoNzVN69ghg8lYYlh0an0Iy4LIHHo9UQ==
+  version "1.0.30001319"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz"
+  integrity sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==
 
 chai-as-promised@^7.1.1:
   version "7.1.1"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

We're using a custom json path retrieval function to find responses and assign them to a variable. We're also converting things that look like a number into a number.

This PR removes all the existing custom path code in favour of using `toPath` + `get` from lodash. We cannot use `get` directly since we support random array access via `[{random}]`.
It also removes the attempted number parsing. APIs should return numbers if they want numbers back. Some customers are returning values like `"00001234"`, which we turn into `1234` which is incorrect for their case.

There's a [ticket to rewrite](https://voiceflow.atlassian.net/browse/VF-2744) all of this, which needs to be done too.