### PR TITLE
[Merged by Bors] - fix: public interact response shape (CT-1046)

### DIFF
--- a/lib/controllers/stateManagement/index.ts
+++ b/lib/controllers/stateManagement/index.ts
@@ -58,12 +58,14 @@ class StateManagementController extends AbstractController {
       { projectID: string; versionID: string }
     >
   ) {
-    return this.services.stateManagement.interact({
+    const trace = await this.services.stateManagement.interact({
       ...req,
       // only pass in select properties to avoid any potential security issues
       query: {}, // no logs allowed
       headers: { projectID: req.headers.projectID, versionID: req.headers.versionID },
     });
+
+    return { trace };
   }
 
   @validate({ HEADERS_PROJECT_ID: VALIDATIONS.HEADERS.PROJECT_ID })


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-1046**

### Brief description. What is this change?
we have this very annoying/bad pattern determined here:
https://github.com/voiceflow/general-runtime/blob/4ee8ab709790bf7dadb4fe337e83923cfccd00ab/lib/services/stateManagement.ts#L27

where it might give back an array of traces OR an object with `{ state, trace: Trace[], request }` inside.
Since the public endpoint isn't used yet, it would be much better for it to return `{ trace: Trace[] }` instead of just `Trace[]`.

This gives us opportunities to add additional return details in the future.