### PR TITLE
[Merged by Bors] - feat: add get publishing endpoint (CT-000)

### DIFF
--- a/backend/api/routers/public.ts
+++ b/backend/api/routers/public.ts
@@ -9,12 +9,16 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
 
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
 
-  router.use([middlewares.project.resolvePublicProjectID, middlewares.rateLimit.versionConsume]);
+  const interactMiddleware = [middlewares.project.resolvePublicProjectID, middlewares.rateLimit.versionConsume];
 
   // full route: /public/:projectID/state/user/:userID/interact
-  router.post('/:projectID/state/user/:userID/interact', controllers.stateManagement.publicInteract);
+  router.post(
+    '/:projectID/state/user/:userID/interact',
+    interactMiddleware,
+    controllers.stateManagement.publicInteract
+  );
 
-  router.get('/:projectID/publishing', controllers.stateManagement.getPublicPublishing);
+  router.get('/:projectID/publishing', interactMiddleware, controllers.stateManagement.getPublicPublishing);
 
   return router;
 };

--- a/backend/api/routers/public.ts
+++ b/backend/api/routers/public.ts
@@ -9,14 +9,12 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
 
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
 
-  const interactMiddleware = [middlewares.project.resolvePublicProjectID, middlewares.rateLimit.versionConsume];
+  router.use([middlewares.project.resolvePublicProjectID, middlewares.rateLimit.versionConsume]);
 
   // full route: /public/:projectID/state/user/:userID/interact
-  router.post(
-    '/:projectID/state/user/:userID/interact',
-    interactMiddleware,
-    controllers.stateManagement.publicInteract
-  );
+  router.post('/:projectID/state/user/:userID/interact', controllers.stateManagement.publicInteract);
+
+  router.get('/:projectID/publishing', controllers.stateManagement.getPublicPublishing);
 
   return router;
 };

--- a/lib/controllers/stateManagement/index.ts
+++ b/lib/controllers/stateManagement/index.ts
@@ -68,6 +68,17 @@ class StateManagementController extends AbstractController {
     return { trace };
   }
 
+  @validate({
+    HEADERS_VERSION_ID: VALIDATIONS.HEADERS.VERSION_ID,
+  })
+  async getPublicPublishing(req: Request<{ userID: string }, never, { versionID: string }>) {
+    const api = await this.services.dataAPI.get();
+
+    const version = await api.getVersion(req.headers.versionID);
+
+    return version.platformData.publishing || {};
+  }
+
   @validate({ HEADERS_PROJECT_ID: VALIDATIONS.HEADERS.PROJECT_ID })
   async get(req: Request<{ userID: string }, any, { projectID: string }>) {
     return this.services.session.getFromDb(req.headers.projectID, req.params.userID);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?
Added a new endpoint: 
`GET /public/:projectID/publishing` - this fetches the `version.platformData.publishing` field of a PUBLIC project

because of the `resolvePublicProjectID` middleware, the project's `project.apiPrivacy` must be public to get this information. This is important to expose because it allows us to fetch project settings and metadata from the adapters/clients.