### PR TITLE
feat: create transcript endpoint (CT-1050)

### DIFF
--- a/backend/api/routers/public.ts
+++ b/backend/api/routers/public.ts
@@ -12,13 +12,11 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   const interactMiddleware = [middlewares.project.resolvePublicProjectID, middlewares.rateLimit.versionConsume];
 
   // full route: /public/:projectID/state/user/:userID/interact
-  router.post(
-    '/:projectID/state/user/:userID/interact',
-    interactMiddleware,
-    controllers.stateManagement.publicInteract
-  );
+  router.post('/:projectID/state/user/:userID/interact', interactMiddleware, controllers.public.interact);
 
-  router.get('/:projectID/publishing', interactMiddleware, controllers.stateManagement.getPublicPublishing);
+  router.post('/:projectID/transcripts', interactMiddleware, controllers.public.createTranscript);
+
+  router.get('/:projectID/publishing', interactMiddleware, controllers.public.getPublishing);
 
   return router;
 };

--- a/lib/controllers/index.ts
+++ b/lib/controllers/index.ts
@@ -3,9 +3,11 @@ import { Config, Controller } from '@/types';
 
 import { FullServiceMap } from '../services';
 import Interact from './interact';
+import Public from './public';
 import StateManagement from './stateManagement';
 
 export interface ControllerMap {
+  public: Public;
   interact: Interact;
   stateManagement: StateManagement;
 }
@@ -19,6 +21,7 @@ export interface ControllerClass<T = Controller> {
  */
 const buildControllers = (services: FullServiceMap, config: Config) => {
   const controllers: ControllerMap = {
+    public: new Public(services, config),
     interact: new Interact(services, config),
     stateManagement: new StateManagement(services, config),
   };

--- a/lib/controllers/public/index.ts
+++ b/lib/controllers/public/index.ts
@@ -1,0 +1,90 @@
+import { Validator } from '@voiceflow/backend-utils';
+import { BaseRequest } from '@voiceflow/base-types';
+import { ObjectId } from 'mongodb';
+
+import { RuntimeRequest } from '@/lib/services/runtime/types';
+import { Request } from '@/types';
+
+import { customAJV, validate } from '../../utils';
+import { AbstractController } from '../utils';
+import { PublicInteractSchema, TranscriptSchema } from './requests';
+
+const { body, header } = Validator;
+const VALIDATIONS = {
+  BODY: {
+    PUBLIC_INTERACT: body().custom(customAJV(PublicInteractSchema)),
+    TRANSCRIPT: body().custom(customAJV(TranscriptSchema)),
+  },
+  HEADERS: {
+    PROJECT_ID: header('projectID').exists().isString(),
+    VERSION_ID: header('versionID').exists().isString(),
+  },
+};
+
+class PublicController extends AbstractController {
+  static VALIDATIONS = VALIDATIONS;
+
+  @validate({
+    HEADERS_PROJECT_ID: VALIDATIONS.HEADERS.PROJECT_ID,
+    HEADERS_VERSION_ID: VALIDATIONS.HEADERS.VERSION_ID,
+    BODY_PUBLIC_INTERACT: VALIDATIONS.BODY.PUBLIC_INTERACT,
+  })
+  async interact(
+    req: Request<
+      { userID: string },
+      { action?: RuntimeRequest; config?: BaseRequest.RequestConfig },
+      { projectID: string; versionID: string }
+    >
+  ) {
+    const trace = await this.services.stateManagement.interact({
+      ...req,
+      // only pass in select properties to avoid any potential security issues
+      query: {}, // no logs allowed
+      headers: { projectID: req.headers.projectID, versionID: req.headers.versionID },
+    });
+
+    return { trace };
+  }
+
+  @validate({
+    HEADERS_VERSION_ID: VALIDATIONS.HEADERS.VERSION_ID,
+  })
+  async getPublishing(req: Request<{ userID: string }, never, { versionID: string }>) {
+    const api = await this.services.dataAPI.get();
+
+    const version = await api.getVersion(req.headers.versionID);
+
+    return version.platformData.publishing || {};
+  }
+
+  @validate({
+    HEADERS_PROJECT_ID: VALIDATIONS.HEADERS.PROJECT_ID,
+    BODY_TRANSCRIPT: VALIDATIONS.BODY.TRANSCRIPT,
+  })
+  async createTranscript(
+    req: Request<never, { sessionID: string; device?: string; os?: string; browser?: string }, { projectID: string }>
+  ) {
+    const {
+      body: { sessionID, device, os, browser },
+      headers: { projectID },
+    } = req;
+    const { mongo } = this.services;
+    if (!mongo) throw new Error('mongo not initialized');
+
+    const {
+      ops: [document],
+    } = await mongo.db.collection('transcripts').insertOne({
+      projectID: new ObjectId(projectID),
+      sessionID,
+      createdAt: new Date(),
+      ...(device && { device }),
+      ...(browser && { browser }),
+      ...(os && { os }),
+      reportTags: [],
+    });
+
+    return document;
+  }
+}
+
+export default PublicController;

--- a/lib/controllers/public/requests.ts
+++ b/lib/controllers/public/requests.ts
@@ -1,0 +1,24 @@
+import { ObjectField, StringField } from '@/lib/controllers/schemaTypes';
+
+import { ConfigSchema } from '../stateManagement/requests';
+
+export const PublicInteractSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    action: ObjectField('action'),
+    config: ConfigSchema,
+  },
+};
+
+export const TranscriptSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['sessionID'],
+  properties: {
+    sessionID: StringField('sessionID'),
+    os: StringField('os'),
+    device: StringField('device'),
+    browser: StringField('browser'),
+  },
+};

