### PR TITLE
[Merged by Bors] - fix: fix a bug in the default runtime logging level used (VF-000)

### DIFF
--- a/lib/validations/runtime/debugLogging.ts
+++ b/lib/validations/runtime/debugLogging.ts
@@ -1,4 +1,5 @@
 import { Validator } from '@voiceflow/backend-utils';
+import { RuntimeLogs } from '@voiceflow/base-types';
 
 import CONFIG from '@/config';
 import { isLogLevelResolvable, resolveLogLevel } from '@/runtime/lib/Runtime/DebugLogging/utils';
@@ -13,8 +14,7 @@ export const QUERY = {
         .withMessage('must be a known log level, boolean, or undefined')
         .customSanitizer(resolveLogLevel)
     : query('logs')
-        .optional()
-        .custom(() => {
-          throw new Error('The runtime logging feature flag is not enabled');
-        }),
+        .custom((value: unknown) => value === undefined)
+        .withMessage('The runtime logging feature flag is not enabled')
+        .customSanitizer(() => RuntimeLogs.LogLevel.OFF),
 };


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

fixes a bug where this validation would only trigger when the feature flag was enabled and a value for `logs` was explicitly provided

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written