### PR TITLE
fix: gracefully handle non-JSON responses in the API step (VF-4002)

### DIFF
--- a/runtime/lib/Handlers/api/utils.ts
+++ b/runtime/lib/Handlers/api/utils.ts
@@ -200,8 +200,11 @@ export const makeAPICall = async (nodeData: APINodeData, runtime: Runtime, confi
 
   const { response, requestOptions } = await doFetch(config, nodeData);
 
-  // TODO: Response bodies that aren't JSON will make this error
-  const rawResponseJSON = await response.json();
+  const rawResponseJSON = await response
+    .json()
+    // Ignore JSON parsing errors and default to an empty object
+    // This is a kinda hacky way to support non-JSON responses without much effort
+    .catch(() => ({}));
 
   const { newVariables, responseJSON } = transformResponseBody(rawResponseJSON, response, nodeData);
 


### PR DESCRIPTION
**Fixes or implements VF-4002**

### Brief description. What is this change?

in the api step try parsing the response as JSON. if that fails, just use an empty blob of JSON (`{}`) as a fallback

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written