### PR TITLE
[Merged by Bors] - fix: replace variables [bugfix] (VF-3384)

### DIFF
--- a/lib/services/runtime/handlers/visual.ts
+++ b/lib/services/runtime/handlers/visual.ts
@@ -13,7 +13,7 @@ const VisualHandler: HandlerFactory<BaseNode.Visual.Node, typeof handlerUtils> =
   handle: (node, runtime, variables) => {
     runtime.trace.debug('__visual__ - entered', BaseNode.NodeType.VISUAL);
 
-    if (node.data.visualType === BaseNode.Visual.VisualType.APL) {
+    if (node.data.visualType === BaseNode.Visual.VisualType.APL && node.data.imageURL) {
       node.data.imageURL = utils.replaceVariables(node.data.imageURL, variables.getState());
     }
 

--- a/lib/services/runtime/handlers/visual.ts
+++ b/lib/services/runtime/handlers/visual.ts
@@ -1,12 +1,21 @@
 import { BaseNode, BaseTrace } from '@voiceflow/base-types';
+import { replaceVariables } from '@voiceflow/common';
 
 import { HandlerFactory } from '@/runtime';
 
-const VisualHandler: HandlerFactory<BaseNode.Visual.Node> = () => ({
+const handlerUtils = {
+  replaceVariables,
+};
+
+const VisualHandler: HandlerFactory<BaseNode.Visual.Node, typeof handlerUtils> = (utils) => ({
   canHandle: (node) => node.type === BaseNode.NodeType.VISUAL && !!node.data,
 
-  handle: (node, runtime) => {
+  handle: (node, runtime, variables) => {
     runtime.trace.debug('__visual__ - entered', BaseNode.NodeType.VISUAL);
+
+    if (node.data.visualType === BaseNode.Visual.VisualType.APL) {
+      node.data.imageURL = utils.replaceVariables(node.data.imageURL, variables.getState());
+    }
 
     runtime.trace.addTrace<BaseTrace.VisualTrace>({
       type: BaseNode.Utils.TraceType.VISUAL,
@@ -17,4 +26,4 @@ const VisualHandler: HandlerFactory<BaseNode.Visual.Node> = () => ({
   },
 });
 
-export default VisualHandler;
+export default () => VisualHandler(handlerUtils);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3384**

### Brief description. What is this change?
This is quite terrible and is meant to be a temporary.
There should be no APL in the base types or as part of the prototype tool. The Alexa project should convert it into a standard visual step.

for example this is how the stream step references a MP3 URL: https://github.com/voiceflow/general-runtime/blob/4e455014623d48d788339953af62c4de2260c367/lib/services/runtime/handlers/stream.ts#L18

Once this is merged I'll come up with a larger refactor to consoliate the visual types in general