### PR TITLE
[Merged by Bors] - feat: added transcript call authorized via api key (PL-363)

### DIFF
--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -6,6 +6,7 @@ import InteractRouter from './routers/interact';
 import PublicRouter from './routers/public';
 import StateRouter from './routers/state';
 import TestRouter from './routers/test';
+import TranscriptRouter from './routers/transcript';
 
 export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   const router = express.Router();
@@ -15,6 +16,7 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   router.use('/state', StateRouter(middlewares, controllers));
   router.use('/public', PublicRouter(middlewares, controllers));
   router.use('/test', TestRouter(middlewares));
+  router.use('/transcript', TranscriptRouter(middlewares, controllers));
 
   return router;
 };

--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -16,7 +16,7 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   router.use('/state', StateRouter(middlewares, controllers));
   router.use('/public', PublicRouter(middlewares, controllers));
   router.use('/test', TestRouter(middlewares));
-  router.use('/transcript', TranscriptRouter(middlewares, controllers));
+  router.use('/transcripts', TranscriptRouter(middlewares, controllers));
 
   return router;
 };

--- a/backend/api/routers/public.ts
+++ b/backend/api/routers/public.ts
@@ -14,7 +14,7 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   // full route: /public/:projectID/state/user/:userID/interact
   router.post('/:projectID/state/user/:userID/interact', interactMiddleware, controllers.public.interact);
 
-  router.post('/:projectID/transcripts', interactMiddleware, controllers.transcript.createTranscript);
+  router.post('/:projectID/transcripts', interactMiddleware, controllers.transcript.upsertTranscript);
 
   router.get('/:projectID/publishing', interactMiddleware, controllers.public.getPublishing);
 

--- a/backend/api/routers/public.ts
+++ b/backend/api/routers/public.ts
@@ -14,7 +14,7 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   // full route: /public/:projectID/state/user/:userID/interact
   router.post('/:projectID/state/user/:userID/interact', interactMiddleware, controllers.public.interact);
 
-  router.post('/:projectID/transcripts', interactMiddleware, controllers.public.createTranscript);
+  router.post('/:projectID/transcripts', interactMiddleware, controllers.transcript.createTranscript);
 
   router.get('/:projectID/publishing', interactMiddleware, controllers.public.getPublishing);
 

--- a/backend/api/routers/transcript.ts
+++ b/backend/api/routers/transcript.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+
+import { BODY_PARSER_SIZE_LIMIT } from '@/backend/constants';
+import { ControllerMap, MiddlewareMap } from '@/lib';
+
+// stateful API routes
+export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
+  const router = express.Router();
+
+  router.use(express.json({ limit: BODY_PARSER_SIZE_LIMIT }));
+
+  const middleware = [
+    middlewares.project.resolveVersionAlias,
+    middlewares.project.attachProjectID,
+    middlewares.rateLimit.versionConsume,
+  ];
+
+  router.post('/:projectID', middleware, controllers.transcript.createTranscript);
+
+  return router;
+};

--- a/backend/api/routers/transcript.ts
+++ b/backend/api/routers/transcript.ts
@@ -15,7 +15,7 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
     middlewares.rateLimit.versionConsume,
   ];
 
-  router.post('/:projectID', middleware, controllers.transcript.createTranscript);
+  router.post('/:projectID', middleware, controllers.transcript.upsertTranscript);
 
   return router;
 };

--- a/lib/controllers/index.ts
+++ b/lib/controllers/index.ts
@@ -5,11 +5,13 @@ import { FullServiceMap } from '../services';
 import Interact from './interact';
 import Public from './public';
 import StateManagement from './stateManagement';
