### PR TITLE
[Merged by Bors] - fix: use actual environment variable names (VF-000)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -34,8 +34,8 @@ const CONFIG: Config = {
   INTEGRATIONS_HANDLER_ENDPOINT: getOptionalProcessEnv('INTEGRATIONS_HANDLER_ENDPOINT') || 'none',
   // api-block
   API_REQUEST_TIMEOUT_MS: Number(getOptionalProcessEnv('API_MAX_TIMEOUT_MS')) || null,
-  API_MAX_REQUEST_SIZE_BYTES: Number(getOptionalProcessEnv('API_MAX_CONTENT_LENGTH_BYTES')) || null,
-  API_MAX_RESPONSE_SIZE_BYTES: Number(getOptionalProcessEnv('API_MAX_BODY_LENGTH_BYTES')) || null,
+  API_MAX_CONTENT_LENGTH_BYTES: Number(getOptionalProcessEnv('API_MAX_CONTENT_LENGTH_BYTES')) || null,
+  API_MAX_BODY_LENGTH_BYTES: Number(getOptionalProcessEnv('API_MAX_BODY_LENGTH_BYTES')) || null,
 
   PROJECT_SOURCE: getOptionalProcessEnv('PROJECT_SOURCE'),
 

--- a/lib/services/runtime/handlers/index.ts
+++ b/lib/services/runtime/handlers/index.ts
@@ -32,8 +32,8 @@ const _v1Handler = _V1Handler();
 
 export default ({
   API_REQUEST_TIMEOUT_MS,
-  API_MAX_RESPONSE_SIZE_BYTES,
-  API_MAX_REQUEST_SIZE_BYTES,
+  API_MAX_CONTENT_LENGTH_BYTES,
+  API_MAX_BODY_LENGTH_BYTES,
   INTEGRATIONS_HANDLER_ENDPOINT,
   CODE_HANDLER_ENDPOINT,
 }: Config) => [
@@ -52,8 +52,8 @@ export default ({
   IfV2Handler({ _v1: _v1Handler }),
   APIHandler({
     requestTimeoutMs: API_REQUEST_TIMEOUT_MS ?? undefined,
-    maxResponseBodySizeBytes: API_MAX_RESPONSE_SIZE_BYTES ?? undefined,
-    maxRequestBodySizeBytes: API_MAX_REQUEST_SIZE_BYTES ?? undefined,
+    maxResponseBodySizeBytes: API_MAX_CONTENT_LENGTH_BYTES ?? undefined,
+    maxRequestBodySizeBytes: API_MAX_BODY_LENGTH_BYTES ?? undefined,
   }),
   IntegrationsHandler({ integrationsEndpoint: INTEGRATIONS_HANDLER_ENDPOINT }),
   RandomHandler(),

--- a/types.ts
+++ b/types.ts
@@ -29,8 +29,8 @@ export interface Config extends RateLimitConfig {
   CODE_HANDLER_ENDPOINT: string | null;
   INTEGRATIONS_HANDLER_ENDPOINT: string;
   API_REQUEST_TIMEOUT_MS: number | null;
-  API_MAX_REQUEST_SIZE_BYTES: number | null;
-  API_MAX_RESPONSE_SIZE_BYTES: number | null;
+  API_MAX_CONTENT_LENGTH_BYTES: number | null;
+  API_MAX_BODY_LENGTH_BYTES: number | null;
 
   // Release information
   GIT_SHA: string | null;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?
Originally we were mapping 
* `API_MAX_CONTENT_LENGTH_BYTES` to `API_MAX_REQUEST_SIZE_BYTES`
* `API_MAX_BODY_LENGTH_BYTES` to `API_MAX_RESPONSE_SIZE_BYTES`

although the remapped names are much more intuitive and readable, it sets a very dangerous precedence of the `config` env var name not being lined up with the ACTUAL environment variable.
