### PR TITLE
[Merged by Bors] - fix: fix canHandle() for code step with empty code (VF-4138)

### DIFF
--- a/runtime/lib/Handlers/code/index.ts
+++ b/runtime/lib/Handlers/code/index.ts
@@ -23,7 +23,7 @@ const CodeHandler: HandlerFactory<BaseNode.Code.Node, CodeOptions | void> = ({
   useStrictVM = false,
   testingEnv = false,
 } = {}) => ({
-  canHandle: (node) => !!node.code,
+  canHandle: (node) => typeof node.code === 'string',
   handle: async (node, runtime, variables) => {
     try {
       const variablesState = variables.getState();


### PR DESCRIPTION
**Fixes or implements VF-4138**

### Brief description. What is this change?

run the code step when the code provided is empty. it will go down the failure path.

### Implementation details. How do you make this change?

the `canHandle()` function was casting `''` to `false`. the new check will return `true` when the code is `''` or any other type of string.

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written