### PR TITLE
fix: upsert transcript instead of insert (CT-1050)

### DIFF
--- a/lib/controllers/public/index.ts
+++ b/lib/controllers/public/index.ts
@@ -71,19 +71,22 @@ class PublicController extends AbstractController {
     const { mongo } = this.services;
     if (!mongo) throw new Error('mongo not initialized');
 
-    const {
-      ops: [document],
-    } = await mongo.db.collection('transcripts').insertOne({
+    const data = {
       projectID: new ObjectId(projectID),
       sessionID,
       createdAt: new Date(),
+      updatedAt: new Date(),
+      reportTags: [],
       ...(device && { device }),
       ...(browser && { browser }),
       ...(os && { os }),
-      reportTags: [],
-    });
+    };
 
-    return document;
+    const { value } = await mongo.db
+      .collection('transcripts')
+      .findOneAndUpdate({ projectID: data.projectID, sessionID: data.sessionID }, { $set: data }, { upsert: true });
+
+    return value;
   }
 }
 


### PR DESCRIPTION
This PR depends on the following database migration to be merged:
https://github.com/voiceflow/database-cli/pull/280

Write up:
https://www.notion.so/voiceflow/Transcripts-and-Sessions-4d48361f56d34c6c9c6f41eb9b9bc869#2347ca976c66407e9fd264051cd083c9

the [findOneAndUpdate](https://www.mongodb.com/docs/manual/reference/method/db.collection.findOneAndUpdate/) allows us to upsert and get back the modified document! It's pretty awesome.
