### PR TITLE
[Merged by Bors] - fix: handle cases around WS and DM key version lookup (VF-3982)

### DIFF
--- a/backend/api/routers/interact.ts
+++ b/backend/api/routers/interact.ts
@@ -10,24 +10,20 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
   router.use(middlewares.rateLimit.verify);
 
-  router.get('/state', middlewares.rateLimit.versionConsume, middlewares.project.attachID, controllers.interact.state);
+  const commonMiddleware = [middlewares.rateLimit.versionConsume];
+  const interactMiddleware = [middlewares.project.resolveVersionAlias, ...commonMiddleware];
+  const legacyMiddleware = [
+    middlewares.project.unifyVersionID,
+    middlewares.project.resolveVersionAliasLegacy,
+    ...commonMiddleware,
+  ];
 
-  router.post('/', middlewares.rateLimit.versionConsume, middlewares.project.attachID, controllers.interact.handler);
+  router.get('/state', interactMiddleware, controllers.interact.state);
+  router.post('/', interactMiddleware, controllers.interact.handler);
 
   // Legacy 1.0.0 routes with versionID in params
-  router.get(
-    '/:versionID/state',
-    middlewares.project.unifyVersionID,
-    middlewares.rateLimit.versionConsume,
-    controllers.interact.state
-  );
-
-  router.post(
-    '/:versionID',
-    middlewares.project.unifyVersionID,
-    middlewares.rateLimit.versionConsume,
-    controllers.interact.handler
-  );
+  router.get('/:versionID/state', legacyMiddleware, controllers.interact.state);
+  router.post('/:versionID', legacyMiddleware, controllers.interact.handler);
 
   return router;
 };

--- a/backend/api/routers/interact.ts
+++ b/backend/api/routers/interact.ts
@@ -10,13 +10,9 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
   router.use(middlewares.rateLimit.verify);
 
-  const commonMiddleware = [middlewares.rateLimit.versionConsume];
-  const interactMiddleware = [middlewares.project.resolveVersionAlias, ...commonMiddleware];
-  const legacyMiddleware = [
-    middlewares.project.unifyVersionID,
-    middlewares.project.resolveVersionAliasLegacy,
-    ...commonMiddleware,
-  ];
+  const interactMiddleware = [middlewares.project.resolveVersionAlias, middlewares.rateLimit.versionConsume];
+
+  const legacyMiddleware = [middlewares.project.unifyVersionID, ...interactMiddleware];
 
   router.get('/state', interactMiddleware, controllers.interact.state);
   router.post('/', interactMiddleware, controllers.interact.handler);

--- a/backend/api/routers/state.ts
+++ b/backend/api/routers/state.ts
@@ -10,13 +10,13 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
   router.use(middlewares.rateLimit.verify);
 
-  const commonMiddleware = [middlewares.rateLimit.versionConsume, middlewares.project.attachProjectID];
-  const statefulAPIMiddleware = [middlewares.project.resolveVersionAlias, ...commonMiddleware];
-  const legacyMiddleware = [
-    middlewares.project.unifyVersionID,
-    middlewares.project.resolveVersionAliasLegacy,
-    ...commonMiddleware,
+  const statefulAPIMiddleware = [
+    middlewares.project.resolveVersionAlias,
+    middlewares.project.attachProjectID,
+    middlewares.rateLimit.versionConsume,
   ];
+
+  const legacyAPIMiddleware = [middlewares.project.unifyVersionID, ...statefulAPIMiddleware];
 
   router.post('/user/:userID/interact', statefulAPIMiddleware, controllers.stateManagement.interact);
   router.get('/user/:userID', statefulAPIMiddleware, controllers.stateManagement.get);
@@ -26,12 +26,12 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   router.patch('/user/:userID/variables', statefulAPIMiddleware, controllers.stateManagement.updateVariables);
 
   // Legacy 1.0.0 routes with versionID in params
-  router.post('/:versionID/user/:userID/interact', legacyMiddleware, controllers.stateManagement.interact);
-  router.get('/:versionID/user/:userID', legacyMiddleware, controllers.stateManagement.get);
-  router.put('/:versionID/user/:userID', legacyMiddleware, controllers.stateManagement.update);
-  router.delete('/:versionID/user/:userID', legacyMiddleware, controllers.stateManagement.delete);
-  router.post('/:versionID/user/:userID', legacyMiddleware, controllers.stateManagement.reset);
-  router.patch('/:versionID/user/:userID/variables', legacyMiddleware, controllers.stateManagement.updateVariables);
+  router.post('/:versionID/user/:userID/interact', legacyAPIMiddleware, controllers.stateManagement.interact);
+  router.get('/:versionID/user/:userID', legacyAPIMiddleware, controllers.stateManagement.get);
+  router.put('/:versionID/user/:userID', legacyAPIMiddleware, controllers.stateManagement.update);
+  router.delete('/:versionID/user/:userID', legacyAPIMiddleware, controllers.stateManagement.delete);
+  router.post('/:versionID/user/:userID', legacyAPIMiddleware, controllers.stateManagement.reset);
+  router.patch('/:versionID/user/:userID/variables', legacyAPIMiddleware, controllers.stateManagement.updateVariables);
 
   return router;
 };

--- a/backend/api/routers/state.ts
+++ b/backend/api/routers/state.ts
@@ -10,96 +10,28 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
   router.use(middlewares.rateLimit.verify);
 
-  router.post(
-    '/user/:userID/interact',
-    middlewares.rateLimit.versionConsume,
-    middlewares.project.attachID,
-    controllers.stateManagement.interact
-  );
+  const commonMiddleware = [middlewares.rateLimit.versionConsume, middlewares.project.attachProjectID];
+  const statefulAPIMiddleware = [middlewares.project.resolveVersionAlias, ...commonMiddleware];
+  const legacyMiddleware = [
+    middlewares.project.unifyVersionID,
+    middlewares.project.resolveVersionAliasLegacy,
+    ...commonMiddleware,
+  ];
 
-  router.get(
-    '/user/:userID',
-    middlewares.rateLimit.versionConsume,
-    middlewares.project.attachID,
-    controllers.stateManagement.get
-  );
-
-  router.put(
-    '/user/:userID',
-    middlewares.rateLimit.versionConsume,
-    middlewares.project.attachID,
-    controllers.stateManagement.update
-  );
-
-  router.delete(
-    '/user/:userID',
-    middlewares.rateLimit.versionConsume,
-    middlewares.project.attachID,
-    controllers.stateManagement.delete
-  );
-
-  router.post(
-    '/user/:userID',
-    middlewares.rateLimit.versionConsume,
-    middlewares.project.attachID,
-    controllers.stateManagement.reset
-  );
-
-  router.patch(
-    '/user/:userID/variables',
-    middlewares.rateLimit.versionConsume,
-    middlewares.project.attachID,
-    controllers.stateManagement.updateVariables
-  );
+  router.post('/user/:userID/interact', statefulAPIMiddleware, controllers.stateManagement.interact);
+  router.get('/user/:userID', statefulAPIMiddleware, controllers.stateManagement.get);
+  router.put('/user/:userID', statefulAPIMiddleware, controllers.stateManagement.update);
+  router.delete('/user/:userID', statefulAPIMiddleware, controllers.stateManagement.delete);
+  router.post('/user/:userID', statefulAPIMiddleware, controllers.stateManagement.reset);
+  router.patch('/user/:userID/variables', statefulAPIMiddleware, controllers.stateManagement.updateVariables);
 
   // Legacy 1.0.0 routes with versionID in params
-  router.post(
-    '/:versionID/user/:userID/interact',
-    middlewares.project.unifyVersionID,
-    middlewares.rateLimit.versionConsume,
-    middlewares.project.attachID,
-    controllers.stateManagement.interact
-  );
-
-  router.get(
-    '/:versionID/user/:userID',
-    middlewares.project.unifyVersionID,
-    middlewares.rateLimit.versionConsume,
-    middlewares.project.attachID,
-    controllers.stateManagement.get
-  );
-
-  router.put(
-    '/:versionID/user/:userID',
-    middlewares.project.unifyVersionID,
-    middlewares.rateLimit.versionConsume,
-    middlewares.project.attachID,
-    controllers.stateManagement.update
-  );
-
-  router.delete(
-    '/:versionID/user/:userID',
-    middlewares.project.unifyVersionID,
-    middlewares.rateLimit.versionConsume,
-    middlewares.project.attachID,
-    controllers.stateManagement.delete
-  );
-
-  router.post(
-    '/:versionID/user/:userID',
-    middlewares.project.unifyVersionID,
-    middlewares.rateLimit.versionConsume,
-    middlewares.project.attachID,
-    controllers.stateManagement.reset
-  );
-
-  router.patch(
-    '/:versionID/user/:userID/variables',
-    middlewares.project.unifyVersionID,
-    middlewares.rateLimit.versionConsume,
-    middlewares.project.attachID,
-    controllers.stateManagement.updateVariables
-  );
+  router.post('/:versionID/user/:userID/interact', legacyMiddleware, controllers.stateManagement.interact);
+  router.get('/:versionID/user/:userID', legacyMiddleware, controllers.stateManagement.get);
+  router.put('/:versionID/user/:userID', legacyMiddleware, controllers.stateManagement.update);
+  router.delete('/:versionID/user/:userID', legacyMiddleware, controllers.stateManagement.delete);
+  router.post('/:versionID/user/:userID', legacyMiddleware, controllers.stateManagement.reset);
+  router.patch('/:versionID/user/:userID/variables', legacyMiddleware, controllers.stateManagement.updateVariables);
 
   return router;
 };

