### PR TITLE
[Merged by Bors] - fix: starting from carousel step on canvas prototype (VF-3748)

### DIFF
--- a/lib/services/runtime/handlers/carousel.ts
+++ b/lib/services/runtime/handlers/carousel.ts
@@ -25,8 +25,9 @@ export const CarouselHandler: HandlerFactory<BaseNode.Carousel.Node, typeof hand
   canHandle: (node) => node.type === NodeType.CAROUSEL,
   handle: (node, runtime, variables) => {
     const defaultPath = node.nextId || null;
+    const isStartingFromCarouselStep = runtime.getAction() === Action.REQUEST && !runtime.getRequest();
 
-    if (runtime.getAction() === Action.RUNNING) {
+    if (runtime.getAction() === Action.RUNNING || isStartingFromCarouselStep) {
       const variablesMap = variables.getState();
       const sanitizedVars = utils.sanitizeVariables(variables.getState());
 

--- a/tests/lib/services/runtime/handlers/carousel.unit.ts
+++ b/tests/lib/services/runtime/handlers/carousel.unit.ts
@@ -201,6 +201,7 @@ describe('Carousel handler', () => {
 
         const runtime = {
           getAction: sinon.stub().returns(Action.REQUEST),
+          getRequest: sinon.stub().returns({}),
           trace: { addTrace: sinon.stub() },
           storage: { delete: sinon.stub() },
         };


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3748**

### Brief description. What is this change?
Currently, if we try to start from a carousel step without anything else on a block, the prototype tool would show nothing

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

So, it turns out that the first interaction with the handlers, is a request type, not a running. I had to account that case in our handler.

Our handler already handles other kind of requests, such as when you click on a button. So, to differenciate between that case, I check if request is empty or not. When we click on a button, the request will be an object with a type. I believe the request is only empty when it's the initial interaction, right?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->