+import Transcript from './transcript/transcript';
 
 export interface ControllerMap {
   public: Public;
   interact: Interact;
   stateManagement: StateManagement;
+  transcript: Transcript;
 }
 
 export interface ControllerClass<T = Controller> {
@@ -24,6 +26,7 @@ const buildControllers = (services: FullServiceMap, config: Config) => {
     public: new Public(services, config),
     interact: new Interact(services, config),
     stateManagement: new StateManagement(services, config),
+    transcript: new Transcript(services, config),
   };
 
   // everything before this will be route-wrapped

--- a/lib/controllers/public/index.ts
+++ b/lib/controllers/public/index.ts
@@ -1,6 +1,5 @@
 import { Validator } from '@voiceflow/backend-utils';
 import { BaseRequest } from '@voiceflow/base-types';
-import { ObjectId } from 'mongodb';
 
 import { RuntimeRequest } from '@/lib/services/runtime/types';
 import { Request } from '@/types';
@@ -55,69 +54,6 @@ class PublicController extends AbstractController {
     const version = await api.getVersion(req.headers.versionID);
 
     return version.platformData.publishing || {};
-  }
-
-  @validate({
-    HEADERS_PROJECT_ID: VALIDATIONS.HEADERS.PROJECT_ID,
-    BODY_TRANSCRIPT: VALIDATIONS.BODY.TRANSCRIPT,
-  })
-  async createTranscript(
-    req: Request<
-      never,
-      { sessionID: string; device?: string; os?: string; browser?: string; user?: { name?: string; image?: string } },
-      { projectID: string }
-    >
-  ) {
-    const {
-      body: { sessionID, device, os, browser, user },
-      headers: { projectID },
-    } = req;
-    const { mongo } = this.services;
-    if (!mongo) throw new Error('mongo not initialized');
-
-    const filter = {
-      projectID: new ObjectId(projectID),
-      sessionID,
-    };
-
-    const insertData = {
-      ...filter,
-      createdAt: new Date(),
-      unread: true,
-      reportTags: [],
-    };
-
-    const updateData: {
-      updatedAt: Date;
-      os?: string | undefined;
-      device?: string | undefined;
-      browser?: string | undefined;
-      user?: {
-        name?: string | undefined;
-        image?: string | undefined;
-      };
-    } = {
-      updatedAt: insertData.createdAt,
-      ...(os && { os }),
-      ...(device && { device }),
-      ...(browser && { browser }),
-      ...(user && {
-        user: {
-          ...(user.name && { name: user.name }),
-          ...(user.image && { image: user.image }),
-        },
-      }),
-    };
-
-    const { value: newTranscript } = await mongo.db
-      .collection('transcripts')
-      .findOneAndUpdate(
-        filter,
-        { $set: updateData, $setOnInsert: insertData },
-        { upsert: true, returnOriginal: false }
-      );
-
-    return newTranscript;
   }
 }
 

--- a/lib/controllers/public/index.ts
+++ b/lib/controllers/public/index.ts
@@ -6,13 +6,12 @@ import { Request } from '@/types';
 
 import { customAJV, validate } from '../../utils';
 import { AbstractController } from '../utils';
