### PR TITLE
refactor: pass config in directly (PL-120)

### DIFF
--- a/backend/api/routers/api.ts
+++ b/backend/api/routers/api.ts
@@ -2,9 +2,9 @@ import bodyParser from '@voiceflow/body-parser';
 import express from 'express';
 
 import { BODY_PARSER_SIZE_LIMIT } from '@/backend/constants';
-import CONFIG from '@/config';
+import config from '@/config';
 import { MiddlewareMap } from '@/lib';
-import { createResponseConfig } from '@/lib/utils';
+import { getAPIBlockHandlerOptions } from '@/lib/services/runtime/handlers/api';
 import { callAPI } from '@/runtime/lib/Handlers/api/utils';
 
 export default (middlewares: MiddlewareMap) => {
@@ -14,7 +14,7 @@ export default (middlewares: MiddlewareMap) => {
   router.use(middlewares.rateLimit.verify);
 
   router.post('/', async (req, res) => {
-    const { responseJSON } = await callAPI(req.body.api, createResponseConfig(CONFIG));
+    const { responseJSON } = await callAPI(req.body.api, getAPIBlockHandlerOptions(config));
     if (responseJSON.VF_STATUS_CODE) {
       res.status(responseJSON.VF_STATUS_CODE);
     }

--- a/lib/services/runtime/handlers/api.ts
+++ b/lib/services/runtime/handlers/api.ts
@@ -1,0 +1,14 @@
+import { APIHandler, APIHandlerConfig } from '@/runtime';
+import { Config } from '@/types';
+
+export const getAPIBlockHandlerOptions = (config: Config): Partial<APIHandlerConfig> => ({
+  requestTimeoutMs: config.API_REQUEST_TIMEOUT_MS ?? undefined,
+  maxResponseBodySizeBytes: config.API_MAX_CONTENT_LENGTH_BYTES ?? undefined,
+  maxRequestBodySizeBytes: config.API_MAX_BODY_LENGTH_BYTES ?? undefined,
+  awsAccessKey: config.AWS_ACCESS_KEY_ID ?? undefined,
+  awsSecretAccessKey: config.AWS_SECRET_ACCESS_KEY ?? undefined,
+  awsRegion: config.AWS_REGION ?? undefined,
+  s3TLSBucket: config.S3_TLS_BUCKET ?? undefined,
+});
+
+export default (config: Config) => APIHandler(getAPIBlockHandlerOptions(config));

--- a/lib/services/runtime/handlers/index.ts
+++ b/lib/services/runtime/handlers/index.ts
@@ -1,5 +1,4 @@
 import {
-  APIHandler,
   CodeHandler,
   EndHandler,
   FlowHandler,
@@ -17,6 +16,7 @@ import {
 import { Config } from '@/types';
 
 import _V1Handler from './_v1';
+import APIHandler from './api';
 import CaptureHandler from './capture';
 import CaptureV2Handler from './captureV2';
 import CardV2Handler from './cardV2';
@@ -46,15 +46,7 @@ export default (config: Config) => [
   FlowHandler(),
   IfHandler(),
   IfV2Handler({ _v1: _v1Handler }),
-  APIHandler({
-    requestTimeoutMs: config.API_REQUEST_TIMEOUT_MS ?? 20_000,
-    maxResponseBodySizeBytes: config.API_MAX_CONTENT_LENGTH_BYTES ?? 1_000_000,
-    maxRequestBodySizeBytes: config.API_MAX_BODY_LENGTH_BYTES ?? 1_000_000,
-    awsAccessKey: config.AWS_ACCESS_KEY_ID ?? undefined,
-    awsSecretAccessKey: config.AWS_SECRET_ACCESS_KEY ?? undefined,
-    awsRegion: config.AWS_REGION ?? undefined,
-    s3TLSBucket: config.S3_TLS_BUCKET ?? undefined,
-  }),
+  APIHandler(config),
   IntegrationsHandler({ integrationsEndpoint: config.INTEGRATIONS_HANDLER_ENDPOINT }),
   RandomHandler(),
   SetHandler(),

--- a/lib/services/runtime/handlers/index.ts
+++ b/lib/services/runtime/handlers/index.ts
@@ -1,4 +1,3 @@
-import { createResponseConfig } from '@/lib/utils';
 import {
   APIHandler,
   CodeHandler,
@@ -47,7 +46,15 @@ export default (config: Config) => [
   FlowHandler(),
   IfHandler(),
   IfV2Handler({ _v1: _v1Handler }),
-  APIHandler(createResponseConfig(config)),
+  APIHandler({
+    requestTimeoutMs: config.API_REQUEST_TIMEOUT_MS ?? 20_000,
+    maxResponseBodySizeBytes: config.API_MAX_CONTENT_LENGTH_BYTES ?? 1_000_000,
+    maxRequestBodySizeBytes: config.API_MAX_BODY_LENGTH_BYTES ?? 1_000_000,
+    awsAccessKey: config.AWS_ACCESS_KEY_ID ?? undefined,
+    awsSecretAccessKey: config.AWS_SECRET_ACCESS_KEY ?? undefined,
+    awsRegion: config.AWS_REGION ?? undefined,
+    s3TLSBucket: config.S3_TLS_BUCKET ?? undefined,
+  }),
   IntegrationsHandler({ integrationsEndpoint: config.INTEGRATIONS_HANDLER_ENDPOINT }),
   RandomHandler(),
   SetHandler(),

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -3,8 +3,7 @@ import Ajv from 'ajv';
 import { RequestHandler } from 'express';
 
 import log from '@/logger';
-import { ResponseConfig } from '@/runtime/lib/Handlers/api/utils';
-import { AnyClass, Config } from '@/types';
+import { AnyClass } from '@/types';
 
 import { ControllerMap } from './controllers';
 import { AbstractController } from './controllers/utils';
@@ -74,16 +73,4 @@ export const isConstructor = <T extends AnyClass>(clazz: T | unknown): clazz is 
   } catch {
     return false;
   }
-};
-
-export const createResponseConfig = (config: Config): ResponseConfig => {
-  return {
-    requestTimeoutMs: config.API_REQUEST_TIMEOUT_MS ?? 20_000,
-    maxResponseBodySizeBytes: config.API_MAX_CONTENT_LENGTH_BYTES ?? 1_000_000,
-    maxRequestBodySizeBytes: config.API_MAX_BODY_LENGTH_BYTES ?? 1_000_000,
-    awsAccessKey: config.AWS_ACCESS_KEY_ID ?? undefined,
-    awsSecretAccessKey: config.AWS_SECRET_ACCESS_KEY ?? undefined,
-    awsRegion: config.AWS_REGION ?? undefined,
-    s3TLSBucket: config.S3_TLS_BUCKET ?? undefined,
-  };
 };

--- a/runtime/lib/Handlers/api/index.ts
+++ b/runtime/lib/Handlers/api/index.ts
@@ -6,7 +6,8 @@ import _ from 'lodash';
 import Handler from '@/runtime/lib/Handler';
 
 import DebugLogging, { SimpleStepMessage } from '../../Runtime/DebugLogging';
-import { APICallResult, APINodeData, makeAPICall, ResponseConfig } from './utils';
+import { APIHandlerConfig } from './types';
+import { APICallResult, APINodeData, makeAPICall } from './utils';
 
 const createLogEntry = async (
   apiCallResult: APICallResult,
@@ -72,7 +73,7 @@ const createLogEntry = async (
 
 export const USER_AGENT_KEY = 'User-Agent';
 export const USER_AGENT = 'Voiceflow/1.0.0 (+https://voiceflow.com)';
-const APIHandler = (config: ResponseConfig): Handler<BaseNode.Integration.Node> => ({
+const APIHandler = (config: Partial<APIHandlerConfig>): Handler<BaseNode.Integration.Node> => ({
   canHandle: (node) =>
     node.type === BaseNode.NodeType.INTEGRATIONS &&
     node.selected_integration === BaseNode.Utils.IntegrationType.CUSTOM_API,

--- a/runtime/lib/Handlers/api/types.ts
+++ b/runtime/lib/Handlers/api/types.ts
@@ -1,0 +1,15 @@
+export interface APIHandlerConfig {
+  requestTimeoutMs: number;
+  maxResponseBodySizeBytes: number;
+  maxRequestBodySizeBytes: number;
+  awsAccessKey?: string;
+  awsSecretAccessKey?: string;
+  awsRegion?: string;
+  s3TLSBucket?: string;
+}
+
+export const DEFAULT_API_HANDLER_CONFIG: APIHandlerConfig = {
+  requestTimeoutMs: 20_000,
+  maxResponseBodySizeBytes: 1_000_000,
+  maxRequestBodySizeBytes: 1_000_000,
+};

--- a/runtime/lib/Handlers/index.ts
+++ b/runtime/lib/Handlers/index.ts
@@ -1,5 +1,6 @@
 // handlers
 export { default as APIHandler } from './api';
+export * from './api/types';
 export { default as CodeHandler } from './code';
 export { ivmExecute, vmExecute } from './code/utils';
 export { default as EndHandler } from './end';


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-120**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

The `createResponseConfig` was not a generic utility, so should not have lived where it was.
By removing the defaults from the exported library package portion, it would mean each runtime that is dependant on this library portion would also have to add defaults themselves. I've attempted to retain these defaults.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