--- a/config.ts
+++ b/config.ts
@@ -40,6 +40,7 @@ const CONFIG: Config = {
   PROJECT_SOURCE: getOptionalProcessEnv('PROJECT_SOURCE'),
 
   GENERAL_SERVICE_ENDPOINT: getOptionalProcessEnv('GENERAL_SERVICE_ENDPOINT'), // voiceflow nlu/tts services
+  LUIS_SERVICE_ENDPOINT: getOptionalProcessEnv('LUIS_SERVICE_ENDPOINT'),
 
   // server-data-api config
   VF_DATA_ENDPOINT: getOptionalProcessEnv('VF_DATA_ENDPOINT'), // server-data-api endpoint

--- a/lib/controllers/interact.ts
+++ b/lib/controllers/interact.ts
@@ -15,8 +15,9 @@ import { SharedValidations } from '../validations';
 import { AbstractController } from './utils';
 
 class InteractController extends AbstractController {
-  async state(req: { headers: { authorization?: string; origin?: string; versionID: string } }): Promise<State> {
-    return this.services.interact.state(req);
+  async state(req: { headers: { authorization: string; versionID: string } }): Promise<State> {
+    const { versionID, authorization } = req.headers;
+    return this.services.interact.state(versionID, authorization);
   }
 
   @validate({
@@ -24,9 +25,9 @@ class InteractController extends AbstractController {
   })
   async handler(
     req: Request<
-      Record<string, unknown>,
+      { userID: string },
       { state?: State; action?: RuntimeRequest; request?: RuntimeRequest; config?: BaseRequest.RequestConfig },
-      { versionID: string },
+      { authorization: string; versionID: string },
       { locale?: string; logs: RuntimeLogs.LogLevel }
     >
   ): Promise<ResponseContext> {

--- a/lib/middlewares/project.ts
+++ b/lib/middlewares/project.ts
@@ -56,7 +56,10 @@ class Project extends AbstractMiddleware {
         if (isVersionTag(req.headers.versionID)) {
           throw new VError('Cannot resolve version alias from a workspace API key', VError.HTTP_STATUS.BAD_REQUEST);
         }
-      } else if (!req.headers.versionID) {
+
+        return next();
+      }
+      if (!req.headers.versionID) {
         req.headers.versionID = VersionTag.DEVELOPMENT;
       }
 

--- a/lib/middlewares/project.ts
+++ b/lib/middlewares/project.ts
@@ -1,6 +1,5 @@
 import { Validator } from '@voiceflow/backend-utils';
 import { BaseModels } from '@voiceflow/base-types';
-import * as Utils from '@voiceflow/common';
 import VError from '@voiceflow/verror';
 import { NextFunction, Response } from 'express';
 
@@ -43,7 +42,6 @@ class Project extends AbstractMiddleware {
     HEADER_AUTHORIZATION: VALIDATIONS.HEADERS.AUTHORIZATION,
     HEADER_VERSION_ID: VALIDATIONS.HEADERS.VERSION_ID,
   })
-  /* eslint-disable-next-line sonarjs/cognitive-complexity */
   async resolveVersionAlias(
     req: Request<any, any, { versionID?: string }>,
     _res: Response,
@@ -72,14 +70,7 @@ class Project extends AbstractMiddleware {
         throw new VError('Error setting up data API', VError.HTTP_STATUS.UNAUTHORIZED);
       });
 
-      if (!Utils.object.hasProperty(api, 'getProjectUsingAuthorization')) {
-        throw new VError(
-          'Project lookup via token is unsupported with current server configuration.',
-          VError.HTTP_STATUS.INTERNAL_SERVER_ERROR
-        );
-      }
-
-      const project = await api.getProjectUsingAuthorization(req.headers.authorization!).catch(() => {
+      const project = await api.getProjectUsingAPIKey(req.headers.authorization!).catch(() => {
         throw new VError(
           'Cannot resolve project version, provide a specific versionID',
           VError.HTTP_STATUS.BAD_REQUEST

--- a/lib/middlewares/project.ts
+++ b/lib/middlewares/project.ts
@@ -56,7 +56,7 @@ class Project extends AbstractMiddleware {
         }
 
         if (isVersionTag(req.headers.versionID)) {
-          throw new VError('Cannot infer version ID from a workspace API key', VError.HTTP_STATUS.BAD_REQUEST);
+          throw new VError('Cannot resolve version alias from a workspace API key', VError.HTTP_STATUS.BAD_REQUEST);
         }
       } else if (!req.headers.versionID) {
         req.headers.versionID = VersionTag.DEVELOPMENT;
@@ -80,7 +80,10 @@ class Project extends AbstractMiddleware {
       }
 
       const project = await api.getProjectUsingAuthorization(req.headers.authorization!).catch(() => {
-        throw new VError('Cannot infer project version, provide a specific versionID', VError.HTTP_STATUS.BAD_REQUEST);
+        throw new VError(
+          'Cannot resolve project version, provide a specific versionID',
+          VError.HTTP_STATUS.BAD_REQUEST
+        );
       });
 
       const resolvedVersionID = versionID === VersionTag.PRODUCTION ? project.liveVersion : project.devVersion;

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -108,17 +108,13 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
       return context;
     }
 
-    const version = await context.data.api.getVersion(context.versionID).catch(() => {
-      throw new VError('Version not found', HTTP_STATUS.NOT_FOUND);
-    });
+    const version = await context.data.api.getVersion(context.versionID);
 
     if (!version.prototype?.model) {
       throw new VError('Model not found');
     }
 
-    const project = await context.data.api.getProject(version.projectID).catch(() => {
-      throw new VError('Project not found', HTTP_STATUS.NOT_FOUND);
-    });
+    const project = await context.data.api.getProjectNLP(version.projectID);
 
     const incomingRequest = context.request;
     const currentStore = context.state.storage[StorageType.DM];
@@ -137,7 +133,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
               model: version.prototype?.model,
               locale: version.prototype?.data.locales[0] as VoiceflowConstants.Locale,
               tag: project.liveVersion === context.versionID ? VersionTag.PRODUCTION : VersionTag.DEVELOPMENT,
-              nlp: project.prototype?.nlp,
+              nlp: project.nlp,
             })
           : incomingRequest;
 

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -6,7 +6,7 @@
 import { BaseModels, BaseRequest, BaseTrace } from '@voiceflow/base-types';
 import { ChatModels } from '@voiceflow/chat-types';
 import { VF_DM_PREFIX } from '@voiceflow/common';
-import VError, { HTTP_STATUS } from '@voiceflow/verror';
+import VError from '@voiceflow/verror';
 import { VoiceModels } from '@voiceflow/voice-types';
 import { VoiceflowConstants, VoiceflowUtils, VoiceflowVersion } from '@voiceflow/voiceflow-types';
 import _ from 'lodash';

--- a/lib/services/interact/index.ts
+++ b/lib/services/interact/index.ts
@@ -20,9 +20,9 @@ const utils = {
 
 @injectServices({ utils })
 class Interact extends AbstractManager<{ utils: typeof utils }> {
-  async state(req: { headers: { authorization?: string; origin?: string; versionID: string } }): Promise<State> {
-    const api = await this.services.dataAPI.get(req.headers.authorization);
-    const version = await api.getVersion(req.headers.versionID);
+  async state(versionID: string, authorization: string): Promise<State> {
+    const api = await this.services.dataAPI.get(authorization);
+    const version = await api.getVersion(versionID);
     return this.services.state.generate(version);
   }
 
@@ -30,7 +30,13 @@ class Interact extends AbstractManager<{ utils: typeof utils }> {
     params: { userID?: string };
     body: { state?: State; action?: RuntimeRequest; request?: RuntimeRequest; config?: BaseRequest.RequestConfig };
     query: { locale?: string; logs: RuntimeLogs.LogLevel };
-    headers: { authorization?: string; origin?: string; sessionid?: string; versionID: string; platform?: string };
+    headers: {
+      authorization?: string;
+      origin?: string;
+      sessionid?: string;
+      versionID: string;
+      platform?: string;
+    };
   }): Promise<ResponseContext> {
     const {
       analytics,
@@ -52,7 +58,7 @@ class Interact extends AbstractManager<{ utils: typeof utils }> {
       body: { state, config = {}, action = null, request = null },
       params: { userID },
       query: { locale, logs: maxLogLevel },
-      headers: { versionID, authorization, origin, sessionid, platform },
+      headers: { authorization, versionID, origin, sessionid, platform },
     } = req;
 
     metrics.generalRequest();

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -4,10 +4,11 @@
  */
 
 import { BaseModels, BaseRequest } from '@voiceflow/base-types';
+import VError, { HTTP_STATUS } from '@voiceflow/verror';
 import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 
 import { isTextRequest } from '@/lib/services/runtime/types';
-import { Context, ContextHandler } from '@/types';
+import { Context, ContextHandler, VersionTag } from '@/types';
 
 import { AbstractManager, injectServices } from '../utils';
 import { handleNLCCommand } from './nlc';
@@ -24,13 +25,15 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     query,
     model,
     locale,
-    projectID,
+    tag,
+    nlp,
   }: {
     query: string;
     model?: BaseModels.PrototypeModel;
     locale?: VoiceflowConstants.Locale;
-    projectID: string;
-  }) {
+    tag: VersionTag | string;
+    nlp: BaseModels.Project.PrototypeNLP | undefined;
+  }): Promise<BaseRequest.IntentRequest> {
     // 1. first try restricted regex (no open slots) - exact string match
     if (model && locale) {
       const intent = handleNLCCommand({ query, model, locale, openSlot: false });
@@ -39,23 +42,29 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
       }
     }
 
-    // 2. next try to resolve with luis NLP on general-service
-    const { data } = await this.services.axios
-      .post<BaseRequest.IntentRequest | null>(`${this.config.GENERAL_SERVICE_ENDPOINT}/runtime/${projectID}/predict`, {
-        query,
-      })
-      .catch(() => ({ data: null }));
+    // 2. next try to resolve with luis NLP
+    if (nlp && nlp.appID && nlp.resourceID) {
+      const { appID, resourceID } = nlp;
 
-    if (data) {
-      return data;
+      const { data } = await this.services.axios
+        .post(`${this.config.LUIS_SERVICE_ENDPOINT}/predict/${appID}`, {
+          query,
+          resourceID,
+          tag,
+        })
+        .catch(() => ({ data: null }));
+
+      if (data) {
+        return data;
+      }
     }
 
     // 3. finally try open regex slot matching
     if (!model) {
-      throw new Error('Model not found!');
+      throw new VError('Model not found', HTTP_STATUS.NOT_FOUND);
     }
     if (!locale) {
-      throw new Error('Locale not found!');
+      throw new VError('Locale not found', HTTP_STATUS.NOT_FOUND);
     }
     return handleNLCCommand({ query, model, locale, openSlot: true });
   }
@@ -73,17 +82,20 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
       };
     }
 
-    const version = await context.data.api.getVersion(context.versionID);
+    const version = await context.data.api.getVersion(context.versionID).catch(() => {
+      throw new VError('Version not found', HTTP_STATUS.NOT_FOUND);
+    });
 
-    if (!version) {
-      throw new Error('Version not found!');
-    }
+    const project = await context.data.api.getProject(version.projectID).catch(() => {
+      throw new VError('Project not found', HTTP_STATUS.NOT_FOUND);
+    });
 
     const request = await this.predict({
       query: context.request.payload,
       model: version.prototype?.model,
       locale: version.prototype?.data.locales[0] as VoiceflowConstants.Locale,
-      projectID: version.projectID,
+      tag: project.liveVersion === context.versionID ? VersionTag.PRODUCTION : VersionTag.DEVELOPMENT,
+      nlp: project.prototype?.nlp,
     });
 
     return { ...context, request };

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -82,20 +82,16 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
       };
     }
 
-    const version = await context.data.api.getVersion(context.versionID).catch(() => {
-      throw new VError('Version not found', HTTP_STATUS.NOT_FOUND);
-    });
+    const version = await context.data.api.getVersion(context.versionID);
 
-    const project = await context.data.api.getProject(version.projectID).catch(() => {
-      throw new VError('Project not found', HTTP_STATUS.NOT_FOUND);
-    });
+    const project = await context.data.api.getProjectNLP(version.projectID);
 
     const request = await this.predict({
       query: context.request.payload,
       model: version.prototype?.model,
       locale: version.prototype?.data.locales[0] as VoiceflowConstants.Locale,
       tag: project.liveVersion === context.versionID ? VersionTag.PRODUCTION : VersionTag.DEVELOPMENT,
-      nlp: project.prototype?.nlp,
+      nlp: project.nlp,
     });
 
     return { ...context, request };

--- a/lib/services/slots/index.ts
+++ b/lib/services/slots/index.ts
@@ -14,11 +14,11 @@ class SlotsService extends AbstractManager<{ utils: typeof utils }> implements C
     }
 
     const version = await context.data.api.getVersion(context.versionID);
-    const slots = version.prototype?.model.slots;
-
     if (!version) {
       throw new Error('Version not found!');
     }
+
+    const slots = version.prototype?.model.slots;
     if (!slots) {
       return context;
     }

--- a/lib/services/state/cacheDataAPI.ts
+++ b/lib/services/state/cacheDataAPI.ts
@@ -40,6 +40,15 @@ class CacheDataAPI implements DataAPI<VoiceflowProgram.Program, VoiceflowVersion
   async fetchDisplayById(displayId: number) {
     return this.api.fetchDisplayById(displayId);
   }
+
+  async getProjectNLP(projectID: string) {
+    return this.api.getProjectNLP(projectID);
+  }
+
+  async getProjectUsingAPIKey(apiKeyID: string): Promise<VoiceflowProject.Project> {
+    const project = await this.api.getProjectUsingAPIKey(apiKeyID);
+    return project as VoiceflowProject.Project;
+  }
 }
 
 export default CacheDataAPI;

--- a/lib/services/state/cacheDataAPI.ts
+++ b/lib/services/state/cacheDataAPI.ts
@@ -8,6 +8,8 @@ class CacheDataAPI implements DataAPI<VoiceflowProgram.Program, VoiceflowVersion
 
   private versions: Record<string, VoiceflowVersion.Version> = {};
 
+  private projectNLPCache: Map<string, Awaited<ReturnType<typeof this.api.getProjectNLP>>> = new Map();
+
   constructor(private api: DataAPI<VoiceflowProgram.Program, VoiceflowVersion.Version>) {}
 
   async getProgram(programID: string) {
@@ -42,7 +44,11 @@ class CacheDataAPI implements DataAPI<VoiceflowProgram.Program, VoiceflowVersion
   }
 
   async getProjectNLP(projectID: string) {
-    return this.api.getProjectNLP(projectID);
+    if (!this.projectNLPCache.has(projectID)) {
+      this.projectNLPCache.set(projectID, await this.api.getProjectNLP(projectID));
+    }
+
+    return this.projectNLPCache.get(projectID)!;
   }
 
   async getProjectUsingAPIKey(apiKeyID: string): Promise<VoiceflowProject.Project> {

--- a/lib/services/stateManagement.ts
+++ b/lib/services/stateManagement.ts
@@ -31,8 +31,12 @@ class StateManagement extends AbstractManager {
     headers: { authorization: string; projectID: string; versionID: string };
     params: { userID: string };
   }) {
-    const state = await this.services.interact.state(data);
-    await this.services.session.saveToDb(data.headers.projectID, data.params.userID, state);
+    const {
+      headers: { projectID, versionID, authorization },
+      params: { userID },
+    } = data;
+    const state = await this.services.interact.state(versionID, authorization);
+    await this.services.session.saveToDb(projectID, userID, state);
     return state;
   }
 }