-import { PublicInteractSchema, TranscriptSchema } from './requests';
+import { PublicInteractSchema } from './requests';
 
 const { body, header } = Validator;
 const VALIDATIONS = {
   BODY: {
     PUBLIC_INTERACT: body().custom(customAJV(PublicInteractSchema)),
-    TRANSCRIPT: body().custom(customAJV(TranscriptSchema)),
   },
   HEADERS: {
     PROJECT_ID: header('projectID').exists().isString(),

--- a/lib/controllers/public/requests.ts
+++ b/lib/controllers/public/requests.ts
@@ -1,4 +1,4 @@
-import { ObjectField, StringField } from '@/lib/controllers/schemaTypes';
+import { ObjectField } from '@/lib/controllers/schemaTypes';
 
 import { ConfigSchema } from '../stateManagement/requests';
 
@@ -8,18 +8,5 @@ export const PublicInteractSchema = {
   properties: {
     action: ObjectField('action'),
     config: ConfigSchema,
-  },
-};
-
-export const TranscriptSchema = {
-  type: 'object',
-  additionalProperties: false,
-  required: ['sessionID'],
-  properties: {
-    sessionID: StringField('sessionID'),
-    os: StringField('os'),
-    device: StringField('device'),
-    browser: StringField('browser'),
-    user: ObjectField('user'),
   },
 };

--- a/lib/controllers/transcript/requests.ts
+++ b/lib/controllers/transcript/requests.ts
@@ -6,6 +6,7 @@ export const TranscriptSchema = {
   required: ['sessionID'],
   properties: {
     sessionID: StringField('sessionID'),
+    apiKey: StringField('apiKey'),
     os: StringField('os'),
     device: StringField('device'),
     browser: StringField('browser'),

--- a/lib/controllers/transcript/requests.ts
+++ b/lib/controllers/transcript/requests.ts
@@ -1,4 +1,4 @@
-import { ObjectField, StringField } from '@/lib/controllers/schemaTypes';
+import { BooleanField, ObjectField, StringField } from '@/lib/controllers/schemaTypes';
 
 export const TranscriptSchema = {
   type: 'object',
@@ -11,5 +11,6 @@ export const TranscriptSchema = {
     device: StringField('device'),
     browser: StringField('browser'),
     user: ObjectField('user'),
+    unread: BooleanField('unread'),
   },
 };

--- a/lib/controllers/transcript/requests.ts
+++ b/lib/controllers/transcript/requests.ts
@@ -6,7 +6,6 @@ export const UpsertTranscriptSchema = {
   required: ['sessionID'],
   properties: {
     sessionID: StringField('sessionID'),
-    apiKey: StringField('apiKey'),
     os: StringField('os'),
     device: StringField('device'),
     browser: StringField('browser'),

--- a/lib/controllers/transcript/requests.ts
+++ b/lib/controllers/transcript/requests.ts
@@ -1,0 +1,14 @@
+import { ObjectField, StringField } from '@/lib/controllers/schemaTypes';
+
+export const TranscriptSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['sessionID'],
+  properties: {
+    sessionID: StringField('sessionID'),
+    os: StringField('os'),
+    device: StringField('device'),
+    browser: StringField('browser'),
+    user: ObjectField('user'),
+  },
+};

--- a/lib/controllers/transcript/requests.ts
+++ b/lib/controllers/transcript/requests.ts
@@ -1,6 +1,6 @@
 import { BooleanField, ObjectField, StringField } from '@/lib/controllers/schemaTypes';
 
-export const TranscriptSchema = {
+export const UpsertTranscriptSchema = {
   type: 'object',
   additionalProperties: false,
   required: ['sessionID'],

--- a/lib/controllers/transcript/transcript.ts
+++ b/lib/controllers/transcript/transcript.ts
@@ -24,11 +24,19 @@ class TranscriptController extends AbstractController {
   async createTranscript(
     req: Request<
       never,
-      { sessionID: string; device?: string; os?: string; browser?: string; user?: { name?: string; image?: string } },
+      {
+        sessionID: string;
+        device?: string;
+        os?: string;
+        browser?: string;
+        user?: { name?: string; image?: string };
+        unread?: boolean;
+      },
       { projectID: string }
     >
   ) {
-    return this.services.transcript.createTranscript(req.headers.projectID, req.body.sessionID, req.body);
+    const { unread } = req.body;
+    return this.services.transcript.createTranscript(req.headers.projectID, req.body.sessionID, req.body, unread);
   }
 }
 

--- a/lib/controllers/transcript/transcript.ts
+++ b/lib/controllers/transcript/transcript.ts
@@ -4,12 +4,12 @@ import { Request } from '@/types';
 
 import { customAJV, validate } from '../../utils';
 import { AbstractController } from '../utils';
-import { TranscriptSchema } from './requests';
+import { UpsertTranscriptSchema } from './requests';
 
 const { body, header } = Validator;
 const VALIDATIONS = {
   BODY: {
-    TRANSCRIPT: body().custom(customAJV(TranscriptSchema)),
+    UPSERT_TRANSCRIPT: body().custom(customAJV(UpsertTranscriptSchema)),
   },
   HEADERS: {
     PROJECT_ID: header('projectID').exists().isString(),
@@ -19,9 +19,9 @@ const VALIDATIONS = {
 class TranscriptController extends AbstractController {
   @validate({
     HEADERS_PROJECT_ID: VALIDATIONS.HEADERS.PROJECT_ID,
-    BODY_TRANSCRIPT: VALIDATIONS.BODY.TRANSCRIPT,
+    BODY_TRANSCRIPT: VALIDATIONS.BODY.UPSERT_TRANSCRIPT,
   })
-  async createTranscript(
+  async upsertTranscript(
     req: Request<
       never,
       {
@@ -36,7 +36,7 @@ class TranscriptController extends AbstractController {
     >
   ) {
     const { unread } = req.body;
-    return this.services.transcript.createTranscript(req.headers.projectID, req.body.sessionID, req.body, unread);
+    return this.services.transcript.upsertTranscript(req.headers.projectID, req.body.sessionID, req.body, unread);
   }
 }
 

--- a/lib/controllers/transcript/transcript.ts
+++ b/lib/controllers/transcript/transcript.ts
@@ -35,8 +35,7 @@ class TranscriptController extends AbstractController {
       { projectID: string }
     >
   ) {
-    const { unread } = req.body;
-    return this.services.transcript.upsertTranscript(req.headers.projectID, req.body.sessionID, req.body, unread);
+    return this.services.transcript.upsertTranscript(req.headers.projectID, req.body.sessionID, req.body);
   }
 }
 

--- a/lib/controllers/transcript/transcript.ts
+++ b/lib/controllers/transcript/transcript.ts
@@ -1,0 +1,35 @@
+import { Validator } from '@voiceflow/backend-utils';
+
+import { Request } from '@/types';
+
+import { customAJV, validate } from '../../utils';
+import { AbstractController } from '../utils';
+import { TranscriptSchema } from './requests';
+
+const { body, header } = Validator;
+const VALIDATIONS = {
+  BODY: {
+    TRANSCRIPT: body().custom(customAJV(TranscriptSchema)),
+  },
+  HEADERS: {
+    PROJECT_ID: header('projectID').exists().isString(),
+  },
+};
+
+class TranscriptController extends AbstractController {
+  @validate({
+    HEADERS_PROJECT_ID: VALIDATIONS.HEADERS.PROJECT_ID,
+    BODY_TRANSCRIPT: VALIDATIONS.BODY.TRANSCRIPT,
+  })
+  async createTranscript(
+    req: Request<
+      never,
+      { sessionID: string; device?: string; os?: string; browser?: string; user?: { name?: string; image?: string } },
+      { projectID: string }
+    >
+  ) {
+    return this.services.transcript.createTranscript(req.headers.projectID, req.body.sessionID, req.body);
+  }
+}
+
+export default TranscriptController;

--- a/lib/services/aiAssist.ts
+++ b/lib/services/aiAssist.ts
@@ -8,8 +8,8 @@ import { AbstractManager } from './utils';
 
 const MAX_TURNS = 3;
 
-// writes a primative string transcript into the context state storage
-class AIAssistContext extends AbstractManager implements ContextHandler {
+// writes a primative string aiAssistTranscript into the context state storage
+class AIAssist extends AbstractManager implements ContextHandler {
   static StorageKey = 'aiAssistTranscript';
 
   static getInput(request: RuntimeRequest) {
@@ -19,12 +19,12 @@ class AIAssistContext extends AbstractManager implements ContextHandler {
   handle = async (context: Context) => {
     if (!context.version?.projectID) return context;
 
-    // only store transcript if freestyle is enabled
+    // only store aiAssistTranscript if freestyle is enabled
     const project = await context.data.api.getProject(context.version.projectID).catch(() => null);
     if (!project?.aiAssistSettings?.freestyle) return context;
 
     /**
-    // skip storing no matches into transcript
+    // skip storing no matches into aiAssistTranscript
     if (context.trace?.find((trace: any) => trace.type === Trace.TraceType.PATH && trace.payload.path === 'reprompt')) {
       return context;
     }
@@ -32,7 +32,7 @@ class AIAssistContext extends AbstractManager implements ContextHandler {
 
     const { request, trace } = context;
 
-    const input = AIAssistContext.getInput(request);
+    const input = AIAssist.getInput(request);
 
     const output =
       trace?.reduce((acc, t) => {
@@ -47,11 +47,11 @@ class AIAssistContext extends AbstractManager implements ContextHandler {
 
     if (!input && !output) return context;
 
-    const transcript = context.state.storage[AIAssistContext.StorageKey] || [];
+    const aiAssistTranscript = context.state.storage[AIAssist.StorageKey] || [];
 
-    transcript.push([input, output]);
+    aiAssistTranscript.push([input, output]);
 
-    if (transcript.length > MAX_TURNS) transcript.shift();
+    if (aiAssistTranscript.length > MAX_TURNS) aiAssistTranscript.shift();
 
     return {
       ...context,
@@ -59,11 +59,11 @@ class AIAssistContext extends AbstractManager implements ContextHandler {
         ...context.state,
         storage: {
           ...context.state.storage,
-          [AIAssistContext.StorageKey]: transcript,
+          [AIAssist.StorageKey]: aiAssistTranscript,
         },
       },
     };
   };
 }
 
-export default AIAssistContext;
+export default AIAssist;

--- a/lib/services/aiAssistContext.ts
+++ b/lib/services/aiAssistContext.ts
@@ -10,7 +10,7 @@ const MAX_TURNS = 3;
 
 // writes a primative string transcript into the context state storage
 class AIAssistContext extends AbstractManager implements ContextHandler {
-  static StorageKey = 'transcript';
+  static StorageKey = 'aiAssistTranscript';
 
   static getInput(request: RuntimeRequest) {
     return (isIntentRequest(request) && request.payload.query) || (isTextRequest(request) && request.payload) || null;

--- a/lib/services/aiAssistContext.ts
+++ b/lib/services/aiAssistContext.ts
@@ -9,7 +9,7 @@ import { AbstractManager } from './utils';
 const MAX_TURNS = 3;
 
 // writes a primative string transcript into the context state storage
-class Transcript extends AbstractManager implements ContextHandler {
+class AIAssistContext extends AbstractManager implements ContextHandler {
   static StorageKey = 'transcript';
 
   static getInput(request: RuntimeRequest) {
@@ -32,7 +32,7 @@ class Transcript extends AbstractManager implements ContextHandler {
 
     const { request, trace } = context;
 
-    const input = Transcript.getInput(request);
+    const input = AIAssistContext.getInput(request);
 
     const output =
       trace?.reduce((acc, t) => {
@@ -47,7 +47,7 @@ class Transcript extends AbstractManager implements ContextHandler {
 
     if (!input && !output) return context;
 
-    const transcript = context.state.storage[Transcript.StorageKey] || [];
+    const transcript = context.state.storage[AIAssistContext.StorageKey] || [];
 
     transcript.push([input, output]);
 
@@ -59,11 +59,11 @@ class Transcript extends AbstractManager implements ContextHandler {
         ...context.state,
         storage: {
           ...context.state.storage,
-          [Transcript.StorageKey]: transcript,
+          [AIAssistContext.StorageKey]: transcript,
         },
       },
     };
   };
 }
 
-export default Transcript;
+export default AIAssistContext;

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -1,6 +1,7 @@
 import { Config } from '@/types';
 
 import { ClientMap } from '../clients';
+import AIAssistContext from './aiAssistContext';
 import Analytics from './analytics';
 import ASR from './asr';
 import Dialog from './dialog';
@@ -20,6 +21,7 @@ import TTS from './tts';
 export interface ServiceMap {
   runtime: Runtime;
   state: State;
+  aiAssistContext: AIAssistContext;
   asr: ASR;
   speak: Speak;
   nlu: NLU;
@@ -32,7 +34,6 @@ export interface ServiceMap {
   analytics: Analytics;
   transcript: Transcript;
   stateManagement: StateManagement;
-  transcript: Transcript;
 }
 
 export interface FullServiceMap extends ClientMap, ServiceMap {}
@@ -58,7 +59,7 @@ const buildServices = (config: Config, clients: ClientMap): FullServiceMap => {
   services.stateManagement = new StateManagement(services, config);
   services.transcript = new Transcript(services, config);
   services.interact = new Interact(services, config);
-  services.transcript = new Transcript(services, config);
+  services.aiAssistContext = new AIAssistContext(services, config);
 
   if (config.SESSIONS_SOURCE === Source.LOCAL) {
     services.session = new LocalSession(services, config);

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -1,7 +1,7 @@
 import { Config } from '@/types';
 
 import { ClientMap } from '../clients';
-import AIAssistContext from './aiAssistContext';
+import AIAssist from './aiAssist';
 import Analytics from './analytics';
 import ASR from './asr';
 import Dialog from './dialog';
@@ -21,7 +21,7 @@ import TTS from './tts';
 export interface ServiceMap {
   runtime: Runtime;
   state: State;
-  aiAssistContext: AIAssistContext;
+  aiAssist: AIAssist;
   asr: ASR;
   speak: Speak;
   nlu: NLU;
@@ -58,8 +58,8 @@ const buildServices = (config: Config, clients: ClientMap): FullServiceMap => {
   services.analytics = new Analytics(services, config);
   services.stateManagement = new StateManagement(services, config);
   services.transcript = new Transcript(services, config);
+  services.aiAssist = new AIAssist(services, config);
   services.interact = new Interact(services, config);
-  services.aiAssistContext = new AIAssistContext(services, config);
 
   if (config.SESSIONS_SOURCE === Source.LOCAL) {
     services.session = new LocalSession(services, config);

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -32,6 +32,7 @@ export interface ServiceMap {
   analytics: Analytics;
   transcript: Transcript;
   stateManagement: StateManagement;
+  transcript: Transcript;
 }
 
 export interface FullServiceMap extends ClientMap, ServiceMap {}
@@ -57,6 +58,7 @@ const buildServices = (config: Config, clients: ClientMap): FullServiceMap => {
   services.stateManagement = new StateManagement(services, config);
   services.transcript = new Transcript(services, config);
   services.interact = new Interact(services, config);
+  services.transcript = new Transcript(services, config);
 
   if (config.SESSIONS_SOURCE === Source.LOCAL) {
     services.session = new LocalSession(services, config);

--- a/lib/services/interact/index.ts
+++ b/lib/services/interact/index.ts
@@ -50,7 +50,7 @@ class Interact extends AbstractManager<{ utils: typeof utils }> {
       slots,
       state: stateManager,
       filter,
-      transcript,
+      aiAssistContext,
     } = this.services;
 
     const {
@@ -87,7 +87,7 @@ class Interact extends AbstractManager<{ utils: typeof utils }> {
       turn.addHandlers(tts);
     }
 
-    turn.addHandlers(speak, filter, transcript);
+    turn.addHandlers(speak, filter, aiAssistContext);
 
     if (config.selfDelegate) {
       return turn.resolve(turn.handle(context));

--- a/lib/services/interact/index.ts
+++ b/lib/services/interact/index.ts
@@ -50,7 +50,7 @@ class Interact extends AbstractManager<{ utils: typeof utils }> {
       slots,
       state: stateManager,
       filter,
-      aiAssistContext,
+      aiAssist,
     } = this.services;
 
     const {
@@ -87,7 +87,7 @@ class Interact extends AbstractManager<{ utils: typeof utils }> {
       turn.addHandlers(tts);
     }
 
-    turn.addHandlers(speak, filter, aiAssistContext);
+    turn.addHandlers(speak, filter, aiAssist);
 
     if (config.selfDelegate) {
       return turn.resolve(turn.handle(context));

--- a/lib/services/runtime/handlers/utils/generativeNoMatch.ts
+++ b/lib/services/runtime/handlers/utils/generativeNoMatch.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import Config from '@/config';
-import Transcript from '@/lib/services/transcript';
+import AIAssistContext from '@/lib/services/aiAssistContext';
 import { Runtime } from '@/runtime';
 
 import { Output } from '../../types';
@@ -13,8 +13,8 @@ export const generateNoMatch = async (runtime: Runtime): Promise<Output | null> 
   const ML_GATEWAY_ENDPOINT = Config.ML_GATEWAY_ENDPOINT.split('/api')[0];
   const autoCompleteEndpoint = `${ML_GATEWAY_ENDPOINT}/api/v1/generation/autocomplete`;
 
-  const newInput = Transcript.getInput(runtime.getRequest());
-  const storageTranscript = runtime.storage.get<[string | null, string | null][]>(Transcript.StorageKey) || [];
+  const newInput = AIAssistContext.getInput(runtime.getRequest());
+  const storageTranscript = runtime.storage.get<[string | null, string | null][]>(AIAssistContext.StorageKey) || [];
   const transcript = [...storageTranscript, [newInput, null]];
 
   const parsedTranscript = transcript.reduce((acc, [input, output]) => {

--- a/lib/services/runtime/handlers/utils/generativeNoMatch.ts
+++ b/lib/services/runtime/handlers/utils/generativeNoMatch.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import Config from '@/config';
-import AIAssistContext from '@/lib/services/aiAssistContext';
+import AIAssist from '@/lib/services/aiAssist';
 import { Runtime } from '@/runtime';
 
 import { Output } from '../../types';
@@ -13,21 +13,21 @@ export const generateNoMatch = async (runtime: Runtime): Promise<Output | null> 
   const ML_GATEWAY_ENDPOINT = Config.ML_GATEWAY_ENDPOINT.split('/api')[0];
   const autoCompleteEndpoint = `${ML_GATEWAY_ENDPOINT}/api/v1/generation/autocomplete`;
 
-  const newInput = AIAssistContext.getInput(runtime.getRequest());
-  const storageTranscript = runtime.storage.get<[string | null, string | null][]>(AIAssistContext.StorageKey) || [];
-  const transcript = [...storageTranscript, [newInput, null]];
+  const newInput = AIAssist.getInput(runtime.getRequest());
+  const storageAIAssistTranscript = runtime.storage.get<[string | null, string | null][]>(AIAssist.StorageKey) || [];
+  const aiAssistTranscript = [...storageAIAssistTranscript, [newInput, null]];
 
-  const parsedTranscript = transcript.reduce((acc, [input, output]) => {
+  const parsedAiAssistTranscript = aiAssistTranscript.reduce((acc, [input, output]) => {
     if (input) acc += `P2: ${input}\n`;
     if (output) acc += `AI: ${output}\n`;
     return acc;
   }, '');
 
-  if (!parsedTranscript) return null;
+  if (!parsedAiAssistTranscript) return null;
 
   const response = await axios
     .post(autoCompleteEndpoint, {
-      transcript: parsedTranscript,
+      transcript: parsedAiAssistTranscript,
       locale: runtime.version?.prototype?.data.locales[0], // use nlu locale
     })
     .catch(() => null);

--- a/lib/services/transcript/index.ts
+++ b/lib/services/transcript/index.ts
@@ -1,0 +1,51 @@
+import { DeepPartial } from '@voiceflow/common';
+import { ObjectId } from 'mongodb';
+
+import { AbstractManager } from '../utils';
+import { TranscriptClientInfo, TranscriptUpdatePayload } from './types';
+
+class TranscriptManager extends AbstractManager {
+  async createTranscript(projectID: string, sessionID: string, clientInfo: DeepPartial<TranscriptClientInfo>) {
+    const { mongo } = this.services;
+    if (!mongo) throw new Error('mongo not initialized');
+
+    const filter = {
+      projectID: new ObjectId(projectID),
+      sessionID,
+    };
+
+    const insertData = {
+      ...filter,
+      createdAt: new Date(),
+      unread: true,
+      reportTags: [],
+    };
+
+    const { os, device, browser, user } = clientInfo;
+
+    const updateData: TranscriptUpdatePayload = {
+      updatedAt: insertData.createdAt,
+      ...(os && { os }),
+      ...(device && { device }),
+      ...(browser && { browser }),
+      ...(user && {
+        user: {
+          ...(user.name && { name: user.name }),
+          ...(user.image && { image: user.image }),
+        },
+      }),
+    };
+
+    const { value: newTranscript } = await mongo.db
+      .collection('transcripts')
+      .findOneAndUpdate(
+        filter,
+        { $set: updateData, $setOnInsert: insertData },
+        { upsert: true, returnOriginal: false }
+      );
+
+    return newTranscript;
+  }
+}
+
+export default TranscriptManager;

--- a/lib/services/transcript/index.ts
+++ b/lib/services/transcript/index.ts
@@ -5,7 +5,12 @@ import { AbstractManager } from '../utils';
 import { TranscriptClientInfo, TranscriptUpdatePayload } from './types';
 
 class TranscriptManager extends AbstractManager {
-  async createTranscript(projectID: string, sessionID: string, clientInfo: DeepPartial<TranscriptClientInfo>) {
+  async createTranscript(
+    projectID: string,
+    sessionID: string,
+    clientInfo: DeepPartial<TranscriptClientInfo>,
+    unread?: boolean
+  ) {
     const { mongo } = this.services;
     if (!mongo) throw new Error('mongo not initialized');
 
@@ -28,6 +33,7 @@ class TranscriptManager extends AbstractManager {
       ...(os && { os }),
       ...(device && { device }),
       ...(browser && { browser }),
+      ...(unread && { unread }),
       ...(user && {
         user: {
           ...(user.name && { name: user.name }),

--- a/lib/services/transcript/index.ts
+++ b/lib/services/transcript/index.ts
@@ -22,7 +22,6 @@ class TranscriptManager extends AbstractManager {
     const insertData = {
       ...filter,
       createdAt: new Date(),
-      unread: true,
       reportTags: [],
     };
 

--- a/lib/services/transcript/index.ts
+++ b/lib/services/transcript/index.ts
@@ -5,7 +5,7 @@ import { AbstractManager } from '../utils';
 import { TranscriptClientInfo, TranscriptUpdatePayload } from './types';
 
 class TranscriptManager extends AbstractManager {
-  async createTranscript(
+  async upsertTranscript(
     projectID: string,
     sessionID: string,
     clientInfo: DeepPartial<TranscriptClientInfo>,

--- a/lib/services/transcript/index.ts
+++ b/lib/services/transcript/index.ts
@@ -5,12 +5,7 @@ import { AbstractManager } from '../utils';
 import { TranscriptClientInfo, TranscriptUpdatePayload } from './types';
 
 class TranscriptManager extends AbstractManager {
-  async upsertTranscript(
-    projectID: string,
-    sessionID: string,
-    clientInfo: DeepPartial<TranscriptClientInfo>,
-    unread?: boolean
-  ) {
+  async upsertTranscript(projectID: string, sessionID: string, clientInfo: DeepPartial<TranscriptClientInfo>) {
     const { mongo } = this.services;
     if (!mongo) throw new Error('mongo not initialized');
 
@@ -25,7 +20,7 @@ class TranscriptManager extends AbstractManager {
       reportTags: [],
     };
 
-    const { os, device, browser, user } = clientInfo;
+    const { os, device, browser, user, unread } = clientInfo;
 
     const updateData: TranscriptUpdatePayload = {
       updatedAt: insertData.createdAt,

--- a/lib/services/transcript/types.ts
+++ b/lib/services/transcript/types.ts
@@ -1,0 +1,20 @@
+export interface TranscriptClientInfo {
+  device: string;
+  os: string;
+  browser: string;
+  user: {
+    name: string;
+    image: string;
+  };
+}
+
+export interface TranscriptUpdatePayload {
+  updatedAt: Date;
+  os?: string | undefined;
+  device?: string | undefined;
+  browser?: string | undefined;
+  user?: {
+    name?: string | undefined;
+    image?: string | undefined;
+  };
+}

--- a/lib/services/transcript/types.ts
+++ b/lib/services/transcript/types.ts
@@ -6,6 +6,7 @@ export interface TranscriptClientInfo {
     name: string;
     image: string;
   };
+  unread: boolean;
 }
 
 export interface TranscriptUpdatePayload {
@@ -17,4 +18,5 @@ export interface TranscriptUpdatePayload {
     name?: string | undefined;
     image?: string | undefined;
   };
+  unread?: boolean | undefined;
 }

--- a/tests/lib/services/interact/interact.unit.ts
+++ b/tests/lib/services/interact/interact.unit.ts
@@ -19,7 +19,7 @@ const buildServices = (context: any) => ({
   analytics: { handle: sinon.stub().resolves(output(context, 'analytics')) },
   dialog: { handle: sinon.stub().resolves(output(context, 'dialog')) },
   filter: { handle: sinon.stub().resolves(output(context, 'filter')) },
-  aiAssistContext: { handle: sinon.stub().resolves(output(context, 'aiAssistTranscript', { trace: 'trace' })) },
+  aiAssist: { handle: sinon.stub().resolves(output(context, 'aiAssistTranscript', { trace: 'trace' })) },
   metrics: { generalRequest: sinon.stub() },
   utils: { TurnBuilder },
 });
@@ -213,7 +213,7 @@ describe('interact service unit tests', () => {
     expect(turnBuilder.addHandlers.args).to.eql([
       [services.asr, services.nlu, services.slots, services.dialog, services.runtime],
       [services.analytics],
-      [services.speak, services.filter, services.aiAssistContext],
+      [services.speak, services.filter, services.aiAssist],
     ]);
     expect(services.utils.autoDelegate.args).to.eql([[turnBuilder, context]]);
     expect(await turnBuilder.resolve.args[0][0]).to.eql(finalState);

--- a/tests/lib/services/interact/interact.unit.ts
+++ b/tests/lib/services/interact/interact.unit.ts
@@ -19,7 +19,7 @@ const buildServices = (context: any) => ({
   analytics: { handle: sinon.stub().resolves(output(context, 'analytics')) },
   dialog: { handle: sinon.stub().resolves(output(context, 'dialog')) },
   filter: { handle: sinon.stub().resolves(output(context, 'filter')) },
-  transcript: { handle: sinon.stub().resolves(output(context, 'transcript', { trace: 'trace' })) },
+  aiAssistContext: { handle: sinon.stub().resolves(output(context, 'aiAssistTranscript', { trace: 'trace' })) },
   metrics: { generalRequest: sinon.stub() },
   utils: { TurnBuilder },
 });
@@ -65,7 +65,7 @@ describe('interact service unit tests', () => {
       const interactManager = new Interact(services as any, null as any);
 
       expect(await interactManager.handler(data as any)).to.eql({
-        state: 'transcript',
+        state: 'aiAssistTranscript',
         request: context.request,
         trace: 'trace',
       });
@@ -126,7 +126,7 @@ describe('interact service unit tests', () => {
       const interactController = new Interact(services as any, null as any);
 
       expect(await interactController.handler(data as any)).to.eql({
-        state: 'transcript',
+        state: 'aiAssistTranscript',
         request: context.request,
         trace: 'trace',
       });
@@ -155,7 +155,7 @@ describe('interact service unit tests', () => {
 
     const interactController = new Interact(services as any, null as any);
     expect(await interactController.handler(data as any)).to.eql({
-      state: 'transcript',
+      state: 'aiAssistTranscript',
       request: context.request,
       trace: 'trace',
     });
@@ -213,7 +213,7 @@ describe('interact service unit tests', () => {
     expect(turnBuilder.addHandlers.args).to.eql([
       [services.asr, services.nlu, services.slots, services.dialog, services.runtime],
       [services.analytics],
-      [services.speak, services.filter, services.transcript],
+      [services.speak, services.filter, services.aiAssistContext],
     ]);
     expect(services.utils.autoDelegate.args).to.eql([[turnBuilder, context]]);
     expect(await turnBuilder.resolve.args[0][0]).to.eql(finalState);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-363**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Adds a new endpoint that behaves similar to the old `controllers.public.createTranscript`, except that it is authorized via DM API key rather than by checking the `apiPrivacy` field on the `project` document.

The `apiPrivacy` field is somewhat tricky to set. The natural place where it should be set is either with a UX toggle or as a part of the channel publish. However,

1. UX toggle requires designs from Mike which is out-of-scope at the moment
2. A custom Teams publish job that sets `apiPrivacy` requires a lot of boilerplate to setup the job on `general-service`, which is far more effort and more error-prone than desired for this small change. 

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

Added a new endpoint `POST /transcripts/:projectID` 

 - `TranscriptManager` in `lib/services/transcript/index.ts` implements the business logic to upsert a transcript that used to be part of `controllers.public.createTranscript`
 - `controllers.public.upsertTranscript`, `controllers.transcript.upsertTranscript` will now call the `upsertTranscript` method of `TranscriptManager` 
 - `controllers.public.upsertTranscript`, `controllers.transcript.upsertTranscript` are guarded by different middleware. The former checks for `apiPrivacy` to have value `'public'` whereas the latter will check the `Authorization` header for a valid DM API key. 

Renamed a different, existing `Transcript` service (that was created for the AI Assist feature to add the transcript to the `context`) to avoid naming conflict with the `TranscriptManager` introduced by this PR. 

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

None

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

None

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/platform/pull/344
- https://github.com/voiceflow/general-runtime/pull/463
- https://github.com/voiceflow/creator-app/pull/6531

### Checklist

- [x] changes have been validated in an ephemeral environment
- [ ] ~~this is a breaking change and should publish a new major version~~
- [ ] appropriate tests have been written
- [ ] ~~any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified~~
