### PR TITLE
ci: added readme integration

### DIFF
--- a/.github/workflows/upload-api-spec-master.yaml
+++ b/.github/workflows/upload-api-spec-master.yaml
@@ -1,0 +1,15 @@
+name: Sync OAS to ReadMe
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: readmeio/rdme@main
+        env:
+          DAY_OF_WEEK: MASTER
+        with:
+          rdme: openapi backend/docs/openapi.yaml --key=${{ secrets.README_API_KEY }} --id=${{ secrets.README_API_DEFINITION_ID }}

--- a/.github/workflows/upload-api-spec-non-master.yaml
+++ b/.github/workflows/upload-api-spec-non-master.yaml
@@ -1,0 +1,12 @@
+name: Sync OAS to ReadMe
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: readmeio/rdme@main
+        env:
+          DAY_OF_WEEK: NONMASTER
+        with:
+          rdme: openapi backend/docs/openapi.yaml --key=${{ secrets.README_API_KEY }} --id=${{ secrets.README_API_DEFINITION_ID }}


### PR DESCRIPTION
added readme integration for openapi spec.

Two github actions have been added:
1. for master
2. for non master branches