### PR TITLE
[Merged by Bors] - fix: nlc open slot threshold (PL-000)

### DIFF
--- a/lib/services/nlu/nlc.ts
+++ b/lib/services/nlu/nlc.ts
@@ -102,12 +102,7 @@ export const createNLC = ({
   return nlc;
 };
 
-export const nlcToIntent = (
-  intent: IIntentFullfilment | null,
-  // eslint-disable-next-line default-param-last
-  query = '',
-  confidence?: number
-): BaseRequest.IntentRequest =>
+export const nlcToIntent = (intent: IIntentFullfilment | null, query = '', confidence = 1): BaseRequest.IntentRequest =>
   (intent && {
     type: BaseRequest.RequestType.INTENT,
     payload: {
@@ -136,7 +131,9 @@ export const handleNLCCommand = ({
 }): BaseRequest.IntentRequest => {
   const nlc = createNLC({ model, locale, openSlot });
 
-  return nlcToIntent(nlc.handleCommand(query), query, openSlot ? undefined : 1);
+  // ensure open slot is lower than the capture step threshold
+  const confidence = openSlot ? 0.5 : 1;
+  return nlcToIntent(nlc.handleCommand(query), query, confidence);
 };
 
 export const handleNLCDialog = ({

--- a/tests/lib/services/nlu/nlc.unit.ts
+++ b/tests/lib/services/nlu/nlc.unit.ts
@@ -59,7 +59,7 @@ describe('nlu nlc service unit tests', () => {
       expect(handleNLCCommand({ query, model, locale } as any)).to.eql(output);
       expect(createNLCStub.args).to.eql([[{ model, locale, openSlot: true }]]);
       expect(nlcObj.handleCommand.args).to.eql([[query]]);
-      expect(nlcToIntentStub.args).to.eql([[commandRes, query, undefined]]);
+      expect(nlcToIntentStub.args).to.eql([[commandRes, query, 0.5]]);
     });
 
     it('openSlot false', () => {


### PR DESCRIPTION
the `openSlot` for NLC (untrained) setting means that a slot can be essentially anything:
![Screen Shot 2022-10-30 at 11 09 59 PM](https://user-images.githubusercontent.com/5643574/198926281-38b68f27-9ffe-452d-b3f5-8e3dc7431113.png)
In the example above, the user could say `whatever whatever not related` or `my size is whatever whatever not related` and still trigger the intent (if the model is not trained).

Today, the openSlot resolves a `undefined` confidence value. We are 100% confidence when it is a perfect regex match, but with open slots its really up in the air because we don't have a regex database for all slot types.

This causes a problem with the capture step with looks for a threshold before jumping to any random intent:
https://github.com/voiceflow/general-runtime/blob/master/lib/services/runtime/handlers/captureV2.ts#L13

If we set it to `0.5` for now that's fine.