### PR TITLE
fix: capture step doesnt leave user hanging if no entity prompt is provided (VF-3977)

### DIFF
--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -39,6 +39,8 @@ export const utils = {
 export interface DMStore {
   intentRequest?: BaseRequest.IntentRequest;
   priorIntent?: BaseRequest.IntentRequest;
+  hasEntityPrompt?: boolean;
+  hasUnfulfilledEntity?: boolean;
 }
 
 @injectServices({ utils })
@@ -222,6 +224,11 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
         },
       });
 
+      context = DialogManagement.setDMStore(context, {
+        ...dmStateStore,
+        hasUnfulfilledEntity: true,
+        hasEntityPrompt: !!prompt,
+      });
       return {
         ...context,
         end: true,
@@ -241,10 +248,12 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
       intentRequest = setElicit(intentRequest, false);
     }
 
+    // cannot clear the DM state store as it is needed for the capture step
+    context = DialogManagement.setDMStore(context, { ...dmStateStore, hasUnfulfilledEntity: false });
+
     context.request = intentRequest;
 
-    // Clear the DM state store
-    return DialogManagement.setDMStore(context, undefined);
+    return context;
   };
 }
 


### PR DESCRIPTION
**Fixes or implements VF-3977**

### Brief description. What is this change?

Whenever a capture step didnt have an entity prompt it was still waiting for that prompt on the node handlers instead of automatically going to the no match case. Now we keep that information on the state so that the node can handle it properly.

### Implementation details. How do you make this change?
For this to work I needed to add some extra context to the dm state store. Namely if the current capture step has an unfulfilled entity and if that unfulfilled entity has an entity prompt. I needed to "hack" this though the state because otherwise that information is not available on the node handler.

If there isnt an unfulfilled entity we must not allow the handleCapturePath to run.

If there isnt an entity prompt we must not give back an entityFillingRequest.