### PR TITLE
[Merged by Bors] - fix: carousel card image not translating variables (CT-707)

### DIFF
--- a/lib/services/runtime/handlers/carousel.ts
+++ b/lib/services/runtime/handlers/carousel.ts
@@ -37,6 +37,7 @@ export const CarouselHandler: HandlerFactory<BaseNode.Carousel.Node, typeof hand
         return {
           ...card,
           title: replaceVariables(card.title, variablesMap),
+          imageUrl: replaceVariables(card.imageUrl, variablesMap),
           description: {
             slate,
             text,

--- a/tests/lib/services/runtime/handlers/carousel.unit.ts
+++ b/tests/lib/services/runtime/handlers/carousel.unit.ts
@@ -41,7 +41,7 @@ describe('Carousel handler', () => {
             id: 'card-1',
             title: 'Card Nike',
             description: slateTransformed,
-            imageUrl: '',
+            imageUrl: 'image/{image1}.jpeg',
             buttons: [
               {
                 name: 'Button Nike buy',
@@ -68,7 +68,7 @@ describe('Carousel handler', () => {
         trace: { addTrace: sinon.stub() },
         storage: { delete: sinon.stub() },
       };
-      const variables = { getState: sinon.stub().returns({ var1: 'val 1' }) };
+      const variables = { getState: sinon.stub().returns({ var1: 'val 1', image1: 'sample-image' }) };
       expect(handler.handle(node, runtime as any, variables as any, null as any)).to.eql(node.id);
       expect(utils.addNoReplyTimeoutIfExists.args).to.eql([[node, runtime]]);
       expect(runtime.storage.delete.callCount).to.eql(2);
@@ -87,7 +87,7 @@ describe('Carousel handler', () => {
                     slate: slateTransformed,
                     text: 'card description',
                   },
-                  imageUrl: '',
+                  imageUrl: 'image/sample-image.jpeg',
                   buttons: [
                     {
                       name: 'Button Nike buy',


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-707**

### Brief description. What is this change?

 - Carousel Images can contain variables in their value and should be translated.

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->


### Checklist

- [ ] this is a breaking change and should publish a new major version
- [X] appropriate tests have been written
