### PR TITLE
[Merged by Bors] - refactor: pass general-service versionID on predict (VF-3904)

### DIFF
--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -132,6 +132,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
           ? await this.services.nlu.predict({
               query: `${prefix} ${query}`,
               projectID: version.projectID,
+              versionID: context.versionID,
             })
           : incomingRequest;
 

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -25,11 +25,13 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     model,
     locale,
     projectID,
+    versionID,
   }: {
     query: string;
     model?: BaseModels.PrototypeModel;
     locale?: VoiceflowConstants.Locale;
     projectID: string;
+    versionID: string;
   }) {
     // 1. first try restricted regex (no open slots) - exact string match
     if (model && locale) {
@@ -41,9 +43,12 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
 
     // 2. next try to resolve with luis NLP on general-service
     const { data } = await this.services.axios
-      .post<BaseRequest.IntentRequest | null>(`${this.config.GENERAL_SERVICE_ENDPOINT}/runtime/${projectID}/predict`, {
-        query,
-      })
+      .post<BaseRequest.IntentRequest | null>(
+        `${this.config.GENERAL_SERVICE_ENDPOINT}/runtime/${projectID}/predict?versionID=${versionID}`,
+        {
+          query,
+        }
+      )
       .catch(() => ({ data: null }));
 
     if (data) {
@@ -84,6 +89,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
       model: version.prototype?.model,
       locale: version.prototype?.data.locales[0] as VoiceflowConstants.Locale,
       projectID: version.projectID,
+      versionID: context.versionID,
     });
 
     return { ...context, request };

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -43,14 +43,10 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
 
     // 2. next try to resolve with luis NLP on general-service
     const { data } = await this.services.axios
-      .post<BaseRequest.IntentRequest | null>(
-        // eslint-disable-next-line prefer-template
-        `${this.config.GENERAL_SERVICE_ENDPOINT}/runtime/${projectID}/predict` +
-          (versionID ? `?versionID=${versionID}` : ''),
-        {
-          query,
-        }
-      )
+      .post<BaseRequest.IntentRequest | null>(`${this.config.GENERAL_SERVICE_ENDPOINT}/runtime/${projectID}/predict`, {
+        query,
+        versionID,
+      })
       .catch(() => ({ data: null }));
 
     if (data) {

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -55,6 +55,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
           query,
           resourceID,
           tag,
+          projectID,
           versionID,
         })
         .catch(() => ({ data: null }));

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -44,7 +44,9 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     // 2. next try to resolve with luis NLP on general-service
     const { data } = await this.services.axios
       .post<BaseRequest.IntentRequest | null>(
-        `${this.config.GENERAL_SERVICE_ENDPOINT}/runtime/${projectID}/predict?versionID=${versionID}`,
+        // eslint-disable-next-line prefer-template
+        `${this.config.GENERAL_SERVICE_ENDPOINT}/runtime/${projectID}/predict` +
+          (versionID ? `?versionID=${versionID}` : ''),
         {
           query,
         }

--- a/tests/lib/services/nlu/index.unit.ts
+++ b/tests/lib/services/nlu/index.unit.ts
@@ -53,8 +53,8 @@ describe('nlu manager unit tests', () => {
       expect(context.data.api.getVersion.args).to.eql([[context.versionID]]);
       expect(services.axios.post.args).to.eql([
         [
-          `${GENERAL_SERVICE_ENDPOINT}/runtime/${version.projectID}/predict?versionID=${version._id}`,
-          { query: oldRequest.payload },
+          `${GENERAL_SERVICE_ENDPOINT}/runtime/${version.projectID}/predict`,
+          { query: oldRequest.payload, versionID: version._id },
         ],
       ]);
     });
@@ -126,7 +126,13 @@ describe('nlu manager unit tests', () => {
           post: sinon.stub().resolves({ data: 'data-val' }),
         },
       };
-      const arg = { model: 'model-val', locale: 'locale-val', query: 'query-val', projectID: 'projectID' } as any;
+      const arg = {
+        model: 'model-val',
+        locale: 'locale-val',
+        query: 'query-val',
+        projectID: 'projectID',
+        versionID: 'versionID',
+      } as any;
       const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
       const handleNLCCommandStub = sinon
         .stub(NLC, 'handleNLCCommand')
@@ -134,7 +140,10 @@ describe('nlu manager unit tests', () => {
 
       expect(await nlu.predict(arg)).to.eql('data-val');
       expect(services.axios.post.args).to.eql([
-        [`${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`, { query: 'query-val' }],
+        [
+          `${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`,
+          { query: 'query-val', versionID: 'versionID' },
+        ],
       ]);
     });
 
@@ -144,14 +153,17 @@ describe('nlu manager unit tests', () => {
           post: sinon.stub().resolves({ data: 'data-val' }),
         },
       };
-      const arg = { model: '', locale: '', query: 'query-val', projectID: 'projectID' } as any;
+      const arg = { model: '', locale: '', query: 'query-val', projectID: 'projectID', versionID: 'versionID' } as any;
       const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
       const handleNLCCommandStub = sinon
         .stub(NLC, 'handleNLCCommand')
         .returns({ payload: { intent: { name: 'abcdefg' } } } as any);
       expect(await nlu.predict(arg)).to.eql('data-val');
       expect(services.axios.post.args).to.eql([
-        [`${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`, { query: 'query-val' }],
+        [
+          `${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`,
+          { query: 'query-val', versionID: 'versionID' },
+        ],
       ]);
     });
 
