### PR TITLE
fix: no-reply behavior for card and carousel (BUG-148)

### DIFF
--- a/lib/services/runtime/handlers/cardV2.ts
+++ b/lib/services/runtime/handlers/cardV2.ts
@@ -57,11 +57,10 @@ export const CardV2Handler: HandlerFactory<VoiceflowNode.CardV2.Node, typeof han
   canHandle: (node) => node.type === BaseNode.NodeType.CARD_V2,
 
   handle: (node, runtime, variables) => {
-    const isStartingFromCardV2Step = runtime.getAction() === Action.REQUEST && !runtime.getRequest();
     const defaultPath = node.nextId || null;
     const { isBlocking } = node;
 
-    if (runtime.getAction() === Action.RUNNING || isStartingFromCardV2Step) {
+    if (runtime.getAction() === Action.RUNNING || runtime.hasStartedFromBlock(node.id)) {
       const variablesMap = variables.getState();
       const description = getDescription(
         variablesMap,

--- a/lib/services/runtime/handlers/carousel.ts
+++ b/lib/services/runtime/handlers/carousel.ts
@@ -22,12 +22,10 @@ const handlerUtils = {
 
 export const CarouselHandler: HandlerFactory<BaseNode.Carousel.Node, typeof handlerUtils> = (utils) => ({
   canHandle: (node) => node.type === BaseNode.NodeType.CAROUSEL,
-  // eslint-disable-next-line sonarjs/cognitive-complexity
   handle: (node, runtime, variables) => {
     const defaultPath = node.nextId || null;
-    const isStartingFromCarouselStep = runtime.getAction() === Action.REQUEST && !runtime.getRequest();
 
-    if (runtime.getAction() === Action.RUNNING || isStartingFromCarouselStep) {
+    if (runtime.getAction() === Action.RUNNING || runtime.hasStartedFromBlock(node.id)) {
       const variablesMap = variables.getState();
       const sanitizedVars = utils.sanitizeVariables(variables.getState());
       const cards: BaseNode.Carousel.TraceCarouselCard[] = [];

--- a/runtime/lib/Runtime/index.ts
+++ b/runtime/lib/Runtime/index.ts
@@ -137,6 +137,15 @@ class Runtime<
     return this.getAction() === Action.END;
   }
 
+  public hasStartedFromBlock(blockID: string): boolean {
+    return (
+      this.getAction() === Action.REQUEST &&
+      !this.getRequest() &&
+      this.trace.get()?.[0]?.type === 'flow' &&
+      this.trace.get()?.[1]?.payload?.blockID === blockID
+    );
+  }
+
   public async callEvent<K extends EventType>(type: K, event: Event<K>) {
     await super.callEvent<K>(type, event, this);
   }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements BUG-148**

### Brief description. What is this change?
When a user starts the conversation from a specific block (the play button in the block), the request action is not `Action.RUNNING` as usual, instead, it is `Action.REQUEST`. 
The problem is that this is the same action type we got when no-reply is triggered. 

I'm not sure if we changed the no-reply Action recently, or if we changed the no-reply request, but this was the previous validation we were doing, that doesn't work anymore:

```ts
const isStartingFromBlock = this.getAction() === Action.REQUEST && !this.getRequest()
```

As the above now is true for starting a block and also when no-reply is triggered, I compared other data that comes with the runtime when it's a "no-reply" and when it's a "start from block".
The best difference I notice, was the trace. When it's a no-reply, trace is a since item, of type block. When it's starting from a block, traces has two items, first is of type flow, second is the block.

```ts
// no-reply trace
[ { type: 'block', payload: { blockID: '63b58f8858eb2bcbdb7bc60d' } } ];

// start from block trace
[
  {
    type: 'flow',
    payload: { diagramID: '63b4547ceaa2b663938cdf12', name: undefined }
  },
  { type: 'block', payload: { blockID: '63b58f8858eb2bcbdb7bc60d' } }
]
```

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] changes have been validated in an ephemeral environment
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified


[BUG-148]: https://voiceflow.atlassian.net/browse/BUG-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