### PR TITLE
[Merged by Bors] - fix: add default variables (PL-000)

### DIFF
--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -56,18 +56,14 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
   initializeVariables(version: BaseModels.Version.Model<any>, state: State) {
     const entities = version.prototype?.model.slots.map(({ name }) => name) || [];
 
-    const variables = {
-      ...initializeStore(entities),
-      ...initializeStore(version.variables),
-      ...state.variables,
-    };
-
-    // new turn default variables
-    variables.timestamp = this.services.utils.getTime(); // unix time in seconds
-
     return {
       ...state,
-      variables,
+      variables: {
+        ...initializeStore(entities),
+        ...initializeStore(version.variables),
+        ...state.variables,
+        timestamp: this.services.utils.getTime(), // unix time in seconds
+      },
     };
   }
 

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -7,7 +7,9 @@ import { Context, InitContextHandler } from '@/types';
 import { AbstractManager, injectServices } from '../utils';
 import CacheDataAPI from './cacheDataAPI';
 
-export const utils = {};
+export const utils = {
+  getTime: () => Math.floor(Date.now() / 1000),
+};
 
 const initializeStore = (variables: string[], defaultValue = 0) =>
   variables.reduce<Record<string, any>>((acc, variable) => {
@@ -38,7 +40,7 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
 
     // new session default variables
     variables.sessions = (_.isNumber(variables.sessions) ? variables.sessions : 0) + 1;
-    variables.user_id = userID;
+    if (userID) variables.user_id = userID;
 
     return {
       stack,
@@ -61,7 +63,7 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
     };
 
     // new turn default variables
-    variables.timestamp = Math.floor(Date.now() / 1000); // unix time in seconds
+    variables.timestamp = this.services.utils.getTime(); // unix time in seconds
 
     return {
       ...state,

--- a/tests/lib/services/state/index.unit.ts
+++ b/tests/lib/services/state/index.unit.ts
@@ -1,9 +1,12 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import StateManager, { utils as defaultUtils } from '@/lib/services/state';
+import StateManager, { utils } from '@/lib/services/state';
 
 const VERSION_ID = 'version_id';
+const defaultTimestamp = 1234567890;
+const userID = 'user_id';
+
 const version = {
   _id: VERSION_ID,
   prototype: {
@@ -29,9 +32,11 @@ const state = {
       variables: {},
     },
   ],
-  variables: { slot1: 0, variable1: 1, variable2: 2 },
+  variables: { slot1: 0, variable1: 1, variable2: 2, sessions: 1, timestamp: defaultTimestamp, user_id: userID },
   storage: {},
 };
+
+const defaultUtils = { ...utils, getTime: sinon.stub().returns(defaultTimestamp) };
 
 describe('state manager unit tests', () => {
   afterEach(() => {
@@ -51,7 +56,7 @@ describe('state manager unit tests', () => {
 
       expect(await stateManager.generate(version as any)).to.eql({
         ...state,
-        variables: { variable1: 1, variable2: 2 },
+        variables: { sessions: 1, variable1: 1, variable2: 2 },
       });
       expect(services.dataAPI.get.callCount).to.eql(0);
       expect(getVersionStub.callCount).to.eql(0);
@@ -69,7 +74,7 @@ describe('state manager unit tests', () => {
       const stateManager = new StateManager({ ...services, utils: { ...defaultUtils } } as any, {} as any);
 
       expect(await stateManager.initializeVariables(version as any, {} as any)).to.eql({
-        variables: { variable1: 0, slot1: 0 },
+        variables: { variable1: 0, slot1: 0, timestamp: defaultTimestamp },
       });
       expect(services.dataAPI.getVersion.callCount).to.eql(0);
     });
@@ -90,6 +95,7 @@ describe('state manager unit tests', () => {
         versionID: VERSION_ID,
         projectID: version.projectID,
         data: { foo: 'bar' },
+        userID,
       } as any;
 
       const newContext = await stateManager.handle(context);
@@ -99,6 +105,7 @@ describe('state manager unit tests', () => {
         versionID: VERSION_ID,
         projectID: version.projectID,
         state,
+        userID,
         version,
         trace: [],
         data: {
@@ -143,6 +150,7 @@ describe('state manager unit tests', () => {
         versionID: VERSION_ID,
         projectID: version.projectID,
         data: { foo: 'bar' },
+        userID,
       } as any;
 
       const newContext = await stateManager.handle(context);
@@ -151,6 +159,7 @@ describe('state manager unit tests', () => {
         request: null,
         versionID: VERSION_ID,
         version,
+        userID,
         projectID: version.projectID,
         state,
         trace: [],
@@ -179,6 +188,7 @@ describe('state manager unit tests', () => {
         versionID: VERSION_ID,
         projectID: version.projectID,
         data: { foo: 'bar' },
+        userID,
       } as any;
 
       const newContext = await stateManager.handle(context);
@@ -190,6 +200,7 @@ describe('state manager unit tests', () => {
         state,
         trace: [],
         version,
+        userID,
         data: {
           ...context.data,
           locale: version.prototype.data.locales[0],


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-000**

### Brief description. What is this change?
This is a quality-of-life fix to populate default variables we already expose on Voiceflow's creator tool: (brought up by @Diophontine)
`sessions`: number of new sessions the user has started (empty stack)
`timestamp`: UNIX time in seconds when the turn started
`user_id`: stateful API user ID in the URL param

Currently, for prototyping they aren't made use of - but it is important for production purposes.

<img width="1019" alt="Screen Shot 2022-11-20 at 3 15 20 PM" src="https://user-images.githubusercontent.com/5643574/202924008-e4a8bbae-2931-4866-bda9-15ea9e1574a9.png">

The timestamp mirrors the functionality in the other runtimes, where it is the UNIX timestamp down to the second, not the millisecond:
https://github.com/voiceflow/alexa-runtime/blob/c93882892df5207e5eaef1629f33c800b5147163/lib/services/alexa/request/lifecycle/update.ts#L18

