### PR TITLE
fix: required entity example [bugfix] (CT-1284)

### DIFF
--- a/lib/services/nlu/nlc.ts
+++ b/lib/services/nlu/nlc.ts
@@ -49,7 +49,7 @@ export const registerIntents = (
         }
 
         // inject intent slot utterances as utterances
-        if (intent.name === dmRequest?.intent.name) {
+        if (intent.name === dmRequest?.intent.name && intentSlot.required) {
           const prefix = dmPrefix(intent.name);
           const dmUtterances = getUtterancesWithSlotNames({
             slots,
@@ -58,6 +58,8 @@ export const registerIntents = (
                 text: `${prefix} ${utterance.text}`,
               })) ?? [],
           });
+          // also inject entity-only utterance
+          dmUtterances.push(`${prefix} {${slot.name}}`);
 
           // if slot is filled already add it to end of samples
           if (dmRequest.entities?.find((entity) => entity.name === slot.name)) {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CT-1284**

### Brief description. What is this change?

so on luis authoring service for required entities that we have to fill inside an intent, for the "dialog manager" we actually inject a utterance that is nothing but the entity. So like "df3d23j4 {name}" for it match against.

We didn't have this so it would never match against anything, even in the open slot fallback configuration:
https://github.com/voiceflow/luis-authoring-service/blob/08f7ef5d108fe43b38db371f8e63e7423ca69de5/lib/jobs/publish/utils/dialogManagement.ts#L145-L150