### PR TITLE
[Merged by Bors] - fix: run oneshot handler only during request action (CT-000)

### DIFF
--- a/lib/services/runtime/handlers/state/oneShot.ts
+++ b/lib/services/runtime/handlers/state/oneShot.ts
@@ -1,6 +1,6 @@
 import { BaseNode } from '@voiceflow/base-types';
 
-import { HandlerFactory } from '@/runtime';
+import { Action, HandlerFactory } from '@/runtime';
 
 import { isIntentRequest } from '../../types';
 import CommandHandler from '../command';
@@ -12,7 +12,10 @@ const utilsObj = {
 export const OneShotIntentHandler: HandlerFactory<BaseNode.Start.Node, typeof utilsObj> = (utils) => ({
   canHandle: (node, runtime) => {
     return (
-      isIntentRequest(runtime.getRequest()) && runtime.stack.getSize() <= 2 && node.type === BaseNode.NodeType.START
+      runtime.getAction() === Action.REQUEST &&
+      isIntentRequest(runtime.getRequest()) &&
+      runtime.stack.getSize() <= 2 &&
+      node.type === BaseNode.NodeType.START
     );
   },
   handle: (node, runtime, variables) => {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

fix the runtime recursion issue when start node is triggered via intent and go to block/domain.
it happens due to OneShot handler. Usually we have only 2 traces when goto is triggered, so OneShot triggers the same intent again, and again, and again...

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
