### PR TITLE
feat(renovate): delegate review permissions to renovate on its own PRs (VF-3507)

### DIFF
--- a/.github/workflows/renovate-delegate.yaml
+++ b/.github/workflows/renovate-delegate.yaml
@@ -1,0 +1,19 @@
+# Delegates reviewer permissions to Renovate on its PRs
+name: Renovatebot Bors Delegate
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  bors-delegate:
+    if: ${{ github.actor != 'renovate[bot]' }}
+    name: Bors Delegate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Bors Delegate
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: bors delegate+
+          GITHUB_TOKEN: ${{ secrets.GH_SA_TOKEN }}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3507**

### Brief description. What is this change?

This adds an action to delegate review permission to renovate[bot] on PRs that is opens.

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
