### PR TITLE
[Merged by Bors] - fix: improve error response from unknown version IDs (PL-62)

### DIFF
--- a/lib/middlewares/project.ts
+++ b/lib/middlewares/project.ts
@@ -114,7 +114,12 @@ class Project extends AbstractMiddleware {
 
       const api = await this.services.dataAPI.get(req.headers.authorization);
 
-      const { projectID } = await api.getVersion(req.headers.versionID);
+      const { projectID } = await api.getVersion(req.headers.versionID).catch(() => {
+        throw new VError(
+          `Could not resolve project with version ID ${req.headers.versionID}`,
+          VError.HTTP_STATUS.BAD_REQUEST
+        );
+      });
 
       req.headers.projectID = projectID;
 


### PR DESCRIPTION
**Fixes or implements PL-62**

### Brief description. What is this change?

before:
![json response](https://user-images.githubusercontent.com/7608555/185552203-a5f10803-c36d-4eec-a18f-b41da00f1791.png)

after:
![json response](https://user-images.githubusercontent.com/7608555/185552168-2b0ca2d2-6d9d-4a1a-8af1-838fad6f9397.png)

### Implementation details. How do you make this change?

the middleware we use as part of resolving projects had a potential error case that wasn't covered.
this resulted in the (very bad) default error handling of "Unknown error" triggering, and responding with a 500.
the change is simple: just `.catch()` the error if fetching the version by ID fails, and blame the user if it does

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written