### PR TITLE
[Merged by Bors] - feat: use projectID for querying sessions (PL-237)

### DIFF
--- a/tests/lib/services/session/mongo.unit.ts
+++ b/tests/lib/services/session/mongo.unit.ts
@@ -39,7 +39,11 @@ describe('mongo sessionManager unit tests', async () => {
 
       const id = `${SessionManager.GENERAL_SESSIONS_MONGO_PREFIX}.${projectID}.${userID}`;
       expect(updateOne.args).to.eql([
-        [{ id }, { $set: { id, projectID: new ObjectId(projectID), attributes: stateObj } }, { upsert: true }],
+        [
+          { id, projectID: new ObjectId(projectID) },
+          { $set: { id, projectID: new ObjectId(projectID), attributes: stateObj } },
+          { upsert: true },
+        ],
       ]);
     });
   });
@@ -52,7 +56,7 @@ describe('mongo sessionManager unit tests', async () => {
         {} as any
       );
 
-      expect(await state.getFromDb('project-id', 'user-id')).to.eql({});
+      expect(await state.getFromDb('60660078d1be7ef51a0be899', 'user-id')).to.eql({});
     });
 
     it('works', async () => {
@@ -66,7 +70,14 @@ describe('mongo sessionManager unit tests', async () => {
       const projectID = '60660078d1be7ef51a0be899';
       const userID = 'user-id';
       expect(await state.getFromDb(projectID, userID)).to.eql(attributes);
-      expect(findOne.args).to.eql([[{ id: `${SessionManager.GENERAL_SESSIONS_MONGO_PREFIX}.${projectID}.${userID}` }]]);
+      expect(findOne.args).to.eql([
+        [
+          {
+            projectID: new ObjectId(projectID),
+            id: `${SessionManager.GENERAL_SESSIONS_MONGO_PREFIX}.${projectID}.${userID}`,
+          },
+        ],
+      ]);
     });
   });
 
@@ -83,7 +94,12 @@ describe('mongo sessionManager unit tests', async () => {
 
       await expect(state.deleteFromDb(projectID, userID)).to.eventually.rejectedWith('delete runtime session error');
       expect(deleteOne.args).to.eql([
-        [{ id: `${SessionManager.GENERAL_SESSIONS_MONGO_PREFIX}.${projectID}.${userID}` }],
+        [
+          {
+            projectID: new ObjectId(projectID),
+            id: `${SessionManager.GENERAL_SESSIONS_MONGO_PREFIX}.${projectID}.${userID}`,
+          },
+        ],
       ]);
     });
 
@@ -99,7 +115,12 @@ describe('mongo sessionManager unit tests', async () => {
 
       await expect(state.deleteFromDb(projectID, userID)).to.eventually.rejectedWith('delete runtime session error');
       expect(deleteOne.args).to.eql([
-        [{ id: `${SessionManager.GENERAL_SESSIONS_MONGO_PREFIX}.${projectID}.${userID}` }],
+        [
+          {
+            projectID: new ObjectId(projectID),
+            id: `${SessionManager.GENERAL_SESSIONS_MONGO_PREFIX}.${projectID}.${userID}`,
+          },
+        ],
       ]);
     });
 
@@ -115,7 +136,12 @@ describe('mongo sessionManager unit tests', async () => {
 
       await state.deleteFromDb(projectID, userID);
       expect(deleteOne.args).to.eql([
-        [{ id: `${SessionManager.GENERAL_SESSIONS_MONGO_PREFIX}.${projectID}.${userID}` }],
+        [
+          {
+            projectID: new ObjectId(projectID),
+            id: `${SessionManager.GENERAL_SESSIONS_MONGO_PREFIX}.${projectID}.${userID}`,
+          },
+        ],
       ]);
     });
   });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-237**

### Brief description. What is this change?

This affects any instance using mongoDB to store a user's session.
We are switching to a compound index of `projectID` + `sessionID` to identify unique sessions.
This is not a breaking change - even if the collection only has a `sessionID_1` index the retrieval will still be optimized since each one is unique at the moment

This way there won't be collisions between sessions on different projects and we streamline this index for our logs and transcripts.

depends on https://github.com/voiceflow/database-cli/pull/277

All current sessions documents should have `projectID` populated as a property. This shouldn't be an issue as `saveToDb` is already configured to set the `projectID`: 
https://github.com/voiceflow/general-runtime/blob/c65dee7b65190c5d6d69aff9ba82826ce1790da9/lib/services/session/mongo.ts#L27-L31
