### PR TITLE
feat: second batch of steps for runtime logging (VF-3554)

### DIFF
--- a/runtime/lib/Handlers/flow.ts
+++ b/runtime/lib/Handlers/flow.ts
@@ -1,14 +1,15 @@
-import { BaseNode } from '@voiceflow/base-types';
+import { BaseNode, RuntimeLogs } from '@voiceflow/base-types';
 
 import { S } from '@/runtime/lib/Constants';
 import { HandlerFactory } from '@/runtime/lib/Handler';
 import Frame from '@/runtime/lib/Runtime/Stack/Frame';
 
+import DebugLogging from '../Runtime/DebugLogging';
 import { mapStores } from '../Runtime/utils/variables';
 
 const FlowHandler: HandlerFactory<BaseNode.Flow.Node> = () => ({
   canHandle: (node) => !!node.diagram_id,
-  handle: (node, runtime, variables) => {
+  handle: (node, runtime, variables, program) => {
     if (!node.diagram_id) {
       return node.nextId || null;
     }
@@ -32,6 +33,10 @@ const FlowHandler: HandlerFactory<BaseNode.Flow.Node> = () => ({
     runtime.stack.push(newFrame);
 
     runtime.trace.debug(`entering flow \`${newFrame.getName() || newFrame.getProgramID()}\``, BaseNode.NodeType.FLOW);
+    runtime.debugLogging.recordStepLog(RuntimeLogs.Kinds.StepLogKind.FLOW, node, {
+      before: DebugLogging.createFlowReference(topFrame),
+      after: DebugLogging.createFlowReference(newFrame),
+    });
 
     return null;
   },

--- a/runtime/lib/Handlers/ifV2.ts
+++ b/runtime/lib/Handlers/ifV2.ts
@@ -1,8 +1,9 @@
-import { BaseNode } from '@voiceflow/base-types';
+import { BaseNode, RuntimeLogs } from '@voiceflow/base-types';
 
 import Handler, { HandlerFactory } from '@/runtime/lib/Handler';
 
 import { TurnType } from '../Constants/flags';
+import DebugLogging from '../Runtime/DebugLogging';
 import CodeHandler from './code';
 
 export interface IfV2Options {
@@ -71,12 +72,24 @@ const IfV2Handler: HandlerFactory<BaseNode.IfV2.Node, IfV2Options> = ({ _v1 }) =
 
     if (outputPortIndex !== -1) {
       runtime.trace.debug(`condition matched - taking path ${outputPortIndex + 1}`, BaseNode.NodeType.IF_V2);
-      return node.paths[outputPortIndex].nextID;
+      const pathID = node.paths[outputPortIndex].nextID;
+
+      runtime.debugLogging.recordStepLog(RuntimeLogs.Kinds.StepLogKind.CONDITION, node, {
+        path: pathID ? DebugLogging.createPathReference(program.getNode(pathID)!) : null,
+      });
+
+      return pathID;
     }
 
     runtime.trace.debug('no conditions matched - taking else path', BaseNode.NodeType.IF_V2);
 
-    return node.payload.elseId || null;
+    const pathID = node.payload.elseId || null;
+
+    runtime.debugLogging.recordStepLog(RuntimeLogs.Kinds.StepLogKind.CONDITION, node, {
+      path: pathID ? DebugLogging.createPathReference(program.getNode(pathID)!) : null,
+    });
+
+    return pathID;
   },
 });
 

--- a/runtime/lib/Runtime/DebugLogging/index.ts
+++ b/runtime/lib/Runtime/DebugLogging/index.ts
@@ -1,6 +1,7 @@
 import { BaseModels, BaseNode, RuntimeLogs } from '@voiceflow/base-types';
 
 import Runtime from '..';
+import { Frame } from '../Stack';
 import Trace from '../Trace';
 import { TraceLogBuffer } from './traceLogBuffer';
 import { AddTraceFn, DEFAULT_LOG_LEVEL, getISO8601Timestamp } from './utils';
@@ -22,6 +23,13 @@ export default class DebugLogging {
       // The fallback here deviates from the spec but is necessary to avoid simply throwing an error when a path leads
       // to a node that isn't mappable to a standard component name
       componentName: RuntimeLogs.Kinds.nodeTypeToStepLogKind(node.type as BaseNode.NodeType) ?? (node.type as any),
+    };
+  }
+
+  public static createFlowReference(frame: Frame): RuntimeLogs.FlowReference {
+    return {
+      name: frame.getName() ?? null,
+      programID: frame.getProgramID(),
     };
   }
 

--- a/tests/lib/services/runtime/handlers/text.unit.ts
+++ b/tests/lib/services/runtime/handlers/text.unit.ts
@@ -1,7 +1,10 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import { BaseNode, RuntimeLogs } from '@/../libs/packages/base-types/build/common';
 import { TextHandler } from '@/lib/services/runtime/handlers/text';
+import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
+import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
 describe('text handler unit tests', async () => {
   afterEach(() => sinon.restore());
@@ -34,6 +37,8 @@ describe('text handler unit tests', async () => {
       const node = {
         texts: [1, 2, 3],
         nextId: 'nextId',
+        id: 'step-id',
+        type: BaseNode.NodeType.TEXT,
       };
 
       const topStorageSet = sinon.stub();
@@ -43,7 +48,9 @@ describe('text handler unit tests', async () => {
           top: sinon.stub().returns({ storage: { set: topStorageSet } }),
         },
         trace: { addTrace: sinon.stub() },
+        debugLogging: null as unknown as DebugLogging,
       };
+      runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
 
       const variables = { getState: sinon.stub().returns('vars') };
 
@@ -51,6 +58,22 @@ describe('text handler unit tests', async () => {
       expect(textHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.nextId);
       expect(runtime.trace.addTrace.args).to.eql([
         [{ type: 'text', payload: { slate: newSlate, message: 'plainText' } }],
+        [
+          {
+            type: 'log',
+            payload: {
+              kind: 'step.text',
+              level: RuntimeLogs.LogLevel.INFO,
+              message: {
+                stepID: 'step-id',
+                componentName: RuntimeLogs.Kinds.StepLogKind.TEXT,
+                plainContent: 'plainText',
+                richContent: newSlate,
+              },
+              timestamp: getISO8601Timestamp(),
+            },
+          },
+        ],
       ]);
       expect(variables.getState.callCount).to.eql(1);
       expect(utils._sample.args).to.eql([[node.texts]]);


### PR DESCRIPTION
**Fixes or implements VF-3554**
**Fixes or implements VF-3824**
**Fixes or implements VF-3825**
**Fixes or implements VF-3828**
**Fixes or implements VF-3832**

### Brief description. What is this change?

adds runtime logging for the following steps:

- condition step (if v1)
- condition step (if v2)
- flow step
- text step

### Related PRs

- https://github.com/voiceflow/libs/pull/305

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written