### PR TITLE
[Merged by Bors] - fix: make session delete idempotent (PL-296)

### DIFF
--- a/lib/services/session/mongo.ts
+++ b/lib/services/session/mongo.ts
@@ -54,11 +54,10 @@ class SessionManager extends AbstractManager {
     const id = this.getSessionID(_projectID, userID);
 
     const {
-      deletedCount,
       result: { ok },
     } = await mongo!.db.collection(this.collectionName).deleteOne({ projectID, id });
 
-    if (!ok || deletedCount !== 1) {
+    if (!ok) {
       throw Error('delete runtime session error');
     }
   }


### PR DESCRIPTION
**Fixes or implements PL-296**

### Brief description. What is this change?
The delete operation of a session was throwing an error if nothing was deleted.
Changing this to be idempotent and still suceed even if nothing needs to be deleted.

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/platform/pull/334
- https://github.com/voiceflow/general-service/pull/440

### Checklist

- [ ] changes have been validated in an ephemeral environment
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [x] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
