### PR TITLE
[Merged by Bors] - feat: nlc entity filling (PL-000)

### DIFF
--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -31,6 +31,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     nlp,
     hasChannelIntents,
     platform,
+    dmRequest,
   }: {
     query: string;
     model?: BaseModels.PrototypeModel;
@@ -41,10 +42,11 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     nlp: BaseModels.Project.PrototypeNLP | undefined;
     hasChannelIntents: boolean;
     platform: VoiceflowConstants.PlatformType;
+    dmRequest?: BaseRequest.IntentRequestPayload;
   }): Promise<BaseRequest.IntentRequest> {
     // 1. first try restricted regex (no open slots) - exact string match
     if (model && locale) {
-      const data = handleNLCCommand({ query, model, locale, openSlot: false });
+      const data = handleNLCCommand({ query, model, locale, openSlot: false, dmRequest });
       if (data.payload.intent.name !== VoiceflowConstants.IntentName.NONE) {
         return mapChannelData(data, platform, hasChannelIntents);
       }
@@ -76,7 +78,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     if (!locale) {
       throw new VError('Locale not found', HTTP_STATUS.NOT_FOUND);
     }
-    const data = handleNLCCommand({ query, model, locale, openSlot: true });
+    const data = handleNLCCommand({ query, model, locale, openSlot: true, dmRequest });
     return mapChannelData(data, platform, hasChannelIntents);
   }
 

--- a/tests/lib/services/nlu/nlc.unit.ts
+++ b/tests/lib/services/nlu/nlc.unit.ts
@@ -36,7 +36,7 @@ describe('nlu nlc service unit tests', () => {
       const openSlot = 'openSlot';
       const dmRequest = 'dmRequest';
 
-      expect(createNLC({ model, locale, openSlot } as any)).to.eql(nlcObj);
+      expect(createNLC({ model, locale, openSlot, dmRequest } as any)).to.eql(nlcObj);
       expect(NLCStub.callCount).to.eql(1);
       expect(registerSlotsStub.args).to.eql([[nlcObj, model, openSlot]]);
       expect(registerIntentsStub.args).to.eql([[nlcObj, model, dmRequest]]);

--- a/tests/lib/services/nlu/nlc.unit.ts
+++ b/tests/lib/services/nlu/nlc.unit.ts
@@ -9,7 +9,6 @@ import * as nlc from '@/lib/services/nlu/nlc';
 import {
   createNLC,
   handleNLCCommand,
-  handleNLCDialog,
   nlcToIntent,
   registerBuiltInIntents,
   registerSlots,
@@ -78,75 +77,6 @@ describe('nlu nlc service unit tests', () => {
       expect(createNLCStub.args).to.eql([[{ model, locale, openSlot: false }]]);
       expect(nlcObj.handleCommand.args).to.eql([[query]]);
       expect(nlcToIntentStub.args).to.eql([[commandRes, query, 1]]);
-    });
-  });
-
-  describe('handleNLCDialog', () => {
-    it('works', () => {
-      const dialogRes = { foo: 'bar' };
-      const intent = { slots: ['s1', 's2'] };
-      const nlcObj = { handleDialog: sinon.stub().returns(dialogRes), getIntent: sinon.stub().returns(intent) };
-      const createNLCStub = sinon.stub(nlc, 'createNLC').returns(nlcObj as any);
-
-      const required = true;
-      const getRequiredStub = sinon.stub(standardSlots, 'getRequired').returns(required as any);
-
-      const output = 'output';
-      const nlcToIntentStub = sinon.stub(nlc, 'nlcToIntent').returns(output as any);
-
-      const query = 'query';
-      const model = 'model';
-      const locale = 'locale';
-      const dmRequest = { payload: { intent: { name: 'intent_name' }, entities: ['e1', 'e2'] } };
-
-      expect(handleNLCDialog({ query, model, locale, dmRequest } as any)).to.eql(output);
-      expect(createNLCStub.args).to.eql([[{ model, locale, openSlot: true }]]);
-      expect(nlcObj.getIntent.args).to.eql([[dmRequest.payload.intent.name]]);
-      expect(getRequiredStub.args).to.eql([[intent.slots, dmRequest.payload.entities]]);
-      expect(nlcObj.handleDialog.args).to.eql([
-        [
-          {
-            intent: dmRequest.payload.intent.name,
-            required,
-            slots: dmRequest.payload.entities,
-          },
-          query,
-        ],
-      ]);
-      expect(nlcToIntentStub.args).to.eql([[dialogRes, query]]);
-    });
-
-    it('no intent', () => {
-      const dialogRes = { foo: 'bar' };
-      const nlcObj = { handleDialog: sinon.stub().returns(dialogRes), getIntent: sinon.stub().returns(null) };
-      const createNLCStub = sinon.stub(nlc, 'createNLC').returns(nlcObj as any);
-
-      const required = true;
-      const getRequiredStub = sinon.stub(standardSlots, 'getRequired').returns(required as any);
-
-      const output = 'output';
-      const nlcToIntentStub = sinon.stub(nlc, 'nlcToIntent').returns(output as any);
-
-      const query = 'query';
-      const model = 'model';
-      const locale = 'locale';
-      const dmRequest = { payload: { intent: { name: 'intent_name' }, entities: ['e1', 'e2'] } };
-
-      expect(handleNLCDialog({ query, model, locale, dmRequest } as any)).to.eql(output);
-      expect(createNLCStub.args).to.eql([[{ model, locale, openSlot: true }]]);
-      expect(nlcObj.getIntent.args).to.eql([[dmRequest.payload.intent.name]]);
-      expect(getRequiredStub.args).to.eql([[[], dmRequest.payload.entities]]);
-      expect(nlcObj.handleDialog.args).to.eql([
-        [
-          {
-            intent: dmRequest.payload.intent.name,
-            required,
-            slots: dmRequest.payload.entities,
-          },
-          query,
-        ],
-      ]);
-      expect(nlcToIntentStub.args).to.eql([[dialogRes, query]]);
     });
   });
 

--- a/tests/lib/services/nlu/nlc.unit.ts
+++ b/tests/lib/services/nlu/nlc.unit.ts
@@ -251,7 +251,7 @@ describe('nlu nlc service unit tests', () => {
     });
   });
 
