### PR TITLE
[Merged by Bors] - fix: resolve action before global no match (BUG-125)

### DIFF
--- a/lib/services/runtime/handlers/noMatch.ts
+++ b/lib/services/runtime/handlers/noMatch.ts
@@ -49,6 +49,12 @@ const getOutput = (node: NoMatchNode, runtime: Runtime, noMatchCounter: number) 
       : nonEmptyNoMatches[noMatchCounter];
   }
 
+  // if we have exhausted reprompts AND there is a following action,
+  // we should not continue prompting
+  if (node.noMatch?.nodeID) {
+    return null;
+  }
+
   if (!isPromptContentEmpty(globalNoMatchPrompt?.content)) {
     return globalNoMatchPrompt?.content;
   }
@@ -86,11 +92,6 @@ export const NoMatchHandler = (utils: typeof utilsObj) => ({
       output,
       variables: variables.getState(),
     });
-
-    if (node.noMatch?.nodeID) {
-      runtime.storage.delete(StorageType.NO_MATCHES_COUNTER);
-      return node.noMatch.nodeID;
-    }
 
     runtime.storage.set(StorageType.NO_MATCHES_COUNTER, noMatchCounter + 1);
 

--- a/tests/lib/services/runtime/handlers/noMatch.unit.ts
+++ b/tests/lib/services/runtime/handlers/noMatch.unit.ts
@@ -224,7 +224,7 @@ describe('noMatch handler unit tests', () => {
         addButtonsIfExists,
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
-      expect(noMatchHandler.handle(node as any, runtime as any, variables as any)).to.eql('next-id');
+      expect(noMatchHandler.handle(node as any, runtime as any, variables as any)).to.eql('node-id');
 
       expect(runtime.trace.addTrace.args).to.eql([
         [RepromptPathTrace],


### PR DESCRIPTION
I spoke to Chris.

So the original issue brought up in https://github.com/voiceflow/general-runtime/pull/445 was mis-classified.
It is okay for the no match to "hang"

It distills down to this very simple pattern:

* If user defines no match escalation, go through all the local node escalations, go to the action if there is one, if not just keep looping global no match.
* If the user has empty no match escalations, go to the action if there is one, if not just keep looping global no match.

If there is no no match escalations and no action, just loop global no match.

PRIORITY QUEUE:
1. local node no match escalations
2. node action/path (next node.id)
3. global no match forever on loop