### PR TITLE
[Merged by Bors] - feat: use user id as transcript sessionID [bugfix] (CT-1050)

### DIFF
--- a/lib/clients/analytics.ts
+++ b/lib/clients/analytics.ts
@@ -50,10 +50,7 @@ export class AnalyticsSystem extends AbstractClient {
     metadata: Context;
     timestamp: Date;
   }): GeneralInteractionBody {
-    const sessionID =
-      metadata.data.reqHeaders?.sessionid ??
-      metadata.userID ??
-      (metadata.state?.variables ? `${versionID}.${metadata.state.variables.user_id}` : versionID);
+    const sessionID = metadata.data.reqHeaders?.sessionid ?? metadata.userID ?? versionID;
 
     return {
       projectID,

--- a/lib/clients/analytics.ts
+++ b/lib/clients/analytics.ts
@@ -52,6 +52,7 @@ export class AnalyticsSystem extends AbstractClient {
   }): GeneralInteractionBody {
     const sessionID =
       metadata.data.reqHeaders?.sessionid ??
+      metadata.userID ??
       (metadata.state?.variables ? `${versionID}.${metadata.state.variables.user_id}` : versionID);
 
     return {

--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -87,6 +87,7 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
     return {
       ...context,
       request,
+      userID,
       versionID,
       state: runtime.getFinalState(),
       trace: runtime.trace.get(),

--- a/tests/lib/services/runtime/index.unit.ts
+++ b/tests/lib/services/runtime/index.unit.ts
@@ -7,6 +7,7 @@ import { TurnType, Variables } from '@/lib/services/runtime/types';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 
 const VERSION_ID = 'version_id';
+const USER_ID = 'user_id';
 
 describe('runtime manager unit tests', () => {
   let clock: sinon.SinonFakeTimers;
@@ -62,10 +63,16 @@ describe('runtime manager unit tests', () => {
         type: BaseRequest.RequestType.INTENT,
         payload: {},
       };
-      const context = { state, request, versionID: VERSION_ID, data: { api: { getProgram: 'api' } } } as any;
+      const context = {
+        state,
+        request,
+        versionID: VERSION_ID,
+        data: { api: { getProgram: 'api' } },
+      } as any;
       expect(await runtimeManager.handle(context)).to.eql({
         state: rawState,
         trace,
+        userID: undefined,
         request,
         versionID: VERSION_ID,
         data: { api: { getProgram: 'api' } },
@@ -119,6 +126,7 @@ describe('runtime manager unit tests', () => {
       };
       const context = {
         state,
+        userID: USER_ID,
         request,
         versionID: VERSION_ID,
         data: { api: { getProgram: 'api' }, config: { stopTypes: ['t1', 't2'] } },
@@ -126,6 +134,7 @@ describe('runtime manager unit tests', () => {
       expect(await runtimeManager.handle(context)).to.eql({
         state: rawState,
         trace,
+        userID: USER_ID,
         request,
         versionID: VERSION_ID,
         data: { api: { getProgram: 'api' }, config: { stopTypes: ['t1', 't2'] } },
@@ -176,11 +185,18 @@ describe('runtime manager unit tests', () => {
         payload: {},
       };
       const state = { foo: 'bar' };
-      const context = { state, request, versionID: VERSION_ID, data: { api: { getProgram: 'api' } } } as any;
+      const context = {
+        state,
+        userID: USER_ID,
+        request,
+        versionID: VERSION_ID,
+        data: { api: { getProgram: 'api' } },
+      } as any;
 
       expect(await runtimeManager.handle(context)).to.eql({
         state: rawState,
         trace,
+        userID: USER_ID,
         request,
         versionID: VERSION_ID,
         data: { api: { getProgram: 'api' } },
@@ -236,7 +252,12 @@ describe('runtime manager unit tests', () => {
         },
       };
       const state = { foo: 'bar' };
-      const context = { state, request, versionID: VERSION_ID, data: { api: { getProgram: 'api' } } } as any;
+      const context = {
+        state,
+        request,
+        versionID: VERSION_ID,
+        data: { api: { getProgram: 'api' } },
+      } as any;
 
       await runtimeManager.handle(context);
 
@@ -301,6 +322,7 @@ describe('runtime manager unit tests', () => {
       expect(await runtimeManager.handle(context)).to.eql({
         state: rawState,
         trace,
+        userID: 'someUserId',
         request,
         versionID: VERSION_ID,
         data: { api: { getProgram: 'api' } },


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-1050**

### Brief description. What is this change?
Now logs are distinct based on `projectID` + `sessionID` and not just `sessionID`. 

The current problem is on the logs, all sessionIDs are saved as this opaque format:
```(metadata.state?.variables ? `${versionID}.${metadata.state.variables.user_id}` : versionID);```

And services calling this would have no idea how to retrieve the logs for a session. All `general-runtime` stateful API calls fills the `userID` field in the `interaction` context.
Instead of saving all our logs as this `${versionID}.${metadata.state.variables.user_id}` format we should just save it as `metadata.userID`

This doesn't affect the only place we expose transcripts to users: the prototype tool, because `metadata.data.reqHeaders?.sessionid` always gets declared there.

It just means all log database entries going forward will just directly user the userID instead of a compound entry with the `versionID` as well.