### PR TITLE
[Merged by Bors] - fix: replace carousel button variables (CT-1055)

### DIFF
--- a/lib/services/runtime/handlers/carousel.ts
+++ b/lib/services/runtime/handlers/carousel.ts
@@ -1,5 +1,5 @@
 import { BaseNode, BaseTrace } from '@voiceflow/base-types';
-import { replaceVariables, sanitizeVariables } from '@voiceflow/common';
+import { deepVariableSubstitution, replaceVariables, sanitizeVariables } from '@voiceflow/common';
 
 import { Action, HandlerFactory } from '@/runtime';
 
@@ -45,8 +45,7 @@ export const CarouselHandler: HandlerFactory<BaseNode.Carousel.Node, typeof hand
             text,
           },
           buttons: card.buttons.map((button) => ({
-            ...button,
-            name: replaceVariables(button.name, variablesMap),
+            ...deepVariableSubstitution(button, variablesMap),
           })),
         };
 

--- a/lib/services/runtime/handlers/carousel.ts
+++ b/lib/services/runtime/handlers/carousel.ts
@@ -44,9 +44,7 @@ export const CarouselHandler: HandlerFactory<BaseNode.Carousel.Node, typeof hand
             slate,
             text,
           },
-          buttons: card.buttons.map((button) => ({
-            ...deepVariableSubstitution(button, variablesMap),
-          })),
+          buttons: card.buttons.map((button) => deepVariableSubstitution(button, variablesMap)),
         };
 
         if (item.title || item.imageUrl || item.description.text || item.buttons.length) {


### PR DESCRIPTION
super simple, but nested attributes of carousel buttons need to get `{....}` replaced with the actual value of the variable.

<img width="375" alt="Screen Shot 2022-10-11 at 7 17 36 PM" src="https://user-images.githubusercontent.com/5643574/195168900-39d75958-e8a0-4791-8ade-ce84d76d3035.png">
<img width="620" alt="Screen Shot 2022-10-11 at 7 18 10 PM" src="https://user-images.githubusercontent.com/5643574/195169025-09869a14-f3ec-4a87-bbf0-02198c547fb3.png">

otherwise it just resolves as `{url}` or something