--- a/runtime/lib/DataAPI/creatorDataAPI.ts
+++ b/runtime/lib/DataAPI/creatorDataAPI.ts
@@ -57,14 +57,20 @@ class CreatorDataAPI<
     return (await this.client.project.get(projectID)) as PJ;
   };
 
-  public getProjectUsingAuthorization = async (apiKey: string): Promise<PJ> => {
-    // Extract the model _id from the key: VF.<type>.<id>.<hash>
-    // Legacy workspace keys do not have a type, so we need to pad the split by one.
-    const split = apiKey.split('.');
-    const [, , _id] = split.length === 4 ? split : ['', ...split];
+  /**
+   * Fetch a subset of project data specifically for runtime prediction
+   */
+  public getProjectNLP = async (projectID: string) => {
+    const { data } = await this.client.fetch.get<any>(`/projects/${projectID}/nlp`);
 
-    const project = await this.client.fetch.get(`/api-keys/${_id}/project`);
-    return project.data as PJ;
+    return data;
+  };
+
+  public getProjectUsingAPIKey = async (key: string): Promise<PJ> => {
+    const apiKeyID = BaseModels.ApiKey.extractAPIKeyID(key);
+
+    const { data } = await this.client.fetch.get<PJ>(`/api-keys/${apiKeyID}/project`);
+    return data;
   };
 }
 

--- a/runtime/lib/DataAPI/creatorDataAPI.ts
+++ b/runtime/lib/DataAPI/creatorDataAPI.ts
@@ -2,6 +2,7 @@ import Voiceflow, { Client } from '@voiceflow/api-sdk';
 import { AnyRecord, BaseModels } from '@voiceflow/base-types';
 
 import { DataAPI } from './types';
+import { extractAPIKeyID } from './utils';
 
 class CreatorDataAPI<
   P extends BaseModels.Program.Model<any, any> = BaseModels.Program.Model<any, any>,
@@ -67,7 +68,7 @@ class CreatorDataAPI<
   };
 
   public getProjectUsingAPIKey = async (key: string): Promise<PJ> => {
-    const apiKeyID = BaseModels.ApiKey.extractAPIKeyID(key);
+    const apiKeyID = extractAPIKeyID(key);
 
     const { data } = await this.client.fetch.get<PJ>(`/api-keys/${apiKeyID}/project`);
     return data;

--- a/runtime/lib/DataAPI/localDataAPI.ts
+++ b/runtime/lib/DataAPI/localDataAPI.ts
@@ -39,6 +39,16 @@ class LocalDataAPI<
   public getProject = async () => this.project;
 
   public fetchDisplayById = async () => null;
+
+  public getProjectNLP = async () => {
+    return {
+      nlp: this.project.prototype?.nlp,
+      devVersion: this.project.devVersion,
+      liveVersion: this.project.liveVersion,
+    };
+  };
+
+  public getProjectUsingAPIKey = async () => this.project;
 }
 
 export default LocalDataAPI;

--- a/runtime/lib/DataAPI/serverDataAPI.ts
+++ b/runtime/lib/DataAPI/serverDataAPI.ts
@@ -5,6 +5,7 @@ import moize from 'moize';
 import { ObjectId } from 'mongodb';
 
 import { DataAPI, Display } from './types';
+import { extractAPIKeyID } from './utils';
 
 class ServerDataAPI<
   P extends BaseModels.Program.Model<any, any>,
@@ -97,7 +98,7 @@ class ServerDataAPI<
   };
 
   public getProjectUsingAPIKey = async (key: string): Promise<PJ> => {
-    const apiKeyID = BaseModels.ApiKey.extractAPIKeyID(key);
+    const apiKeyID = extractAPIKeyID(key);
 
     const { data } = await this.client.get<PJ>(`/api-key/${apiKeyID}/project`);
     return data;

--- a/runtime/lib/DataAPI/serverDataAPI.ts
+++ b/runtime/lib/DataAPI/serverDataAPI.ts
@@ -85,6 +85,23 @@ class ServerDataAPI<
 
     return data;
   };
+
+  public getProjectNLP = async (projectID: string) => {
+    const { data } = await this.client.get<PJ>(`/project/${projectID}`);
+
+    return {
+      nlp: data.prototype?.nlp,
+      devVersion: data.devVersion,
+      liveVersion: data.liveVersion,
+    };
+  };
+
+  public getProjectUsingAPIKey = async (key: string): Promise<PJ> => {
+    const apiKeyID = BaseModels.ApiKey.extractAPIKeyID(key);
+
+    const { data } = await this.client.get<PJ>(`/api-key/${apiKeyID}/project`);
+    return data;
+  };
 }
 
 export default ServerDataAPI;

--- a/runtime/lib/DataAPI/types.ts
+++ b/runtime/lib/DataAPI/types.ts
@@ -20,4 +20,12 @@ export interface DataAPI<
   unhashVersionID(versionID: string): Promise<string>;
 
   getProject(projectID: string): Promise<PJ>;
+
+  getProjectNLP(projectID: string): Promise<{
+    nlp?: BaseModels.Project.PrototypeNLP;
+    devVersion?: string;
+    liveVersion?: string;
+  }>;
+
+  getProjectUsingAPIKey(key: string): Promise<PJ>;
 }

--- a/runtime/lib/DataAPI/utils.ts
+++ b/runtime/lib/DataAPI/utils.ts
@@ -1,0 +1,12 @@
+import { BaseModels } from '@voiceflow/base-types';
+
+export const extractAPIKeyID = (key: unknown): string => {
+  if (BaseModels.ApiKey.isWorkspaceAPIKey(key) || BaseModels.ApiKey.isDialogManagerAPIKey(key)) {
+    return key.split('.')[2];
+  }
+  // Handle legacy workspace API keys: "VF.<id>.<key>"
+  if (typeof key === 'string' && key.startsWith(BaseModels.ApiKey.API_KEY_PREFIX)) {
+    return key.split('.')[1];
+  }
+  throw new Error('Cannot extract the ID from an unknown API Key');
+};

