### PR TITLE
[Merged by Bors] - fix: paths no longer working on NoMatch and NoResponse (PL-87)

### DIFF
--- a/lib/services/runtime/handlers/noMatch.ts
+++ b/lib/services/runtime/handlers/noMatch.ts
@@ -65,7 +65,7 @@ export const NoMatchHandler = (utils: typeof utilsObj) => ({
     runtime.storage.set(StorageType.NO_MATCHES_COUNTER, noMatchCounter + 1);
 
     utils.outputTrace({
-      addTrace: runtime.trace.addTrace,
+      addTrace: runtime.trace.addTrace.bind(runtime.trace),
       debugLogging: runtime.debugLogging,
       node,
       output,

--- a/lib/services/runtime/handlers/noReply.ts
+++ b/lib/services/runtime/handlers/noReply.ts
@@ -63,7 +63,7 @@ export const NoReplyHandler = (utils: typeof utilsObj) => ({
     runtime.storage.set(StorageType.NO_REPLIES_COUNTER, noReplyCounter + 1);
 
     utils.outputTrace({
-      addTrace: runtime.trace.addTrace,
+      addTrace: runtime.trace.addTrace.bind(runtime.trace),
       debugLogging: runtime.debugLogging,
       node,
       output,

--- a/lib/services/runtime/handlers/repeat.ts
+++ b/lib/services/runtime/handlers/repeat.ts
@@ -32,7 +32,7 @@ export const RepeatHandler = (utils: typeof utilsObj) => ({
 
     utils.outputTrace({
       output,
-      addTrace: runtime.trace.addTrace,
+      addTrace: runtime.trace.addTrace.bind(runtime.trace),
       debugLogging: runtime.debugLogging,
     });
 

--- a/lib/services/runtime/init.ts
+++ b/lib/services/runtime/init.ts
@@ -34,7 +34,7 @@ const init = (client: Client) => {
     }
 
     outputTrace({
-      addTrace: runtime.trace.addTrace,
+      addTrace: runtime.trace.addTrace.bind(runtime.trace),
       debugLogging: runtime.debugLogging,
       output,
     });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-87**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Fixed issue where No Reply Response and No Match paths were not working properly.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

The issue is because we're passing in a class method like `myObject.method` but inside the method, but the keyword `this` is `undefined`

The reason for this is because of JavaScript subtleties, when you just pass in a class method like `myObject.method` it doesn't automatically set `this` to `myObject`. So the function `runtime.trace.addTrace` gets called with `this` as `undefined` and the line `this.runtime.callEvent` fails with a type error because `.runtime` is not a property of `undefined`

<img width="1284" alt="Screen Shot 2022-07-26 at 2 47 03 PM" src="https://user-images.githubusercontent.com/32404412/181090707-93afed3d-1e06-4853-81e9-3f0006dd2910.png">

There are two solutions:

1. Use `.bind()` to ensure that `runtime.trace.addTrace` gets the right `this` parameter <-- I went with this
2. Wrap `runtime.trace.addTrace` in another function.
```js
(...args) => runtime.trace.addTrace(...args);
```

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

N/A

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

N/A

### Related PRs

<!-- List related PRs against other branches -->

N/A

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
