### PR TITLE
[Merged by Bors] - fix: remove dialogflow intent mapping (PL-305)

### DIFF
--- a/lib/services/nlu/utils.ts
+++ b/lib/services/nlu/utils.ts
@@ -28,9 +28,6 @@ export const mapChannelData = (data: any, platform: VoiceflowConstants.PlatformT
   // this means old programs will hold VF intents, new ones wil hold channel intents
   const mapToUse = match(platform)
     .with(VoiceflowConstants.PlatformType.GOOGLE, () => googleIntentMap)
-    .with(VoiceflowConstants.PlatformType.DIALOGFLOW_ES, () => googleIntentMap)
-    .with(VoiceflowConstants.PlatformType.DIALOGFLOW_ES_CHAT, () => googleIntentMap)
-    .with(VoiceflowConstants.PlatformType.DIALOGFLOW_ES_VOICE, () => googleIntentMap)
     .with(VoiceflowConstants.PlatformType.ALEXA, () => {
       if (hasChannelIntents) return alexaIntentMap;
       return {};

--- a/tests/lib/services/nlu/utils.unit.ts
+++ b/tests/lib/services/nlu/utils.unit.ts
@@ -14,19 +14,12 @@ describe('nlu manager utils unit tests', () => {
   });
 
   describe('mapChannelData', () => {
-    [
-      VoiceflowConstants.PlatformType.GOOGLE,
-      VoiceflowConstants.PlatformType.DIALOGFLOW_ES,
-      VoiceflowConstants.PlatformType.DIALOGFLOW_ES_CHAT,
-      VoiceflowConstants.PlatformType.DIALOGFLOW_ES_VOICE,
-    ].forEach((platform) => {
-      it(`maps vf intents for ${platform} platform`, async () => {
-        const inputData = { payload: { intent: { name: VoiceflowConstants.IntentName.YES } } };
-        const outputData = mapChannelData(inputData, platform);
+    it(`maps vf intents for google platform`, async () => {
+      const inputData = { payload: { intent: { name: VoiceflowConstants.IntentName.YES } } };
+      const outputData = mapChannelData(inputData, VoiceflowConstants.PlatformType.GOOGLE);
 
-        const expectData = { payload: { intent: { name: GoogleConstants.GoogleIntent.YES } } };
-        expect(outputData).to.eql(expectData);
-      });
+      const expectData = { payload: { intent: { name: GoogleConstants.GoogleIntent.YES } } };
+      expect(outputData).to.eql(expectData);
     });
 
     // ALEXA


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-305**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Dialogflow ES projects use VF builtin intents, so we do not want to map those to the Google format.
We send all intents and utterances to DF and do not rely on built-ins