### PR TITLE
[Merged by Bors] - fix: transcripts default to unread [bugfix] (CT-1206)

### DIFF
--- a/lib/controllers/public/index.ts
+++ b/lib/controllers/public/index.ts
@@ -89,6 +89,7 @@ class PublicController extends AbstractController {
           ...(user.image && { image: user.image }),
         },
       }),
+      unread: true,
       reportTags: [],
     };
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-1206**

### Brief description. What is this change?
All new transcripts generated by general-runtime should by default be unread.
