### PR TITLE
[Merged by Bors] - feat: first batch of steps for runtime logging (VF-3554)

### DIFF
--- a/lib/services/runtime/handlers/speak.ts
+++ b/lib/services/runtime/handlers/speak.ts
@@ -1,4 +1,4 @@
-import { BaseNode } from '@voiceflow/base-types';
+import { BaseNode, RuntimeLogs } from '@voiceflow/base-types';
 import { replaceVariables, sanitizeVariables } from '@voiceflow/common';
 import { VoiceflowNode } from '@voiceflow/voiceflow-types';
 import _ from 'lodash';
@@ -35,6 +35,7 @@ const SpeakHandler: HandlerFactory<VoiceflowNode.Speak.Node> = () => ({
         type: BaseNode.Utils.TraceType.SPEAK,
         payload: { message: output, type: BaseNode.Speak.TraceSpeakType.MESSAGE },
       });
+      runtime.debugLogging.recordStepLog(RuntimeLogs.Kinds.StepLogKind.SPEAK, node, { text: output });
     }
 
     return node.nextId ?? null;

--- a/runtime/lib/Handlers/end.ts
+++ b/runtime/lib/Handlers/end.ts
@@ -4,7 +4,7 @@ import { HandlerFactory } from '@/runtime/lib/Handler';
 
 const EndHandler: HandlerFactory<BaseNode.Exit.Node> = () => ({
   canHandle: (node) => !!node.end,
-  handle: (node, runtime, _store): null => {
+  handle: (node, runtime): null => {
     runtime.stack.top().setNodeID(null);
 
     // pop all program frames that are already ended

--- a/runtime/lib/Handlers/end.ts
+++ b/runtime/lib/Handlers/end.ts
@@ -1,20 +1,29 @@
-import { BaseNode, BaseTrace } from '@voiceflow/base-types';
+import { BaseNode, BaseTrace, RuntimeLogs } from '@voiceflow/base-types';
 
 import { HandlerFactory } from '@/runtime/lib/Handler';
 
 const EndHandler: HandlerFactory<BaseNode.Exit.Node> = () => ({
   canHandle: (node) => !!node.end,
-  handle: (_, runtime): null => {
+  handle: (node, runtime, _store): null => {
     runtime.stack.top().setNodeID(null);
 
     // pop all program frames that are already ended
     while (!runtime.stack.isEmpty() && !runtime.stack.top().getNodeID()) {
       runtime.stack.pop();
     }
-
     runtime.turn.set('end', true);
     runtime.trace.addTrace<BaseTrace.ExitTrace>({ type: BaseNode.Utils.TraceType.END, payload: null });
     runtime.trace.debug('exiting session - saving location/resolving stack', BaseNode.NodeType.EXIT);
+
+    const shouldLogVerbose = runtime.debugLogging.shouldLog(RuntimeLogs.LogLevel.VERBOSE);
+    runtime.debugLogging.recordStepLog(
+      RuntimeLogs.Kinds.StepLogKind.EXIT,
+      node,
+      {
+        state: shouldLogVerbose ? runtime.getFinalState() : null,
+      },
+      shouldLogVerbose ? RuntimeLogs.LogLevel.VERBOSE : RuntimeLogs.LogLevel.INFO
+    );
 
     runtime.end();
 

--- a/runtime/lib/Handlers/random.ts
+++ b/runtime/lib/Handlers/random.ts
@@ -1,5 +1,4 @@
 import { BaseNode, RuntimeLogs } from '@voiceflow/base-types';
-import assert from 'assert';
 
 import { S } from '@/runtime/lib/Constants';
 import { HandlerFactory } from '@/runtime/lib/Handler';

--- a/runtime/lib/Handlers/random.ts
+++ b/runtime/lib/Handlers/random.ts
@@ -59,10 +59,9 @@ const randomHandler: HandlerFactory<BaseNode.Random.Node> = () => ({
       nextId = node.nextIds[Math.floor(Math.random() * node.nextIds.length)];
     }
 
-    assert(nextId);
     runtime.trace.debug('going down random path', BaseNode.NodeType.RANDOM);
     runtime.debugLogging.recordStepLog(RuntimeLogs.Kinds.StepLogKind.RANDOM, node, {
-      path: DebugLogging.createPathReference(program.getNode(nextId)!),
+      path: nextId ? DebugLogging.createPathReference(program.getNode(nextId)!) : null,
     });
 
     return nextId;

--- a/runtime/lib/Handlers/start.ts
+++ b/runtime/lib/Handlers/start.ts
@@ -1,4 +1,4 @@
-import { BaseNode } from '@voiceflow/base-types';
+import { BaseNode, RuntimeLogs } from '@voiceflow/base-types';
 
 import { HandlerFactory } from '@/runtime/lib/Handler';
 
@@ -6,6 +6,7 @@ const StartHandler: HandlerFactory<BaseNode.Start.Node> = () => ({
   canHandle: (node) => (Object.keys(node).length === 2 || node.type === 'start') && !!node.nextId,
   handle: (node, runtime) => {
     runtime.trace.debug('beginning flow', BaseNode.NodeType.START);
+    runtime.debugLogging.recordStepLog(RuntimeLogs.Kinds.StepLogKind.START, node, {});
     return node.nextId ?? null;
   },
 });

--- a/runtime/lib/Runtime/DebugLogging/utils.ts
+++ b/runtime/lib/Runtime/DebugLogging/utils.ts
@@ -1,4 +1,7 @@
 import { BaseNode, RuntimeLogs, Trace } from '@voiceflow/base-types';
+import { Environment } from '@voiceflow/common';
+
+import CONFIG from '@/config';
 
 export const DEFAULT_LOG_LEVEL = RuntimeLogs.LogLevel.INFO;
 
@@ -7,7 +10,16 @@ export const createLogTrace = (log: RuntimeLogs.Log): Trace.LogTrace => ({
   payload: log,
 });
 
-export const getISO8601Timestamp = (): RuntimeLogs.Iso8601Timestamp => new Date().toISOString();
+export const getISO8601Timestamp: () => RuntimeLogs.Iso8601Timestamp =
+  CONFIG.NODE_ENV === Environment.TEST
+    ? () => {
+        const date = new Date();
+        // A semi-hacky way to avoid the need to mock the timers API in tests
+        // Our tests run fast but sometimes a 1 millisecond difference can cause an assertion to fail
+        date.setMilliseconds(0);
+        return date.toISOString();
+      }
+    : () => new Date().toISOString();
 
 export type AddTraceFn = (trace: BaseNode.Utils.BaseTraceFrame) => void;
 

--- a/tests/lib/services/runtime/handlers/speak.unit.ts
+++ b/tests/lib/services/runtime/handlers/speak.unit.ts
@@ -1,7 +1,7 @@
+import { BaseNode } from '@voiceflow/base-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { BaseNode } from '@/../libs/packages/base-types/build/common';
 import SpeakHandler from '@/lib/services/runtime/handlers/speak';
 import { FrameType } from '@/lib/services/runtime/types';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';

--- a/tests/lib/services/runtime/handlers/speak.unit.ts
+++ b/tests/lib/services/runtime/handlers/speak.unit.ts
@@ -1,8 +1,11 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import { BaseNode } from '@/../libs/packages/base-types/build/common';
 import SpeakHandler from '@/lib/services/runtime/handlers/speak';
 import { FrameType } from '@/lib/services/runtime/types';
+import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
+import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
 describe('speak handler unit tests', async () => {
   const speakHandler = SpeakHandler();
@@ -30,6 +33,8 @@ describe('speak handler unit tests', async () => {
       const node = {
         nextId: 'next-id',
         random_speak: ['one', 'two', 'three'],
+        id: 'step-id',
+        type: BaseNode.NodeType.SPEAK,
       };
 
       const topFrame = {
@@ -39,18 +44,50 @@ describe('speak handler unit tests', async () => {
         trace: { addTrace: sinon.stub() },
         storage: { produce: sinon.stub() },
         stack: { top: sinon.stub().returns(topFrame) },
+        debugLogging: null as unknown as DebugLogging,
       };
+      runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
+
       const variables = { getState: sinon.stub().returns({}) };
 
       expect(speakHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.nextId);
       expect(topFrame.storage.set.args[0][0]).to.eql(FrameType.OUTPUT);
       // output is one of the options in random_speak
+      const spokenPhrase = runtime.trace.addTrace.args[0][0].payload.message as string;
       expect(node.random_speak.includes(topFrame.storage.set.args[0][1])).to.eql(true);
+      expect(runtime.trace.addTrace.args).to.eql([
+        [
+          {
+            payload: {
+              message: spokenPhrase,
+              type: 'message',
+            },
+            type: 'speak',
+          },
+        ],
+        [
+          {
+            payload: {
+              kind: 'step.speak',
+              level: 'info',
+              message: {
+                componentName: 'speak',
+                stepID: 'step-id',
+                text: spokenPhrase,
+              },
+              timestamp: getISO8601Timestamp(),
+            },
+            type: 'log',
+          },
+        ],
+      ]);
     });
 
     it('speak', () => {
       const node = {
         speak: 'random {var} or {var1}',
+        id: 'step-id',
+        type: BaseNode.NodeType.SPEAK,
       };
 
       const topFrame = {
@@ -60,7 +97,10 @@ describe('speak handler unit tests', async () => {
         trace: { addTrace: sinon.stub() },
         storage: { produce: sinon.stub() },
         stack: { top: sinon.stub().returns(topFrame) },
+        debugLogging: null as unknown as DebugLogging,
       };
+      runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
+
       const varState = { var: 1.234, var1: 'here' };
       const variables = { getState: sinon.stub().returns(varState) };
 
@@ -69,6 +109,21 @@ describe('speak handler unit tests', async () => {
       expect(topFrame.storage.set.args).to.eql([[FrameType.OUTPUT, 'random 1.23 or here']]);
       expect(runtime.trace.addTrace.args).to.eql([
         [{ type: 'speak', payload: { message: 'random 1.23 or here', type: 'message' } }],
+        [
+          {
+            type: 'log',
+            payload: {
+              kind: 'step.speak',
+              level: 'info',
+              message: {
+                componentName: 'speak',
+                stepID: 'step-id',
+                text: 'random 1.23 or here',
+              },
+              timestamp: getISO8601Timestamp(),
+            },
+          },
+        ],
       ]);
     });
 

--- a/tests/runtime/lib/Handlers/set.unit.ts
+++ b/tests/runtime/lib/Handlers/set.unit.ts
@@ -1,10 +1,12 @@
-import { BaseNode } from '@voiceflow/base-types';
+import { BaseNode, RuntimeLogs } from '@voiceflow/base-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
 import SetHandler from '@/runtime/lib/Handlers/set';
 import * as Utils from '@/runtime/lib/Handlers/utils/shuntingYard';
 import { EventType } from '@/runtime/lib/Lifecycle';
+import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
+import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
 describe('setHandler unit tests', () => {
   const setHandler = SetHandler();
@@ -41,10 +43,32 @@ describe('setHandler unit tests', () => {
           { variable: 'v3', expression: 'v3-expression' },
         ],
         nextId: 'next-id',
+        id: 'step-id',
+        type: BaseNode.NodeType.SET,
       };
-      const runtime = { trace: { debug: sinon.stub() }, callEvent: sinon.stub() };
+      const runtime = {
+        trace: { debug: sinon.stub(), addTrace: sinon.stub() },
+        callEvent: sinon.stub(),
+        debugLogging: null as unknown as DebugLogging,
+      };
+      runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variablesState = 'variables-state';
-      const variables = { getState: sinon.stub().returns(variablesState), set: sinon.stub() };
+      const variables = {
+        getState: sinon.stub().returns(variablesState),
+        get: (variable: string) => {
+          switch (variable) {
+            case 'v1':
+              return 'v1-value';
+            case 'v2':
+              return 'v2-value';
+            case 'v3':
+              return 'v3-value';
+            default:
+              return undefined;
+          }
+        },
+        set: sinon.stub(),
+      };
 
       expect(await setHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.nextId);
       expect(shuntingYardStub.args).to.eql([
@@ -63,6 +87,27 @@ describe('setHandler unit tests', () => {
         ['setting `{v2}`  \nevaluating `v2-expression` to `undefined`', BaseNode.NodeType.SET],
         ['setting `{v3}`  \nevaluating `v3-expression` to `5`', BaseNode.NodeType.SET],
       ]);
+      expect(runtime.trace.addTrace.args).to.eql([
+        [
+          {
+            type: 'log',
+            payload: {
+              kind: 'step.set',
+              message: {
+                changedVariables: {
+                  v1: { before: 'v1-value', after: null },
+                  v2: { before: 'v2-value', after: null },
+                  v3: { before: 'v3-value', after: 5 },
+                },
+                stepID: 'step-id',
+                componentName: RuntimeLogs.Kinds.StepLogKind.SET,
+              },
+              level: RuntimeLogs.LogLevel.INFO,
+              timestamp: getISO8601Timestamp(),
+            },
+          },
+        ],
+      ]);
       expect(runtime.callEvent.callCount).to.eql(1);
       expect(runtime.callEvent.args[0][0]).to.eql(EventType.handlerDidCatch);
       expect(runtime.callEvent.args[0][1].error.toString()).to.eql('Error: No Variable Defined');
@@ -71,10 +116,35 @@ describe('setHandler unit tests', () => {
     it('without nextId', async () => {
       const node = {
         sets: [{ expression: '' }],
+        id: 'step-id',
+        type: BaseNode.NodeType.SET,
       };
-      const runtime = { trace: { debug: sinon.stub() }, callEvent: sinon.stub() };
+      const runtime = {
+        trace: { debug: sinon.stub(), addTrace: sinon.stub() },
+        callEvent: sinon.stub(),
+        debugLogging: null as unknown as DebugLogging,
+      };
+      runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
 
       expect(await setHandler.handle(node as any, runtime as any, null as any, null as any)).to.eql(null);
+
+      expect(runtime.trace.addTrace.args).to.eql([
+        [
+          {
+            type: 'log',
+            payload: {
+              kind: 'step.set',
+              message: {
+                changedVariables: {},
+                stepID: 'step-id',
+                componentName: RuntimeLogs.Kinds.StepLogKind.SET,
+              },
+              level: RuntimeLogs.LogLevel.INFO,
+              timestamp: getISO8601Timestamp(),
+            },
+          },
+        ],
+      ]);
     });
   });
 });

--- a/tests/runtime/lib/Handlers/start.unit.ts
+++ b/tests/runtime/lib/Handlers/start.unit.ts
@@ -1,8 +1,10 @@
-import { BaseNode } from '@voiceflow/base-types';
+import { BaseNode, RuntimeLogs, Trace } from '@voiceflow/base-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
 import StartHandler from '@/runtime/lib/Handlers/start';
+import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
+import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
 describe('startHandler unit tests', () => {
   const startHandler = StartHandler();
@@ -24,17 +26,59 @@ describe('startHandler unit tests', () => {
 
   describe('handle', () => {
     it('nextId', () => {
-      const node = { nextId: 'next-id' };
-      const runtime = { trace: { debug: sinon.stub() } };
+      const node = { id: 'step-id', type: BaseNode.NodeType.START, nextId: 'next-id' };
+      const runtime = {
+        trace: { debug: sinon.stub(), addTrace: sinon.stub() },
+        debugLogging: null as unknown as DebugLogging,
+      };
+      runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
+
       expect(startHandler.handle(node as any, runtime as any, null as any, null as any)).to.eql(node.nextId);
       expect(runtime.trace.debug.args).to.eql([['beginning flow', BaseNode.NodeType.START]]);
+      expect(runtime.trace.addTrace.args).to.eql([
+        [
+          {
+            type: Trace.TraceType.LOG,
+            payload: {
+              kind: 'step.start',
+              message: {
+                stepID: 'step-id',
+                componentName: RuntimeLogs.Kinds.StepLogKind.START,
+              },
+              level: RuntimeLogs.LogLevel.INFO,
+              timestamp: getISO8601Timestamp(),
+            },
+          },
+        ],
+      ]);
     });
 
     it('no nextId', () => {
-      const node = {};
-      const runtime = { trace: { debug: sinon.stub() } };
+      const node = { id: 'step-id', type: BaseNode.NodeType.START };
+      const runtime = {
+        trace: { debug: sinon.stub(), addTrace: sinon.stub() },
+        debugLogging: null as unknown as DebugLogging,
+      };
+      runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
+
       expect(startHandler.handle(node as any, runtime as any, null as any, null as any)).to.eql(null);
       expect(runtime.trace.debug.args).to.eql([['beginning flow', BaseNode.NodeType.START]]);
+      expect(runtime.trace.addTrace.args).to.eql([
+        [
+          {
+            type: Trace.TraceType.LOG,
+            payload: {
+              kind: 'step.start',
+              message: {
+                stepID: 'step-id',
+                componentName: RuntimeLogs.Kinds.StepLogKind.START,
+              },
+              level: RuntimeLogs.LogLevel.INFO,
+              timestamp: getISO8601Timestamp(),
+            },
+          },
+        ],
+      ]);
     });
   });
 });


### PR DESCRIPTION
**Fixes or implements VF-3554**
**Fixes or implements VF-3819**
**Fixes or implements VF-3820**
**Fixes or implements VF-3827**
**Fixes or implements VF-3929**
**Fixes or implements VF-3830**

### Brief description. What is this change?

adds runtime logging for the following steps:
- end step
- set step (v1)
- set step (v2)
- start step
- random step
- speak step

### Related PRs

- https://github.com/voiceflow/libs/pull/302

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written