--- a/tests/lib/controllers/interact.unit.ts
+++ b/tests/lib/controllers/interact.unit.ts
@@ -4,15 +4,22 @@ import sinon from 'sinon';
 import Interact from '@/lib/controllers/interact';
 
 describe('interact controller unit tests', () => {
+  const versionID = 'some-version-id';
+  const authorization = 'VF.ABCD.efgh';
+
   describe('state', () => {
     it('works', async () => {
       const output = { foo: 'bar' };
       const services = { interact: { state: sinon.stub().resolves(output) } };
       const controller = new Interact(services as any, {} as any);
 
-      const req = { headers: {}, params: {}, body: {} };
+      const req = {
+        headers: { versionID, authorization },
+        params: {},
+        body: {},
+      };
       expect(await controller.state(req as any)).to.eql(output);
-      expect(services.interact.state.args).to.eql([[req]]);
+      expect(services.interact.state.args[0]).to.eql([versionID, authorization]);
     });
   });
 

--- a/tests/lib/middlewares/project.unit.ts
+++ b/tests/lib/middlewares/project.unit.ts
@@ -1,41 +1,335 @@
+import VError from '@voiceflow/verror';
 import { expect } from 'chai';
+import { Request, Response } from 'express';
 import sinon from 'sinon';
 
 import Project from '@/lib/middlewares/project';
+import { VersionTag } from '@/types';
 
 describe('project middleware unit tests', () => {
-  describe('attachID', () => {
-    it('throws', async () => {
-      const api = { getVersion: sinon.stub().throws() };
-      const services = { dataAPI: { get: sinon.stub().resolves(api) } };
-      const middleware = new Project(services as any, {} as any);
+  const getMockRequest = <P, RB, B, H>({ params, body, headers }: { params?: P; body?: B; headers?: H } = {}): Request<
+    P,
+    RB,
+    B,
+    H
+  > => ({ params, body, headers } as any);
+  const getMockResponse = (): Response => ({} as any);
+  const getMockNext = () => sinon.fake();
 
-      const req = { headers: { authorization: 'auth', versionID: 'version-id' } };
-      await expect(middleware.attachID(req as any, null as any, null as any)).to.eventually.rejectedWith(
-        'no permissions for this version'
-      );
-      expect(services.dataAPI.get.args).to.eql([[req.headers.authorization]]);
-      expect(api.getVersion.args).to.eql([[req.headers.versionID]]);
+  const versionID1 = 'xyz';
+  const versionID2 = 'abc';
+
+  const liveVersion = '1';
+  const devVersion = '2';
+
+  const projectID = 'some-project-id';
+
+  const authorization = 'VF.DM.abcd.1234';
+
+  describe('unifyVersionID', () => {
+    it('adds versionID to header if it exists on params', async () => {
+      // arrange
+      const middleware = new Project({} as any, {} as any);
+
+      const req = getMockRequest({
+        headers: { versionID: versionID1 },
+        params: { versionID: versionID2 },
+        body: null,
+      });
+      const res = getMockResponse();
+      const next = getMockNext();
+
+      // act
+      await middleware.unifyVersionID(req, res, next);
+
+      // assert
+      expect(next.callCount).to.equal(1);
+      expect(next.args[0].length).to.equal(0);
+      expect(req.headers.versionID).to.equal(versionID2);
     });
 
-    it('calls next', async () => {
-      const version = { projectID: 'project-id' };
-      const api = { getVersion: sinon.stub().resolves(version) };
-      const services = { dataAPI: { get: sinon.stub().resolves(api) } };
+    it('does nothing if versionID is only specified on header', async () => {
+      // arrange
+      const middleware = new Project({} as any, {} as any);
+
+      const req = getMockRequest({
+        headers: { versionID: versionID1 },
+        params: {},
+        body: null,
+      });
+      const res = getMockResponse();
+      const next = getMockNext();
+
+      // act
+      await middleware.unifyVersionID(req, res, next);
+
+      // assert
+      expect(next.callCount).to.equal(1);
+      expect(next.args[0].length).to.equal(0);
+      expect(req.headers.versionID).to.equal(versionID1);
+    });
+
+    it('throws error if no versionID in header or params', async () => {
+      // arrange
+      const middleware = new Project({} as any, {} as any);
+
+      const req = getMockRequest({
+        headers: {},
+        params: {},
+        body: null,
+      });
+      const res = getMockResponse();
+      const next = getMockNext();
+
+      // act
+      const result = middleware.unifyVersionID(req, res, next);
+
+      // assert
+      await expect(result).to.be.eventually.rejectedWith('Missing versionID in request');
+    });
+  });
+
+  describe('attachVersionID', () => {
+    it('does not look up alias if version ID is not an alias tag', async () => {
+      // arrange
+      const middleware = new Project({} as any, {} as any);
+
+      const req = getMockRequest({ headers: { versionID: versionID1 } });
+      const res = getMockResponse();
+      const next = getMockNext();
+
+      // act
+      await middleware.resolveVersionAlias(req, res, next);
+
+      // assert
+      expect(next.callCount).to.equal(1);
+      expect(next.args[0].length).to.equal(0);
+      expect(req.headers.versionID).to.equal(versionID1);
+    });
+
+    it('rejects if the dataAPI cannot be instantiated', async () => {
+      // arrange
+      const services = {
+        dataAPI: { get: sinon.stub().rejects() },
+      };
       const middleware = new Project(services as any, {} as any);
 
-      const req = { headers: { authorization: 'auth', versionID: 'version-id' } };
-      const next = sinon.stub();
-      await middleware.attachID(req as any, null as any, next as any);
+      const req = getMockRequest({ headers: { versionID: VersionTag.DEVELOPMENT, authorization } });
+      const res = getMockResponse();
+      const next = getMockNext();
 
-      expect(next.callCount).to.eql(1);
-      expect(services.dataAPI.get.args).to.eql([[req.headers.authorization]]);
-      expect(api.getVersion.args).to.eql([[req.headers.versionID]]);
-      expect(req.headers).to.eql({
-        authorization: req.headers.authorization,
-        projectID: version.projectID,
-        versionID: req.headers.versionID,
+      // act
+      await middleware.resolveVersionAlias(req, res, next);
+
+      // assert
+      expect(next.callCount).to.equal(1);
+      expect(next.args[0][0]).to.be.instanceOf(VError);
+    });
+
+    it('rejects if the wrong API was accessed', async () => {
+      // arrange
+      const services = {
+        dataAPI: { get: sinon.stub().resolves({}) },
+      };
+      const middleware = new Project(services as any, {} as any);
+
+      const req = getMockRequest({
+        headers: {
+          versionID: VersionTag.DEVELOPMENT,
+          authorization,
+        },
       });
+      const res = getMockResponse();
+      const next = getMockNext();
+
+      // act
+      await middleware.resolveVersionAlias(req, res, next);
+
+      // assert
+      expect(next.callCount).to.equal(1);
+      expect(next.args[0][0]).to.be.instanceOf(VError);
+    });
+
+    it('rejects if a project cannot be found', async () => {
+      // arrange
+      const api = {
+        getProjectUsingAuthorization: sinon.stub().rejects(),
+      };
+      const services = {
+        dataAPI: { get: sinon.stub().resolves(api) },
+      };
+      const middleware = new Project(services as any, {} as any);
+
+      const req = getMockRequest({ headers: { versionID: VersionTag.DEVELOPMENT, authorization } });
+      const res = getMockResponse();
+      const next = getMockNext();
+
+      // act
+      await middleware.resolveVersionAlias(req, res, next);
+
+      // assert
+      expect(next.callCount).to.equal(1);
+      expect(next.args[0][0]).to.be.instanceOf(VError);
+    });
+
+    it('changes versionID based on tag', async () => {
+      // arrange
+      const api = {
+        getProjectUsingAuthorization: sinon.stub().resolves({
+          liveVersion,
+          devVersion,
+        }),
+      };
+      const services = {
+        dataAPI: { get: sinon.stub().resolves(api) },
+      };
+      const middleware = new Project(services as any, {} as any);
+
+      const reqProd = getMockRequest({ headers: { versionID: VersionTag.PRODUCTION, authorization } });
+      const reqDev = getMockRequest({ headers: { versionID: VersionTag.DEVELOPMENT, authorization } });
+
+      const res = getMockResponse();
+      const next = getMockNext();
+
+      // act
+      await middleware.resolveVersionAlias(reqProd, res, next);
+      await middleware.resolveVersionAliasLegacy(reqDev, res, next);
+
+      // assert
+      expect(reqProd.headers.versionID).to.equal(liveVersion);
+      expect(reqDev.headers.versionID).to.equal(devVersion);
+    });
+
+    it('defaults to devVersion if no versionID specified', async () => {
+      // arrange
+      const api = {
+        getProjectUsingAuthorization: sinon.stub().resolves({
+          liveVersion,
+          devVersion,
+        }),
+      };
+      const services = {
+        dataAPI: { get: sinon.stub().resolves(api) },
+      };
+      const middleware = new Project(services as any, {} as any);
+
+      const req = getMockRequest({ headers: { versionID: undefined, authorization } });
+      const res = getMockResponse();
+      const next = getMockNext();
+
+      // act
+      await middleware.resolveVersionAlias(req, res, next);
+
+      // assert
+      expect(req.headers.versionID).to.equal(devVersion);
+    });
+  });
+
+  describe('attachProjectID', () => {
+    it('works', async () => {
+      // arrange
+      const api = {
+        getVersion: sinon.stub().resolves({ projectID }),
+      };
+      const services = {
+        dataAPI: { get: sinon.stub().resolves(api) },
+      };
+      const middleware = new Project(services as any, {} as any);
+
+      const req = getMockRequest({
+        headers: {
+          versionID: versionID1,
+          authorization,
+        },
+      });
+      const res = getMockResponse();
+      const next = getMockNext();
+
+      // act
+      await middleware.attachProjectID(req, res, next);
+
+      // assert
+      expect(next.callCount).to.equal(1);
+      expect(next.args[0].length).to.equal(0);
+      expect(req.headers.projectID).to.equal(projectID);
+    });
+
+    it('rejects with missing versionID', async () => {
+      // arrange
+      const api = {
+        getVersion: sinon.stub().resolves({ projectID }),
+      };
+      const services = {
+        dataAPI: { get: sinon.stub().resolves(api) },
+      };
+      const middleware = new Project(services as any, {} as any);
+
+      const req = getMockRequest({
+        headers: {
+          versionID: undefined,
+          authorization,
+        },
+      });
+      const res = getMockResponse();
+      const next = getMockNext();
+
+      // act
+      await middleware.attachProjectID(req, res, next);
+
+      // assert
+      expect(next.callCount).to.equal(1);
+      expect(next.args[0][0]).to.be.instanceOf(VError);
+    });
+
+    it('rejects if API cannot be retrieved', async () => {
+      // arrange
+      const services = {
+        dataAPI: { get: sinon.stub().rejects('some-error') },
+      };
+      const middleware = new Project(services as any, {} as any);
+
+      const req = getMockRequest({
+        headers: {
+          versionID: undefined,
+          authorization,
+        },
+      });
+      const res = getMockResponse();
+      const next = getMockNext();
+
+      // act
+      await middleware.attachProjectID(req, res, next);
+
+      // assert
+      expect(next.callCount).to.equal(1);
+      expect(next.args[0][0]).to.be.instanceOf(VError);
+    });
+
+    it('rejects if API cannot read the version', async () => {
+      // arrange
+      const api = {
+        getVersion: sinon.stub().rejects(new Error('Unknown error')),
+      };
+      const services = {
+        dataAPI: { get: sinon.stub().resolves(api) },
+      };
+      const middleware = new Project(services as any, {} as any);
+
+      const req = getMockRequest({
+        headers: {
+          versionID: versionID1,
+          authorization,
+        },
+      });
+      const res = getMockResponse();
+      const next = getMockNext();
+
+      // act
+      await middleware.attachProjectID(req, res, next);
+
+      // assert
+      expect(next.callCount).to.equal(1);
+      expect(next.args[0][0]).to.be.instanceOf(VError);
     });
   });
 });

--- a/tests/lib/middlewares/project.unit.ts
+++ b/tests/lib/middlewares/project.unit.ts
@@ -153,7 +153,7 @@ describe('project middleware unit tests', () => {
     it('rejects if a project cannot be found', async () => {
       // arrange
       const api = {
-        getProjectUsingAuthorization: sinon.stub().rejects(),
+        getProjectUsingAPIKey: sinon.stub().rejects(),
       };
       const services = {
         dataAPI: { get: sinon.stub().resolves(api) },
@@ -175,7 +175,7 @@ describe('project middleware unit tests', () => {
     it('changes versionID based on tag', async () => {
       // arrange
       const api = {
-        getProjectUsingAuthorization: sinon.stub().resolves({
+        getProjectUsingAPIKey: sinon.stub().resolves({
           liveVersion,
           devVersion,
         }),
@@ -203,7 +203,7 @@ describe('project middleware unit tests', () => {
     it('defaults to devVersion if no versionID specified', async () => {
       // arrange
       const api = {
-        getProjectUsingAuthorization: sinon.stub().resolves({
+        getProjectUsingAPIKey: sinon.stub().resolves({
           liveVersion,
           devVersion,
         }),

--- a/tests/lib/middlewares/project.unit.ts
+++ b/tests/lib/middlewares/project.unit.ts
@@ -193,7 +193,7 @@ describe('project middleware unit tests', () => {
 
       // act
       await middleware.resolveVersionAlias(reqProd, res, next);
-      await middleware.resolveVersionAliasLegacy(reqDev, res, next);
+      await middleware.resolveVersionAlias(reqDev, res, next);
 
       // assert
       expect(reqProd.headers.versionID).to.equal(liveVersion);

--- a/tests/lib/services/dialog/fixture.ts
+++ b/tests/lib/services/dialog/fixture.ts
@@ -419,8 +419,11 @@ export const mockVersion = {
   },
 };
 
+export const mockProject = {};
+
 export const mockDataAPI = {
   getVersion: sinon.stub().resolves(mockVersion),
+  getProject: sinon.stub().resolves(mockProject),
 } as unknown as CacheDataAPI;
 
 export const mockFulfilledIntentRequest: BaseRequest.IntentRequest = {
@@ -469,6 +472,7 @@ export const mockDMContext: Context = {
     variables: {},
   },
   request: mockUnfulfilledIntentRequest,
+  projectID: '507f191e810c19729de860ea',
   versionID: '5ff486b75b99f8b36505ecfd',
   trace: [],
   data: {
@@ -484,6 +488,7 @@ export const mockRegularContext: Context = {
     variables: {},
   },
   request: mockUnfulfilledIntentRequest,
+  projectID: '507f191e810c19729de860ea',
   versionID: '5ff486b75b99f8b36505ecfd',
   trace: [],
   data: {

--- a/tests/lib/services/dialog/fixture.ts
+++ b/tests/lib/services/dialog/fixture.ts
@@ -419,11 +419,11 @@ export const mockVersion = {
   },
 };
 
-export const mockProject = {};
+export const mockProjectNLP = {};
 
 export const mockDataAPI = {
   getVersion: sinon.stub().resolves(mockVersion),
-  getProject: sinon.stub().resolves(mockProject),
+  getProjectNLP: sinon.stub().resolves(mockProjectNLP),
 } as unknown as CacheDataAPI;
 
 export const mockFulfilledIntentRequest: BaseRequest.IntentRequest = {

--- a/tests/lib/services/dialog/index.unit.ts
+++ b/tests/lib/services/dialog/index.unit.ts
@@ -40,7 +40,7 @@ describe('dialog manager unit tests', () => {
   describe('general handler', () => {
     it('fails if version is not found', async () => {
       const services = {
-        dataAPI: { getVersion: sinon.stub().resolves(), getProject: sinon.stub().resolves() },
+        dataAPI: { getVersion: sinon.stub().resolves(), getProjectNLP: sinon.stub().resolves() },
       };
       const dm = new DialogManager({ utils: { ...defaultUtils }, ...services } as any, {} as any);
       const result = dm.handle({
@@ -54,7 +54,7 @@ describe('dialog manager unit tests', () => {
       const services = {
         dataAPI: {
           getVersion: sinon.stub().resolves({ prototype: { model: true } }),
-          getProject: sinon.stub().resolves({}),
+          getProjectNLP: sinon.stub().resolves({}),
         },
       };
       const dm = new DialogManager(

--- a/tests/lib/services/dialog/index.unit.ts
+++ b/tests/lib/services/dialog/index.unit.ts
@@ -40,7 +40,7 @@ describe('dialog manager unit tests', () => {
   describe('general handler', () => {
     it('fails if version is not found', async () => {
       const services = {
-        dataAPI: { getVersion: sinon.stub().resolves() },
+        dataAPI: { getVersion: sinon.stub().resolves(), getProject: sinon.stub().resolves() },
       };
       const dm = new DialogManager({ utils: { ...defaultUtils }, ...services } as any, {} as any);
       const result = dm.handle({
@@ -52,7 +52,10 @@ describe('dialog manager unit tests', () => {
 
     it('exits early if intent not in scope', async () => {
       const services = {
-        dataAPI: { getVersion: sinon.stub().resolves({ prototype: { model: true } }) },
+        dataAPI: {
+          getVersion: sinon.stub().resolves({ prototype: { model: true } }),
+          getProject: sinon.stub().resolves({}),
+        },
       };
       const dm = new DialogManager(
         { utils: { ...defaultUtils, isIntentInScope: sinon.stub().resolves(false) }, ...services } as any,

--- a/tests/lib/services/nlu/index.unit.ts
+++ b/tests/lib/services/nlu/index.unit.ts
@@ -1,4 +1,8 @@
-import { BaseRequest } from '@voiceflow/base-types';
+import { BaseModels, BaseRequest, Project, Version } from '@voiceflow/base-types';
+import { PrototypeModel } from '@voiceflow/base-types/build/common/models';
+import { PrototypeNLP } from '@voiceflow/base-types/build/common/models/project';
+import { IntentRequest, RequestType } from '@voiceflow/base-types/build/common/request';
+import { Locale } from '@voiceflow/voiceflow-types/build/common/constants';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
@@ -6,6 +10,7 @@ import sinon from 'sinon';
 import NLUManager, { utils as defaultUtils } from '@/lib/services/nlu';
 import * as NLC from '@/lib/services/nlu/nlc';
 import { NONE_INTENT } from '@/lib/services/nlu/utils';
+import { VersionTag } from '@/types';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -20,25 +25,72 @@ describe('nlu manager unit tests', () => {
     sinon.restore();
   });
 
+  const model: PrototypeModel = {
+    slots: [],
+    intents: [],
+  };
+  const tag = VersionTag.PRODUCTION;
+  const locale = Locale.DE_DE;
+  const query = 'I would like a large sofa pizza with extra chair';
+  const nlp: PrototypeNLP = {
+    type: BaseModels.ProjectNLP.LUIS,
+    appID: 'nlp-app-id',
+    resourceID: 'nlp-resource-id',
+  };
+  const version: Pick<Version.Version, '_id' | 'projectID'> = {
+    _id: 'version-id',
+    projectID: 'project-id',
+  };
+  const project: Pick<Project.Project, '_id' | 'prototype'> = {
+    _id: 'project-id',
+    prototype: {
+      nlp,
+      data: {},
+    },
+  };
+  const liveVersion = 'some-live-version';
+
+  const nlcMatchedIntent: IntentRequest = {
+    type: RequestType.INTENT,
+    payload: {
+      intent: {
+        name: 'abcedfg',
+      },
+      query,
+      entities: [],
+      confidence: 0.56,
+    },
+  };
+
+  const noneIntent: IntentRequest = {
+    type: RequestType.INTENT,
+    payload: {
+      intent: {
+        name: NONE_INTENT,
+      },
+      query,
+      entities: [],
+    },
+  };
+  const luisResponse = {
+    type: BaseRequest.RequestType.INTENT,
+    payload: {
+      intent: {
+        name: 'Order Pizza',
+      },
+      entities: [],
+    },
+  };
+
   describe('handle', () => {
     it('works', async () => {
-      const version = { _id: 'version-id', projectID: 'project-id' };
       const oldRequest = {
         type: BaseRequest.RequestType.TEXT,
         payload: 'query',
       };
-      const newRequest = {
-        type: BaseRequest.RequestType.INTENT,
-        payload: {
-          intent: {
-            name: 'queryIntent',
-          },
-          entities: [],
-        },
-      };
       const services = {
         axios: {
-          post: sinon.stub().resolves({ data: newRequest }),
+          post: sinon.stub().resolves({ data: luisResponse }),
         },
       };
       const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
@@ -47,16 +99,57 @@ describe('nlu manager unit tests', () => {
         request: oldRequest,
         state: { foo: 'bar' },
         versionID: version._id,
-        data: { api: { getVersion: sinon.stub().resolves(version) } },
+        data: {
+          api: {
+            getVersion: sinon.stub().resolves(version),
+            getProject: sinon.stub().resolves(project),
+          },
+        },
       };
-      expect(await nlu.handle(context as any)).to.eql({ ...context, request: newRequest });
-      expect(context.data.api.getVersion.args).to.eql([[context.versionID]]);
-      expect(services.axios.post.args).to.eql([
-        [`${GENERAL_SERVICE_ENDPOINT}/runtime/${version.projectID}/predict`, { query: oldRequest.payload }],
-      ]);
+
+      const result = await nlu.handle(context as any);
+
+      expect(result).to.eql({ ...context, request: luisResponse });
     });
 
-    it('throws on invalid version', async () => {
+    it('works with production', async () => {
+      const oldRequest = {
+        type: BaseRequest.RequestType.TEXT,
+        payload: query,
+      };
+      const services = {
+        axios: {
+          post: sinon.stub().resolves({ data: luisResponse }),
+        },
+      };
+      const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
+
+      const context = {
+        request: oldRequest,
+        state: { foo: 'bar' },
+        versionID: liveVersion,
+        data: {
+          api: {
+            getVersion: sinon.stub().resolves(version),
+            getProject: sinon.stub().resolves({
+              ...project,
+              liveVersion,
+            }),
+          },
+        },
+      };
+
+      const result = await nlu.handle(context as any);
+
+      expect(result).to.eql({ ...context, request: luisResponse });
+      expect(services.axios.post.args[0][1]).to.eql({
+        query,
+        resourceID: nlp.resourceID,
+        tag: VersionTag.PRODUCTION,
+      });
+    });
+
+    it('rejects on invalid version', async () => {
       const oldRequest = {
         type: BaseRequest.RequestType.TEXT,
         payload: 'query',
@@ -72,11 +165,9 @@ describe('nlu manager unit tests', () => {
         request: oldRequest,
         state: { foo: 'bar' },
         versionID: 'version-id',
-        data: { api: { getVersion: sinon.stub().throws() } },
+        data: { api: { getVersion: sinon.stub().rejects() } },
       };
-      await expect(nlu.handle(context as any)).to.eventually.be.rejectedWith();
-      expect(context.data.api.getVersion.args).to.eql([[context.versionID]]);
-      expect(services.axios.post.callCount).to.eql(0);
+      await expect(nlu.handle(context as any)).to.eventually.be.rejectedWith('Version not found');
     });
 
     it('rejects non text requests', async () => {
@@ -96,8 +187,54 @@ describe('nlu manager unit tests', () => {
 
       const context = { request: oldRequest, state: { foo: 'bar' }, versionID: 'version-id' };
       expect(await nlu.handle(context as any)).to.eql(context);
-      expect(services.dataAPI.getVersion.callCount).to.eql(0);
-      expect(services.axios.post.callCount).to.eql(0);
+    });
+
+    it('rejects with missing query', async () => {
+      const oldRequest = {
+        type: BaseRequest.RequestType.TEXT,
+        payload: '',
+      };
+
+      const nlu = new NLUManager({ utils: { ...defaultUtils } } as any, config as any);
+
+      const context = { request: oldRequest };
+
+      const result = await nlu.handle(context as any);
+
+      expect(result).to.eql({
+        ...context,
+        request: {
+          ...noneIntent,
+          payload: {
+            ...noneIntent.payload,
+            query: '',
+          },
+        },
+      });
+    });
+
+    it('rejects with missing project', async () => {
+      const oldRequest = {
+        type: BaseRequest.RequestType.TEXT,
+        payload: query,
+      };
+
+      const nlu = new NLUManager({ utils: { ...defaultUtils } } as any, config as any);
+
+      const context = {
+        request: oldRequest,
+        versionID: liveVersion,
+        data: {
+          api: {
+            getVersion: sinon.stub().resolves(version),
+            getProject: sinon.stub().rejects('Could not find project'),
+          },
+        },
+      };
+
+      const result = nlu.handle(context as any);
+
+      await expect(result).to.be.eventually.rejectedWith('Project not found');
     });
   });
 
@@ -110,46 +247,57 @@ describe('nlu manager unit tests', () => {
       };
       const arg = { model: 'model-val', locale: 'locale-val', query: 'query-val', projectID: 'projectID' } as any;
       const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
-      const handleNLCCommandStub = sinon
-        .stub(NLC, 'handleNLCCommand')
-        .returns({ payload: { intent: { name: 'abcdefg' } } } as any);
+      sinon.stub(NLC, 'handleNLCCommand').returns(nlcMatchedIntent as any);
 
-      expect(await nlu.predict(arg)).to.eql({ payload: { intent: { name: 'abcdefg' } } });
+      const result = await nlu.predict(arg);
+
+      expect(result).to.eql(nlcMatchedIntent);
     });
 
     it('works with model and locale defined and intent is NONE_INTENT, prediction is not empty', async () => {
       const services = {
         axios: {
-          post: sinon.stub().resolves({ data: 'data-val' }),
+          post: sinon.stub().resolves({ data: luisResponse }),
         },
       };
-      const arg = { model: 'model-val', locale: 'locale-val', query: 'query-val', projectID: 'projectID' } as any;
-      const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
-      const handleNLCCommandStub = sinon
-        .stub(NLC, 'handleNLCCommand')
-        .returns({ payload: { intent: { name: NONE_INTENT } } } as any);
 
-      expect(await nlu.predict(arg)).to.eql('data-val');
-      expect(services.axios.post.args).to.eql([
-        [`${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`, { query: 'query-val' }],
-      ]);
+      const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
+
+      const arg: Parameters<typeof nlu.predict>[0] = {
+        model: { key: 'value' } as any,
+        locale: Locale.EN_US,
+        query: 'query-val',
+        nlp,
+        tag: VersionTag.DEVELOPMENT,
+      };
+
+      sinon.stub(NLC, 'handleNLCCommand').returns(noneIntent as any);
+
+      const result = await nlu.predict(arg);
+
+      expect(result).to.eql(luisResponse);
     });
 
     it('works with model and locale undefined, intent is not NONE_INTENT, prediction is not empty', async () => {
       const services = {
         axios: {
-          post: sinon.stub().resolves({ data: 'data-val' }),
+          post: sinon.stub().resolves({ data: luisResponse }),
         },
       };
-      const arg = { model: '', locale: '', query: 'query-val', projectID: 'projectID' } as any;
+
       const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
-      const handleNLCCommandStub = sinon
-        .stub(NLC, 'handleNLCCommand')
-        .returns({ payload: { intent: { name: 'abcdefg' } } } as any);
-      expect(await nlu.predict(arg)).to.eql('data-val');
-      expect(services.axios.post.args).to.eql([
-        [`${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`, { query: 'query-val' }],
-      ]);
+
+      const arg: Parameters<typeof nlu.predict>[0] = {
+        query: 'query-val',
+        nlp,
+        tag: VersionTag.DEVELOPMENT,
+      };
+
+      sinon.stub(NLC, 'handleNLCCommand').returns(nlcMatchedIntent as any);
+
+      const result = await nlu.predict(arg);
+
+      expect(result).to.eql(luisResponse);
     });
 
     it('works with model and locale undefined, intent is not NONE_INTENT, prediction empty', async () => {
@@ -158,16 +306,17 @@ describe('nlu manager unit tests', () => {
           post: sinon.stub().resolves({ data: undefined }),
         },
       };
-      const arg = { model: '', locale: '', query: 'query-val', projectID: 'projectID' } as any;
-      const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
-      const handleNLCCommandStub = sinon
-        .stub(NLC, 'handleNLCCommand')
-        .returns({ payload: { intent: { name: 'abcdefg' } } } as any);
 
-      await expect(nlu.predict(arg)).to.be.rejectedWith(Error);
-      expect(services.axios.post.args).to.eql([
-        [`${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`, { query: 'query-val' }],
-      ]);
+      const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
+
+      const arg: Parameters<typeof nlu.predict>[0] = {
+        query: 'query-val',
+        nlp,
+        tag: VersionTag.DEVELOPMENT,
+      };
+      sinon.stub(NLC, 'handleNLCCommand').returns(nlcMatchedIntent as any);
+
+      await expect(nlu.predict(arg)).to.be.rejectedWith('Model not found');
     });
 
     it('works with model defined and locale undefined, intent is not NONE_INTENT, prediction empty', async () => {
@@ -176,16 +325,18 @@ describe('nlu manager unit tests', () => {
           post: sinon.stub().resolves({ data: undefined }),
         },
       };
-      const arg = { model: 'abcd', locale: '', query: 'query-val', projectID: 'projectID' } as any;
-      const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
-      const handleNLCCommandStub = sinon
-        .stub(NLC, 'handleNLCCommand')
-        .returns({ payload: { intent: { name: 'abcdefg' } } } as any);
 
-      await expect(nlu.predict(arg)).to.be.rejectedWith(Error);
-      expect(services.axios.post.args).to.eql([
-        [`${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`, { query: 'query-val' }],
-      ]);
+      const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
+
+      const arg: Parameters<typeof nlu.predict>[0] = {
+        model: { key: 'value' } as any,
+        query: 'query-val',
+        nlp,
+        tag: VersionTag.DEVELOPMENT,
+      };
+      sinon.stub(NLC, 'handleNLCCommand').returns(nlcMatchedIntent as any);
+
+      await expect(nlu.predict(arg)).to.be.rejectedWith('Locale not found');
     });
 
     it('works with model and locale defined, intent is NONE_INTENT, prediction is empty', async () => {
@@ -194,17 +345,64 @@ describe('nlu manager unit tests', () => {
           post: sinon.stub().resolves({ data: undefined }),
         },
       };
-      const arg = { model: 'abcd', locale: 'abcd', query: 'query-val', projectID: 'projectID' } as any;
       const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
-      const handleNLCCommandStub = sinon
-        .stub(NLC, 'handleNLCCommand')
-        .returns({ payload: { intent: { name: NONE_INTENT } } } as any);
+      const arg: Parameters<typeof nlu.predict>[0] = {
+        model: { key: 'value' } as any,
+        locale: Locale.EN_US,
+        query: 'query-val',
+        nlp,
+        tag: VersionTag.DEVELOPMENT,
+      };
+      const handleNLCCommandStub = sinon.stub(NLC, 'handleNLCCommand').returns(noneIntent as any);
 
-      expect(await nlu.predict(arg)).to.eql({ payload: { intent: { name: NONE_INTENT } } });
+      expect(await nlu.predict(arg)).to.eql(noneIntent);
       expect(handleNLCCommandStub.callCount).to.eql(2);
-      expect(services.axios.post.args).to.eql([
-        [`${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`, { query: 'query-val' }],
-      ]);
+    });
+
+    it('falls back to open regex slot matching if LUIS throws', async () => {
+      const services = {
+        axios: {
+          post: sinon.stub().rejects('some-error'),
+        },
+      };
+
+      const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
+
+      const arg: Parameters<typeof nlu.predict>[0] = {
+        query: 'query-val',
+        nlp,
+        tag: VersionTag.DEVELOPMENT,
+      };
+
+      sinon.stub(NLC, 'handleNLCCommand').returns(nlcMatchedIntent as any);
+
+      const result = nlu.predict(arg);
+
+      await expect(result).to.be.rejectedWith('Model not found');
+    });
+
+    it('skip NLU prediction if not defined', async () => {
+      const services = {
+        axios: {
+          post: sinon.stub().rejects('some-error'),
+        },
+      };
+
+      const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
+
+      const arg: Parameters<typeof nlu.predict>[0] = {
+        query,
+        nlp: undefined,
+        tag,
+        model,
+        locale,
+      };
+
+      sinon.stub(NLC, 'handleNLCCommand').onCall(0).returns(noneIntent).onCall(1).returns(nlcMatchedIntent);
+
+      const result = await nlu.predict(arg);
+
+      expect(result).to.eql(nlcMatchedIntent);
     });
   });
 });

--- a/tests/lib/services/nlu/index.unit.ts
+++ b/tests/lib/services/nlu/index.unit.ts
@@ -41,12 +41,10 @@ describe('nlu manager unit tests', () => {
     _id: 'version-id',
     projectID: 'project-id',
   };
-  const project: Pick<Project.Project, '_id' | 'prototype'> = {
-    _id: 'project-id',
-    prototype: {
-      nlp,
-      data: {},
-    },
+  const project = {
+    nlp,
+    liveVersion: '1',
+    devVersion: '2',
   };
   const liveVersion = 'some-live-version';
 
@@ -102,7 +100,7 @@ describe('nlu manager unit tests', () => {
         data: {
           api: {
             getVersion: sinon.stub().resolves(version),
-            getProject: sinon.stub().resolves(project),
+            getProjectNLP: sinon.stub().resolves(project),
           },
         },
       };
@@ -131,7 +129,7 @@ describe('nlu manager unit tests', () => {
         data: {
           api: {
             getVersion: sinon.stub().resolves(version),
-            getProject: sinon.stub().resolves({
+            getProjectNLP: sinon.stub().resolves({
               ...project,
               liveVersion,
             }),
@@ -167,7 +165,7 @@ describe('nlu manager unit tests', () => {
         versionID: 'version-id',
         data: { api: { getVersion: sinon.stub().rejects() } },
       };
-      await expect(nlu.handle(context as any)).to.eventually.be.rejectedWith('Version not found');
+      await expect(nlu.handle(context as any)).to.eventually.be.rejectedWith();
     });
 
     it('rejects non text requests', async () => {
@@ -227,14 +225,14 @@ describe('nlu manager unit tests', () => {
         data: {
           api: {
             getVersion: sinon.stub().resolves(version),
-            getProject: sinon.stub().rejects('Could not find project'),
+            getProjectNLP: sinon.stub().rejects('Could not find project'),
           },
         },
       };
 
       const result = nlu.handle(context as any);
 
-      await expect(result).to.be.eventually.rejectedWith('Project not found');
+      await expect(result).to.be.eventually.rejectedWith();
     });
   });
 

--- a/tests/lib/services/state/index.unit.ts
+++ b/tests/lib/services/state/index.unit.ts
@@ -5,6 +5,7 @@ import StateManager, { utils as defaultUtils } from '@/lib/services/state';
 
 const VERSION_ID = 'version_id';
 const version = {
+  _id: VERSION_ID,
   prototype: {
     data: {
       locales: ['en-US'],

--- a/tests/lib/services/stateManagement.unit.ts
+++ b/tests/lib/services/stateManagement.unit.ts
@@ -135,13 +135,13 @@ describe('stateManagement manager unit tests', () => {
       const data = {
         params: { userID: 'user-id' },
         body: {},
-        headers: { projectID: 'project-id', version: 'version-id' },
+        headers: { projectID: 'project-id', versionID: 'version-id', authorization: 'VF.ABCD.EFGH' },
       };
 
       expect(await service.reset(data as any)).to.eql(session);
 
-      expect(services.interact.state.args).to.eql([[data]]);
-      expect(services.session.saveToDb.args).to.eql([[data.headers.projectID, data.params.userID, session]]);
+      expect(services.interact.state.args[0]).to.eql([data.headers.versionID, data.headers.authorization]);
+      expect(services.session.saveToDb.args[0]).to.eql([data.headers.projectID, data.params.userID, session]);
     });
   });
 });

--- a/tests/runtime/lib/DataAPI/utils.unit.ts
+++ b/tests/runtime/lib/DataAPI/utils.unit.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+
+import * as utils from '@/runtime/lib/DataAPI/utils';
+
+describe('DataAPI utils', () => {
+  describe('extractAPIKeyID', () => {
+    it('extracts ID from a Dialog Manager API key', () => {
+      // eslint-disable-next-line no-secrets/no-secrets
+      const key = 'VF.DM.628d5d92faf688001bda7907.dmC8KKO1oX8JO5ai';
+      const result = utils.extractAPIKeyID(key);
+
+      expect(result).to.equal('628d5d92faf688001bda7907');
+    });
+
+    it('extracts ID from a Workspace API key', () => {
+      // eslint-disable-next-line no-secrets/no-secrets
+      const key = 'VF.WS.62bcb0cca5184300066f5ac7.egnKyyzZksiS5iGa';
+      const result = utils.extractAPIKeyID(key);
+
+      expect(result).to.equal('62bcb0cca5184300066f5ac7');
+    });
+
+    it('extracts ID from a Legacy Workspace API key', () => {
+      // eslint-disable-next-line no-secrets/no-secrets
+      const key = 'VF.62bcb0cca5184300066f5ac7.dmC8KKO1oX8JO5az';
+      const result = utils.extractAPIKeyID(key);
+
+      expect(result).to.equal('62bcb0cca5184300066f5ac7');
+    });
+
+    it('throws if cannot match format', () => {
+      const key = 'hello world';
+      expect(() => utils.extractAPIKeyID(key)).to.throw();
+    });
+  });
+});

--- a/tests/server/interact.unit.ts
+++ b/tests/server/interact.unit.ts
@@ -87,7 +87,7 @@ const tests = [
       middlewares: {
         project: {
           unifyVersionID: 1,
-          resolveVersionAliasLegacy: 1,
+          resolveVersionAlias: 1,
         },
         rateLimit: {
           verify: 1,
@@ -101,7 +101,7 @@ const tests = [
               HEADER_VERSION_ID: 1,
               PARAMS_VERSION_ID: 1,
             },
-            resolveVersionAliasLegacy: {
+            resolveVersionAlias: {
               HEADER_AUTHORIZATION: 1,
               HEADER_VERSION_ID: 1,
             },
@@ -122,7 +122,7 @@ const tests = [
       middlewares: {
         project: {
           unifyVersionID: 1,
-          resolveVersionAliasLegacy: 1,
+          resolveVersionAlias: 1,
         },
         rateLimit: {
           verify: 1,
@@ -143,7 +143,7 @@ const tests = [
               HEADER_VERSION_ID: 1,
               PARAMS_VERSION_ID: 1,
             },
-            resolveVersionAliasLegacy: {
+            resolveVersionAlias: {
               HEADER_AUTHORIZATION: 1,
               HEADER_VERSION_ID: 1,
             },

--- a/tests/server/interact.unit.ts
+++ b/tests/server/interact.unit.ts
@@ -18,20 +18,20 @@ const tests = [
         },
       },
       middlewares: {
+        project: {
+          resolveVersionAlias: 1,
+        },
         rateLimit: {
           verify: 1,
           versionConsume: 1,
-        },
-        project: {
-          attachID: 1,
         },
       },
       validations: {
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            resolveVersionAlias: {
+              HEADER_AUTHORIZATION: 1,
+              HEADER_VERSION_ID: 1,
             },
           },
         },
@@ -48,20 +48,20 @@ const tests = [
         },
       },
       middlewares: {
+        project: {
+          resolveVersionAlias: 1,
+        },
         rateLimit: {
           verify: 1,
           versionConsume: 1,
-        },
-        project: {
-          attachID: 1,
         },
       },
       validations: {
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            resolveVersionAlias: {
+              HEADER_AUTHORIZATION: 1,
+              HEADER_VERSION_ID: 1,
             },
           },
         },
@@ -75,7 +75,6 @@ const tests = [
       },
     },
   },
-  // legacy routes
   {
     method: 'get',
     calledPath: '/interact/:versionID/state',
@@ -86,13 +85,29 @@ const tests = [
         },
       },
       middlewares: {
-        project: { unifyVersionID: 1 },
+        project: {
+          unifyVersionID: 1,
+          resolveVersionAliasLegacy: 1,
+        },
         rateLimit: {
           verify: 1,
           versionConsume: 1,
         },
       },
-      validations: {},
+      validations: {
+        middlewares: {
+          project: {
+            unifyVersionID: {
+              HEADER_VERSION_ID: 1,
+              PARAMS_VERSION_ID: 1,
+            },
+            resolveVersionAliasLegacy: {
+              HEADER_AUTHORIZATION: 1,
+              HEADER_VERSION_ID: 1,
+            },
+          },
+        },
+      },
     },
   },
   {
@@ -105,7 +120,10 @@ const tests = [
         },
       },
       middlewares: {
-        project: { unifyVersionID: 1 },
+        project: {
+          unifyVersionID: 1,
+          resolveVersionAliasLegacy: 1,
+        },
         rateLimit: {
           verify: 1,
           versionConsume: 1,
@@ -116,6 +134,18 @@ const tests = [
           interact: {
             handler: {
               QUERY_LOGS: 1,
+            },
+          },
+        },
+        middlewares: {
+          project: {
+            unifyVersionID: {
+              HEADER_VERSION_ID: 1,
+              PARAMS_VERSION_ID: 1,
+            },
+            resolveVersionAliasLegacy: {
+              HEADER_AUTHORIZATION: 1,
+              HEADER_VERSION_ID: 1,
             },
           },
         },
@@ -138,7 +168,8 @@ describe('interact route unit tests', async () => {
       const fixture = await fixtures.createFixture();
       ({ app, server } = await GetApp(fixture));
 
-      const response = await request(app)[test.method](test.calledPath);
+      // TODO - Remove any and fix strange error with SuperTest<Test> not having index signature
+      const response = await (request(app) as any)[test.method](test.calledPath);
 
       fixtures.checkFixture(fixture, test.expected);
       expect(response.body).to.eql({ done: 'done' });

--- a/tests/server/state.unit.ts
+++ b/tests/server/state.unit.ts
@@ -24,15 +24,20 @@ const tests = [
           versionConsume: 1,
         },
         project: {
-          attachID: 1,
+          resolveVersionAlias: 1,
+          attachProjectID: 1,
         },
       },
       validations: {
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            resolveVersionAlias: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
+            },
+            attachProjectID: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
             },
           },
         },
@@ -64,7 +69,8 @@ const tests = [
           versionConsume: 1,
         },
         project: {
-          attachID: 1,
+          resolveVersionAlias: 1,
+          attachProjectID: 1,
         },
       },
       validations: {
@@ -77,9 +83,13 @@ const tests = [
         },
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            resolveVersionAlias: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
+            },
+            attachProjectID: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
             },
           },
         },
@@ -101,7 +111,8 @@ const tests = [
           versionConsume: 1,
         },
         project: {
-          attachID: 1,
+          resolveVersionAlias: 1,
+          attachProjectID: 1,
         },
       },
       validations: {
@@ -115,9 +126,13 @@ const tests = [
         },
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            resolveVersionAlias: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
+            },
+            attachProjectID: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
             },
           },
         },
@@ -139,15 +154,20 @@ const tests = [
           versionConsume: 1,
         },
         project: {
-          attachID: 1,
+          resolveVersionAlias: 1,
+          attachProjectID: 1,
         },
       },
       validations: {
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            resolveVersionAlias: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
+            },
+            attachProjectID: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
             },
           },
         },
@@ -176,15 +196,20 @@ const tests = [
           versionConsume: 1,
         },
         project: {
-          attachID: 1,
+          resolveVersionAlias: 1,
+          attachProjectID: 1,
         },
       },
       validations: {
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            resolveVersionAlias: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
+            },
+            attachProjectID: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
             },
           },
         },
@@ -214,7 +239,8 @@ const tests = [
           versionConsume: 1,
         },
         project: {
-          attachID: 1,
+          resolveVersionAlias: 1,
+          attachProjectID: 1,
         },
       },
       validations: {
@@ -228,9 +254,13 @@ const tests = [
         },
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            resolveVersionAlias: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
+            },
+            attachProjectID: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
             },
           },
         },
@@ -254,15 +284,24 @@ const tests = [
         },
         project: {
           unifyVersionID: 1,
-          attachID: 1,
+          resolveVersionAliasLegacy: 1,
+          attachProjectID: 1,
         },
       },
       validations: {
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            unifyVersionID: {
+              HEADER_VERSION_ID: 1,
+              PARAMS_VERSION_ID: 1,
+            },
+            resolveVersionAliasLegacy: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
+            },
+            attachProjectID: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
             },
           },
         },
@@ -295,7 +334,8 @@ const tests = [
         },
         project: {
           unifyVersionID: 1,
-          attachID: 1,
+          resolveVersionAliasLegacy: 1,
+          attachProjectID: 1,
         },
       },
       validations: {
@@ -308,9 +348,17 @@ const tests = [
         },
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            unifyVersionID: {
+              HEADER_VERSION_ID: 1,
+              PARAMS_VERSION_ID: 1,
+            },
+            resolveVersionAliasLegacy: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
+            },
+            attachProjectID: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
             },
           },
         },
@@ -333,7 +381,8 @@ const tests = [
         },
         project: {
           unifyVersionID: 1,
-          attachID: 1,
+          resolveVersionAliasLegacy: 1,
+          attachProjectID: 1,
         },
       },
       validations: {
@@ -347,9 +396,17 @@ const tests = [
         },
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            unifyVersionID: {
+              HEADER_VERSION_ID: 1,
+              PARAMS_VERSION_ID: 1,
+            },
+            resolveVersionAliasLegacy: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
+            },
+            attachProjectID: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
             },
           },
         },
@@ -372,15 +429,24 @@ const tests = [
         },
         project: {
           unifyVersionID: 1,
-          attachID: 1,
+          resolveVersionAliasLegacy: 1,
+          attachProjectID: 1,
         },
       },
       validations: {
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            unifyVersionID: {
+              HEADER_VERSION_ID: 1,
+              PARAMS_VERSION_ID: 1,
+            },
+            resolveVersionAliasLegacy: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
+            },
+            attachProjectID: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
             },
           },
         },
@@ -410,15 +476,24 @@ const tests = [
         },
         project: {
           unifyVersionID: 1,
-          attachID: 1,
+          resolveVersionAliasLegacy: 1,
+          attachProjectID: 1,
         },
       },
       validations: {
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            unifyVersionID: {
+              HEADER_VERSION_ID: 1,
+              PARAMS_VERSION_ID: 1,
+            },
+            resolveVersionAliasLegacy: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
+            },
+            attachProjectID: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
             },
           },
         },
@@ -449,7 +524,8 @@ const tests = [
         },
         project: {
           unifyVersionID: 1,
-          attachID: 1,
+          resolveVersionAliasLegacy: 1,
+          attachProjectID: 1,
         },
       },
       validations: {
@@ -463,9 +539,17 @@ const tests = [
         },
         middlewares: {
           project: {
-            attachID: {
-              HEADERS_VERSION_ID: 1,
-              HEADERS_AUTHORIZATION: 1,
+            unifyVersionID: {
+              HEADER_VERSION_ID: 1,
+              PARAMS_VERSION_ID: 1,
+            },
+            resolveVersionAliasLegacy: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
+            },
+            attachProjectID: {
+              HEADER_VERSION_ID: 1,
+              HEADER_AUTHORIZATION: 1,
             },
           },
         },
@@ -488,7 +572,7 @@ describe('state route unit tests', () => {
       const fixture = await fixtures.createFixture();
       ({ app, server } = await GetApp(fixture));
 
-      const response = await request(app)[test.method](test.calledPath);
+      const response = await (request(app) as any)[test.method](test.calledPath);
 
       fixtures.checkFixture(fixture, test.expected);
       expect(response.body).to.eql({ done: 'done' });

--- a/tests/server/state.unit.ts
+++ b/tests/server/state.unit.ts
@@ -284,7 +284,7 @@ const tests = [
         },
         project: {
           unifyVersionID: 1,
-          resolveVersionAliasLegacy: 1,
+          resolveVersionAlias: 1,
           attachProjectID: 1,
         },
       },
@@ -295,7 +295,7 @@ const tests = [
               HEADER_VERSION_ID: 1,
               PARAMS_VERSION_ID: 1,
             },
-            resolveVersionAliasLegacy: {
+            resolveVersionAlias: {
               HEADER_VERSION_ID: 1,
               HEADER_AUTHORIZATION: 1,
             },
@@ -334,7 +334,7 @@ const tests = [
         },
         project: {
           unifyVersionID: 1,
-          resolveVersionAliasLegacy: 1,
+          resolveVersionAlias: 1,
           attachProjectID: 1,
         },
       },
@@ -352,7 +352,7 @@ const tests = [
               HEADER_VERSION_ID: 1,
               PARAMS_VERSION_ID: 1,
             },
-            resolveVersionAliasLegacy: {
+            resolveVersionAlias: {
               HEADER_VERSION_ID: 1,
               HEADER_AUTHORIZATION: 1,
             },
@@ -381,7 +381,7 @@ const tests = [
         },
         project: {
           unifyVersionID: 1,
-          resolveVersionAliasLegacy: 1,
+          resolveVersionAlias: 1,
           attachProjectID: 1,
         },
       },
@@ -400,7 +400,7 @@ const tests = [
               HEADER_VERSION_ID: 1,
               PARAMS_VERSION_ID: 1,
             },
-            resolveVersionAliasLegacy: {
+            resolveVersionAlias: {
               HEADER_VERSION_ID: 1,
               HEADER_AUTHORIZATION: 1,
             },
@@ -429,7 +429,7 @@ const tests = [
         },
         project: {
           unifyVersionID: 1,
-          resolveVersionAliasLegacy: 1,
+          resolveVersionAlias: 1,
           attachProjectID: 1,
         },
       },
@@ -440,7 +440,7 @@ const tests = [
               HEADER_VERSION_ID: 1,
               PARAMS_VERSION_ID: 1,
             },
-            resolveVersionAliasLegacy: {
+            resolveVersionAlias: {
               HEADER_VERSION_ID: 1,
               HEADER_AUTHORIZATION: 1,
             },
@@ -476,7 +476,7 @@ const tests = [
         },
         project: {
           unifyVersionID: 1,
-          resolveVersionAliasLegacy: 1,
+          resolveVersionAlias: 1,
           attachProjectID: 1,
         },
       },
@@ -487,7 +487,7 @@ const tests = [
               HEADER_VERSION_ID: 1,
               PARAMS_VERSION_ID: 1,
             },
-            resolveVersionAliasLegacy: {
+            resolveVersionAlias: {
               HEADER_VERSION_ID: 1,
               HEADER_AUTHORIZATION: 1,
             },
@@ -524,7 +524,7 @@ const tests = [
         },
         project: {
           unifyVersionID: 1,
-          resolveVersionAliasLegacy: 1,
+          resolveVersionAlias: 1,
           attachProjectID: 1,
         },
       },
@@ -543,7 +543,7 @@ const tests = [
               HEADER_VERSION_ID: 1,
               PARAMS_VERSION_ID: 1,
             },
-            resolveVersionAliasLegacy: {
+            resolveVersionAlias: {
               HEADER_VERSION_ID: 1,
               HEADER_AUTHORIZATION: 1,
             },

--- a/types.ts
+++ b/types.ts
@@ -39,6 +39,7 @@ export interface Config extends RateLimitConfig {
   BUILD_URL: string | null;
 
   GENERAL_SERVICE_ENDPOINT: string | null;
+  LUIS_SERVICE_ENDPOINT: string | null;
 
   CREATOR_API_ENDPOINT: string | null;
   CREATOR_API_AUTHORIZATION: string | null;
@@ -98,6 +99,14 @@ export interface Class<T, A extends any[]> {
   new (...args: A): T;
 }
 export type AnyClass = Class<any, any[]>;
+
+export enum VersionTag {
+  DEVELOPMENT = 'development',
+  PRODUCTION = 'production',
+}
+
+export const isVersionTag = (value: unknown): value is VersionTag =>
+  value === VersionTag.DEVELOPMENT || value === VersionTag.PRODUCTION;
 
 export interface ContextData {
   api: CacheDataAPI;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3982**

### Brief description. What is this change?

The `resolveVersionAlias` needs to support looking up a version ID using an alias (`"development"`, or `"production"`). But this can only occur if using a dialog manager (DM) API key though, so we need to fail if a workspace key (WS) is trying to resolve an alias.

A DM key can default to the attached project's `devVersion` if a version ID is not provided. But with a WS key a version ID must always be provided.

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/creator-api/pull/1023
- https://github.com/voiceflow/general-runtime/pull/363