@@ -161,7 +173,7 @@ describe('nlu manager unit tests', () => {
           post: sinon.stub().resolves({ data: undefined }),
         },
       };
-      const arg = { model: '', locale: '', query: 'query-val', projectID: 'projectID' } as any;
+      const arg = { model: '', locale: '', query: 'query-val', projectID: 'projectID', versionID: 'versionID' } as any;
       const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
       const handleNLCCommandStub = sinon
         .stub(NLC, 'handleNLCCommand')
@@ -169,7 +181,10 @@ describe('nlu manager unit tests', () => {
 
       await expect(nlu.predict(arg)).to.be.rejectedWith(Error);
       expect(services.axios.post.args).to.eql([
-        [`${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`, { query: 'query-val' }],
+        [
+          `${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`,
+          { query: 'query-val', versionID: 'versionID' },
+        ],
       ]);
     });
 
@@ -179,7 +194,13 @@ describe('nlu manager unit tests', () => {
           post: sinon.stub().resolves({ data: undefined }),
         },
       };
-      const arg = { model: 'abcd', locale: '', query: 'query-val', projectID: 'projectID' } as any;
+      const arg = {
+        model: 'abcd',
+        locale: '',
+        query: 'query-val',
+        projectID: 'projectID',
+        versionID: 'versionID',
+      } as any;
       const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
       const handleNLCCommandStub = sinon
         .stub(NLC, 'handleNLCCommand')
@@ -187,7 +208,10 @@ describe('nlu manager unit tests', () => {
 
       await expect(nlu.predict(arg)).to.be.rejectedWith(Error);
       expect(services.axios.post.args).to.eql([
-        [`${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`, { query: 'query-val' }],
+        [
+          `${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`,
+          { query: 'query-val', versionID: 'versionID' },
+        ],
       ]);
     });
 
@@ -197,7 +221,13 @@ describe('nlu manager unit tests', () => {
           post: sinon.stub().resolves({ data: undefined }),
         },
       };
-      const arg = { model: 'abcd', locale: 'abcd', query: 'query-val', projectID: 'projectID' } as any;
+      const arg = {
+        model: 'abcd',
+        locale: 'abcd',
+        query: 'query-val',
+        projectID: 'projectID',
+        versionID: 'versionID',
+      } as any;
       const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
       const handleNLCCommandStub = sinon
         .stub(NLC, 'handleNLCCommand')
@@ -206,7 +236,10 @@ describe('nlu manager unit tests', () => {
       expect(await nlu.predict(arg)).to.eql({ payload: { intent: { name: NONE_INTENT } } });
       expect(handleNLCCommandStub.callCount).to.eql(2);
       expect(services.axios.post.args).to.eql([
-        [`${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`, { query: 'query-val' }],
+        [
+          `${GENERAL_SERVICE_ENDPOINT}/runtime/${arg.projectID}/predict`,
+          { query: 'query-val', versionID: 'versionID' },
+        ],
       ]);
     });
   });

--- a/tests/lib/services/nlu/index.unit.ts
+++ b/tests/lib/services/nlu/index.unit.ts
@@ -52,7 +52,10 @@ describe('nlu manager unit tests', () => {
       expect(await nlu.handle(context as any)).to.eql({ ...context, request: newRequest });
       expect(context.data.api.getVersion.args).to.eql([[context.versionID]]);
       expect(services.axios.post.args).to.eql([
-        [`${GENERAL_SERVICE_ENDPOINT}/runtime/${version.projectID}/predict`, { query: oldRequest.payload }],
+        [
+          `${GENERAL_SERVICE_ENDPOINT}/runtime/${version.projectID}/predict?versionID=${version._id}`,
+          { query: oldRequest.payload },
+        ],
       ]);
     });
 

--- a/tests/lib/services/nlu/index.unit.ts
+++ b/tests/lib/services/nlu/index.unit.ts
@@ -143,6 +143,7 @@ describe('nlu manager unit tests', () => {
         query,
         resourceID: nlp.resourceID,
         tag: VersionTag.PRODUCTION,
+        projectID: version.projectID,
         versionID: liveVersion,
       });
     });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3904**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