--- a/lib/controllers/stateManagement/index.ts
+++ b/lib/controllers/stateManagement/index.ts
@@ -1,20 +1,18 @@
 import { Validator } from '@voiceflow/backend-utils';
-import { BaseRequest, RuntimeLogs } from '@voiceflow/base-types';
+import { RuntimeLogs } from '@voiceflow/base-types';
 
-import { RuntimeRequest } from '@/lib/services/runtime/types';
 import { SharedValidations } from '@/lib/validations';
 import { State } from '@/runtime';
 import { Request } from '@/types';
 
 import { customAJV, validate } from '../../utils';
 import { AbstractController } from '../utils';
-import { PublicInteractSchema, UpdateSchema } from './requests';
+import { UpdateSchema } from './requests';
 
 const { body, header, query } = Validator;
 const VALIDATIONS = {
   BODY: {
     UPDATE_SESSION: body().custom(customAJV(UpdateSchema)),
-    PUBLIC_INTERACT: body().custom(customAJV(PublicInteractSchema)),
     OBJECT: body().exists(),
   },
   HEADERS: {
@@ -44,39 +42,6 @@ class StateManagementController extends AbstractController {
     >
   ) {
     return this.services.stateManagement.interact(req);
-  }
-
-  @validate({
-    HEADERS_PROJECT_ID: VALIDATIONS.HEADERS.PROJECT_ID,
-    HEADERS_VERSION_ID: VALIDATIONS.HEADERS.VERSION_ID,
-    BODY_PUBLIC_INTERACT: VALIDATIONS.BODY.PUBLIC_INTERACT,
-  })
-  async publicInteract(
-    req: Request<
-      { userID: string },
-      { action?: RuntimeRequest; config?: BaseRequest.RequestConfig },
-      { projectID: string; versionID: string }
-    >
-  ) {
-    const trace = await this.services.stateManagement.interact({
-      ...req,
-      // only pass in select properties to avoid any potential security issues
-      query: {}, // no logs allowed
-      headers: { projectID: req.headers.projectID, versionID: req.headers.versionID },
-    });
-
-    return { trace };
-  }
-
-  @validate({
-    HEADERS_VERSION_ID: VALIDATIONS.HEADERS.VERSION_ID,
-  })
-  async getPublicPublishing(req: Request<{ userID: string }, never, { versionID: string }>) {
-    const api = await this.services.dataAPI.get();
-
-    const version = await api.getVersion(req.headers.versionID);
-
-    return version.platformData.publishing || {};
   }
 
   @validate({ HEADERS_PROJECT_ID: VALIDATIONS.HEADERS.PROJECT_ID })

--- a/lib/controllers/stateManagement/requests.ts
+++ b/lib/controllers/stateManagement/requests.ts
@@ -36,12 +36,3 @@ export const ConfigSchema = {
     excludeTypes: ArrayField('excludeTypes', StringField('excludeType')),
   },
 };
-
-export const PublicInteractSchema = {
-  type: 'object',
-  additionalProperties: false,
-  properties: {
-    action: ObjectField('action'),
-    config: ConfigSchema,
-  },
-};


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-1050**

### Brief description. What is this change?
Moved `stateManagement.publicInteract` and `stateManagement.getPublicPublishing` over to a new controller called `public`: `public.interact` and `public.getPublishing`

Added a new endpoint that basically mirrors this endpoint on `creator-api` (the webchat client shouldn't ever need to call creator-api`: https://github.com/voiceflow/creator-api/blob/3f331e174d3712c5d478099c9f0ceb3e0254f9d5/backend/api/routes/v2/transcripts.ts#L18
