### PR TITLE
[Merged by Bors] - fix: api debug messages (VF-3263)

### DIFF
--- a/runtime/lib/Handlers/api/index.ts
+++ b/runtime/lib/Handlers/api/index.ts
@@ -29,14 +29,17 @@ const APIHandler = (config: ResponseConfig = {}): Handler<BaseNode.Integration.N
 
       // if custom api returned error http status nextId to fail port, otherwise success
       if (data.response.status >= 400) {
-        runtime.trace.debug(`API call returned status code ${data.response.status}`, BaseNode.NodeType.API);
+        runtime.trace.debug(
+          `API call error - \n${safeJSONStringify({ status: data.response.status, data: data.response.data })}`,
+          BaseNode.NodeType.API
+        );
         nextId = node.fail_id ?? null;
       } else {
         runtime.trace.debug('API call successfully triggered', BaseNode.NodeType.API);
         nextId = node.success_id ?? null;
       }
     } catch (error) {
-      runtime.trace.debug(`API call failed - Error: \n${safeJSONStringify(error.response?.data || error)}`, BaseNode.NodeType.API);
+      runtime.trace.debug(`API call failed - Error: \n${safeJSONStringify(error?.message || error)}`, BaseNode.NodeType.API);
       nextId = node.fail_id ?? null;
     }
 

--- a/tests/runtime/lib/Handlers/api.unit.ts
+++ b/tests/runtime/lib/Handlers/api.unit.ts
@@ -86,7 +86,7 @@ describe('API Handler unit tests', () => {
       const variables = { getState: sinon.stub().returns({}), merge: sinon.stub() };
 
       expect(await apiHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
-      expect(runtime.trace.debug.args).to.eql([[`API call returned status code ${resultVariables.data.response.status}`, BaseNode.NodeType.API]]);
+      expect(runtime.trace.debug.args).to.eql([['API call error - \n{"status":401}', BaseNode.NodeType.API]]);
     });
 
     it('error status with fail_id', async () => {
@@ -99,7 +99,7 @@ describe('API Handler unit tests', () => {
       const variables = { getState: sinon.stub().returns({}), merge: sinon.stub() };
 
       expect(await apiHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.fail_id);
-      expect(runtime.trace.debug.args).to.eql([[`API call returned status code ${resultVariables.data.response.status}`, BaseNode.NodeType.API]]);
+      expect(runtime.trace.debug.args).to.eql([['API call error - \n{"status":401}', BaseNode.NodeType.API]]);
     });
 
     describe('fails', () => {
@@ -113,7 +113,7 @@ describe('API Handler unit tests', () => {
         const variables = { getState: sinon.stub().returns({}) };
 
         expect(await apiHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
-        expect(runtime.trace.debug.args).to.eql([[`API call failed - Error: \n"${axiosErr.response.data}"`, BaseNode.NodeType.API]]);
+        expect(runtime.trace.debug.args).to.eql([[`API call failed - Error: \n${JSON.stringify(axiosErr)}`, BaseNode.NodeType.API]]);
         expect(makeAPICallStub.args).to.eql([[AGENT_ACTION_DATA, runtime, {}]]);
       });
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3263**

### Brief description. What is this change?
So it turns out when you `stringify` a `VError` you actually don't get the error message, but everything else, which is kinda stupid. 

BEFORE:
![Screen Shot 2022-04-16 at 12 35 07 AM](https://user-images.githubusercontent.com/5643574/163676644-717b2998-7dd4-49b8-a0d8-bffd04151e47.png)


AFTER:
![Screen Shot 2022-04-16 at 12 31 32 AM](https://user-images.githubusercontent.com/5643574/163661454-767cd019-57c7-4630-9e59-4d48e1adaf64.png)

I also updated the debug message so if you get a >400 response on the API call, we show the body too.