### PR TITLE
fix: buttons substitution [bugfix] (CT-1050)

### DIFF
--- a/lib/services/runtime/handlers/cardV2.ts
+++ b/lib/services/runtime/handlers/cardV2.ts
@@ -1,5 +1,5 @@
 import { AnyRecord, BaseNode, BaseText, BaseTrace } from '@voiceflow/base-types';
-import { replaceVariables, sanitizeVariables } from '@voiceflow/common';
+import { deepVariableSubstitution, replaceVariables, sanitizeVariables } from '@voiceflow/common';
 import { VoiceflowNode } from '@voiceflow/voiceflow-types';
 
 import { Action, HandlerFactory } from '@/runtime';
@@ -18,6 +18,7 @@ const handlerUtils = {
   slateToPlaintext,
   sanitizeVariables,
   slateInjectVariables,
+  deepVariableSubstitution,
   addNoReplyTimeoutIfExists,
 };
 
@@ -72,10 +73,7 @@ export const CardV2Handler: HandlerFactory<VoiceflowNode.CardV2.Node, typeof han
 
       const title = replaceVariables(node.title, variablesMap);
 
-      const buttons = node.buttons.map((button) => ({
-        ...button,
-        name: replaceVariables(button.name, variablesMap),
-      }));
+      const buttons = node.buttons.map((button) => utils.deepVariableSubstitution(button, variablesMap));
 
       if (title || buttons.length || description.text || node.imageUrl) {
         runtime.trace.addTrace<BaseNode.CardV2.TraceFrame>({


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-1050**

### Brief description. What is this change?
![Screen Shot 2022-11-01 at 4 05 16 PM](https://user-images.githubusercontent.com/5643574/199330311-eeb9ae11-23b9-4a6d-bff2-d95cab88e3f1.png)
For card steps we aren't doing variable substitutions in the buttons - this means that the URL action with variables in it is broken, enough though the FE makes it look like its supported:

![Screen Shot 2022-11-01 at 4 06 44 PM](https://user-images.githubusercontent.com/5643574/199330745-ea5b02c9-19ec-469c-a2fd-4d6e8bbfe5c3.png)
