### PR TITLE
[Merged by Bors] - feat: make channel action create channel action traces (PL-38)

### DIFF
--- a/lib/services/runtime/handlers/channelAction.ts
+++ b/lib/services/runtime/handlers/channelAction.ts
@@ -12,8 +12,8 @@ export const ChannelActionHandler: HandlerFactory<BaseNode.ChannelAction.Node> =
     const _v1Node: BaseNode._v1.Node = {
       ...node,
       _v: 1,
-      type: node.data.name,
-      payload: node.data.payload,
+      type: BaseNode.NodeType.CHANNEL_ACTION,
+      payload: node.data,
     };
 
     return _v1Handler.handle(_v1Node, ...args);


### PR DESCRIPTION
**Fixes or implements PL-38**

### Brief description. What is this change?

Lets not hide the card/permissions.userInfo/etc traces are actually a channel action
The `trace.payload.name` will hold it.
Actual payload will live in `trace.payload.payload`