-  describe.only('registerIntents', () => {
+  describe('registerIntents', () => {
     afterEach(() => {
       sinon.restore();
     });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-000**

### Brief description. What is this change?
this fix requires a long description, but the code is pretty hard to navigate as well so I'll do my best to explain.
I've noticed terrible performance for the capture step/entity filling feature if the model is untrained. We should have a decent fallback measure if the NLP isn't working.

[NLC](https://github.com/voiceflow/natural-language-commander) is a library we use to handle regex matching against intent utterances and extracting entities when the NLP is untrained. It will only match if the user types everything correctly letter for letter.

In the current implementation of entity filling (called dialog management in the code atm, a bit confusing I know, just assume dialog management = entity filling), if we know the user is trying to fill a SPECIFIC entity of an intent, we first make a match of [their intent against the general model](https://github.com/voiceflow/general-runtime/blob/8e22616890c8c4d011ea12845ae463df788d34e4/lib/services/nlu/index.ts#L85-L115). 

Then we also check it against a `dmPrefix`'ed intent utterances:
![Screen Shot 2022-12-05 at 3 56 39 PM](https://user-images.githubusercontent.com/5643574/205741203-edfacfad-90ab-4161-a4ed-c00e941a8fce.png)
![Screen Shot 2022-12-05 at 4 03 47 PM](https://user-images.githubusercontent.com/5643574/205742304-013944b3-8577-4dd0-8258-a34928eaf666.png)

These are special utterances tied to the intent, the prefix is just a hash of the intent name. When we know the user is trying to fill for a specific intent, we call the NLP and prepend the prefix to their raw text query:
https://github.com/voiceflow/general-runtime/blob/8e22616890c8c4d011ea12845ae463df788d34e4/lib/services/dialog/index.ts#L125-L128

So if they said "quote for life insurance" as `query` we would first run it against the NLP normally and then against "1f79373e6d quote for life insurance" as `query`. The LUIS model already has these utterances with prefixes baked in, the NLC does not. 

Also our [predict](https://github.com/voiceflow/general-runtime/blob/8e22616890c8c4d011ea12845ae463df788d34e4/lib/services/nlu/index.ts#L24) code comes in 3 stages:
1. try against the NLC regex but hard matching for slots. If the utterance is something like "quote for {insuranceType}" only valid forms of the slot are okay. They can't say "quote for toilet paper" and expect NLC to match
2. call the actual `luis-authoring-service` endpoint and check against the actual NLP
3. if the user never trained their model, try against NLC regex but open matching flow slots, If the utterance is something like "quote for {insuranceType}" then  "quote for toilet paper" will match the intent and insuranceType = "toilet paper"

What this PR does is if we KNOW that we're looking for the entity of a specific intent, we pass that through when generating the NLC model, and inject that intent's slots' (`intent.slots[].dialog.utterances`) utterances, with prefixes, into the actual utterances of the intent.

[we have this `handleDialog` function for NLC]( "quote for toilet paper"), but looked through the source code, it never worked. It relies on `slot.dialog.utterances` which was never getting passed in:
https://github.com/voiceflow/general-runtime/blob/15a8cfbad416a14af7c194bc59b1516325b50ea3/lib/services/nlu/nlc.ts#L155-L162
`filledEntities` never contains the `dialog.utterances` required, so this would be `NoneIntent` all the time anyways.

TLDR, if we are looking for a specific intent's slots' utterances, just add them to the regex model with a prefix. 

In action:
![Screen Shot 2022-12-05 at 3 47 43 PM](https://user-images.githubusercontent.com/5643574/205746744-b4315ef2-1d2e-4e44-967f-b22be2fbf2c8.png)