### PR TITLE
[Merged by Bors] - fix: allow prototype to start from buttons (BUG-81)

### DIFF
--- a/lib/services/runtime/handlers/interaction/interaction.ts
+++ b/lib/services/runtime/handlers/interaction/interaction.ts
@@ -24,9 +24,10 @@ const utilsObj = {
 export const InteractionHandler: HandlerFactory<VoiceflowNode.Interaction.Node, typeof utilsObj> = (utils) => ({
   canHandle: (node) => !!node.interactions,
   handle: (node, runtime, variables) => {
-    const isStartingFromButtonsStep = runtime.getAction() === Action.REQUEST && !runtime.getRequest();
+    const runtimeAction = runtime.getAction();
+    const isStartingFromButtonsStep = runtimeAction === Action.REQUEST && !runtime.getRequest();
 
-    if (runtime.getAction() === Action.RUNNING || isStartingFromButtonsStep) {
+    if (runtimeAction === Action.RUNNING || isStartingFromButtonsStep) {
       utils.addButtonsIfExists(node, runtime, variables);
       utils.addNoReplyTimeoutIfExists(node, runtime);
 

--- a/lib/services/runtime/handlers/interaction/interaction.ts
+++ b/lib/services/runtime/handlers/interaction/interaction.ts
@@ -24,7 +24,9 @@ const utilsObj = {
 export const InteractionHandler: HandlerFactory<VoiceflowNode.Interaction.Node, typeof utilsObj> = (utils) => ({
   canHandle: (node) => !!node.interactions,
   handle: (node, runtime, variables) => {
-    if (runtime.getAction() === Action.RUNNING) {
+    const isStartingFromButtonsStep = runtime.getAction() === Action.REQUEST && !runtime.getRequest();
+
+    if (runtime.getAction() === Action.RUNNING || isStartingFromButtonsStep) {
       utils.addButtonsIfExists(node, runtime, variables);
       utils.addNoReplyTimeoutIfExists(node, runtime);
 

--- a/tests/lib/services/runtime/handlers/interaction/interaction.unit.ts
+++ b/tests/lib/services/runtime/handlers/interaction/interaction.unit.ts
@@ -38,7 +38,7 @@ describe('Interaction handler', () => {
         const handler = InteractionHandler(utils as any);
 
         expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.id);
-        expect(runtime.getAction.callCount).to.eql(2);
+        expect(runtime.getAction.callCount).to.eql(1);
         expect(utils.addButtonsIfExists.args).to.eql([[node, runtime, variables]]);
         expect(runtime.storage.delete.args).to.eql([
           [StorageType.NO_MATCHES_COUNTER],
@@ -70,7 +70,7 @@ describe('Interaction handler', () => {
         const handler = InteractionHandler(utils as any);
 
         expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.id);
-        expect(runtime.getAction.callCount).to.eql(2);
+        expect(runtime.getAction.callCount).to.eql(1);
         expect(utils.addButtonsIfExists.args).to.eql([[node, runtime, variables]]);
         expect(runtime.trace.addTrace.callCount).to.eql(0);
         expect(runtime.storage.delete.args).to.eql([
@@ -102,7 +102,7 @@ describe('Interaction handler', () => {
           const handler = InteractionHandler(utils as any);
 
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql('else-id');
-          expect(runtime.getAction.callCount).to.eql(2);
+          expect(runtime.getAction.callCount).to.eql(1);
           expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.noMatchHandler.handle.args).to.eql([[node, runtime, variables]]);
@@ -129,7 +129,7 @@ describe('Interaction handler', () => {
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
-            expect(runtime.getAction.callCount).to.eql(2);
+            expect(runtime.getAction.callCount).to.eql(1);
             expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.noMatchHandler.handle.args).to.eql([[node, runtime, variables]]);
@@ -155,7 +155,7 @@ describe('Interaction handler', () => {
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql('else-id');
-            expect(runtime.getAction.callCount).to.eql(2);
+            expect(runtime.getAction.callCount).to.eql(1);
             expect(utils.commandHandler.canHandle.callCount).to.eql(0);
             expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.noMatchHandler.handle.args).to.eql([[node, runtime, variables]]);
@@ -182,7 +182,7 @@ describe('Interaction handler', () => {
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
-            expect(runtime.getAction.callCount).to.eql(2);
+            expect(runtime.getAction.callCount).to.eql(1);
             expect(utils.findEventMatcher.args).to.eql([[{ event: node.interactions[0].event, runtime }]]);
             expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
@@ -210,7 +210,7 @@ describe('Interaction handler', () => {
           const handler = InteractionHandler(utils as any);
 
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(output);
-          expect(runtime.getAction.callCount).to.eql(2);
+          expect(runtime.getAction.callCount).to.eql(1);
           expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.commandHandler.handle.args).to.eql([[runtime, variables]]);
         });
@@ -234,7 +234,7 @@ describe('Interaction handler', () => {
           const handler = InteractionHandler(utils as any);
 
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(output);
-          expect(runtime.getAction.callCount).to.eql(2);
+          expect(runtime.getAction.callCount).to.eql(1);
           expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.repeatHandler.handle.args).to.eql([[runtime]]);
@@ -260,7 +260,7 @@ describe('Interaction handler', () => {
           const handler = InteractionHandler(utils as any);
 
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(output);
-          expect(runtime.getAction.callCount).to.eql(2);
+          expect(runtime.getAction.callCount).to.eql(1);
           expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.noMatchHandler.handle.args).to.eql([[node, runtime, variables]]);
@@ -310,7 +310,7 @@ describe('Interaction handler', () => {
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(
               node.interactions[0].nextId
             );
-            expect(runtime.getAction.callCount).to.eql(2);
+            expect(runtime.getAction.callCount).to.eql(1);
             expect(utils.findEventMatcher.args).to.eql([[{ event: node.interactions[0].event, runtime }]]);
             expect(sideEffect.callCount).to.eql(1);
             expect(runtime.trace.addTrace.args).to.eql([[{ type: 'path', payload: { path: 'choice:1' } }]]);
@@ -340,7 +340,7 @@ describe('Interaction handler', () => {
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.id);
-            expect(runtime.getAction.callCount).to.eql(2);
+            expect(runtime.getAction.callCount).to.eql(1);
             expect(utils.findEventMatcher.args).to.eql([[{ event: node.interactions[0].event, runtime }]]);
             expect(sideEffect.callCount).to.eql(1);
             expect(runtime.trace.addTrace.args).to.eql([
@@ -377,7 +377,7 @@ describe('Interaction handler', () => {
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(
               node.interactions[3].nextId
             );
-            expect(runtime.getAction.callCount).to.eql(2);
+            expect(runtime.getAction.callCount).to.eql(1);
             expect(utils.findEventMatcher.args[3]).to.eql([{ event: node.interactions[3].event, runtime }]);
             expect(sideEffect.callCount).to.eql(1);
             expect(runtime.trace.addTrace.args).to.eql([[{ type: 'path', payload: { path: 'choice:4' } }]]);
@@ -402,7 +402,7 @@ describe('Interaction handler', () => {
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
-            expect(runtime.getAction.callCount).to.eql(2);
+            expect(runtime.getAction.callCount).to.eql(1);
             expect(utils.findEventMatcher.args).to.eql([[{ event: node.interactions[0].event, runtime }]]);
             expect(sideEffect.callCount).to.eql(1);
             expect(runtime.trace.addTrace.args).to.eql([[{ type: 'path', payload: { path: 'choice:1' } }]]);

--- a/tests/lib/services/runtime/handlers/interaction/interaction.unit.ts
+++ b/tests/lib/services/runtime/handlers/interaction/interaction.unit.ts
@@ -38,7 +38,7 @@ describe('Interaction handler', () => {
         const handler = InteractionHandler(utils as any);
 
         expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.id);
-        expect(runtime.getAction.callCount).to.eql(1);
+        expect(runtime.getAction.callCount).to.eql(2);
         expect(utils.addButtonsIfExists.args).to.eql([[node, runtime, variables]]);
         expect(runtime.storage.delete.args).to.eql([
           [StorageType.NO_MATCHES_COUNTER],
@@ -70,7 +70,7 @@ describe('Interaction handler', () => {
         const handler = InteractionHandler(utils as any);
 
         expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.id);
-        expect(runtime.getAction.callCount).to.eql(1);
+        expect(runtime.getAction.callCount).to.eql(2);
         expect(utils.addButtonsIfExists.args).to.eql([[node, runtime, variables]]);
         expect(runtime.trace.addTrace.callCount).to.eql(0);
         expect(runtime.storage.delete.args).to.eql([
@@ -102,7 +102,7 @@ describe('Interaction handler', () => {
           const handler = InteractionHandler(utils as any);
 
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql('else-id');
-          expect(runtime.getAction.callCount).to.eql(1);
+          expect(runtime.getAction.callCount).to.eql(2);
           expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.noMatchHandler.handle.args).to.eql([[node, runtime, variables]]);
@@ -129,7 +129,7 @@ describe('Interaction handler', () => {
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
-            expect(runtime.getAction.callCount).to.eql(1);
+            expect(runtime.getAction.callCount).to.eql(2);
             expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.noMatchHandler.handle.args).to.eql([[node, runtime, variables]]);
@@ -155,7 +155,7 @@ describe('Interaction handler', () => {
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql('else-id');
-            expect(runtime.getAction.callCount).to.eql(1);
+            expect(runtime.getAction.callCount).to.eql(2);
             expect(utils.commandHandler.canHandle.callCount).to.eql(0);
             expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.noMatchHandler.handle.args).to.eql([[node, runtime, variables]]);
@@ -182,7 +182,7 @@ describe('Interaction handler', () => {
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
-            expect(runtime.getAction.callCount).to.eql(1);
+            expect(runtime.getAction.callCount).to.eql(2);
             expect(utils.findEventMatcher.args).to.eql([[{ event: node.interactions[0].event, runtime }]]);
             expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
             expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
@@ -210,7 +210,7 @@ describe('Interaction handler', () => {
           const handler = InteractionHandler(utils as any);
 
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(output);
-          expect(runtime.getAction.callCount).to.eql(1);
+          expect(runtime.getAction.callCount).to.eql(2);
           expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.commandHandler.handle.args).to.eql([[runtime, variables]]);
         });
@@ -234,7 +234,7 @@ describe('Interaction handler', () => {
           const handler = InteractionHandler(utils as any);
 
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(output);
-          expect(runtime.getAction.callCount).to.eql(1);
+          expect(runtime.getAction.callCount).to.eql(2);
           expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.repeatHandler.handle.args).to.eql([[runtime]]);
@@ -260,7 +260,7 @@ describe('Interaction handler', () => {
           const handler = InteractionHandler(utils as any);
 
           expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(output);
-          expect(runtime.getAction.callCount).to.eql(1);
+          expect(runtime.getAction.callCount).to.eql(2);
           expect(utils.commandHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.repeatHandler.canHandle.args).to.eql([[runtime]]);
           expect(utils.noMatchHandler.handle.args).to.eql([[node, runtime, variables]]);
@@ -310,7 +310,7 @@ describe('Interaction handler', () => {
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(
               node.interactions[0].nextId
             );
-            expect(runtime.getAction.callCount).to.eql(1);
+            expect(runtime.getAction.callCount).to.eql(2);
             expect(utils.findEventMatcher.args).to.eql([[{ event: node.interactions[0].event, runtime }]]);
             expect(sideEffect.callCount).to.eql(1);
             expect(runtime.trace.addTrace.args).to.eql([[{ type: 'path', payload: { path: 'choice:1' } }]]);
@@ -340,7 +340,7 @@ describe('Interaction handler', () => {
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.id);
-            expect(runtime.getAction.callCount).to.eql(1);
+            expect(runtime.getAction.callCount).to.eql(2);
             expect(utils.findEventMatcher.args).to.eql([[{ event: node.interactions[0].event, runtime }]]);
             expect(sideEffect.callCount).to.eql(1);
             expect(runtime.trace.addTrace.args).to.eql([
@@ -377,7 +377,7 @@ describe('Interaction handler', () => {
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(
               node.interactions[3].nextId
             );
-            expect(runtime.getAction.callCount).to.eql(1);
+            expect(runtime.getAction.callCount).to.eql(2);
             expect(utils.findEventMatcher.args[3]).to.eql([{ event: node.interactions[3].event, runtime }]);
             expect(sideEffect.callCount).to.eql(1);
             expect(runtime.trace.addTrace.args).to.eql([[{ type: 'path', payload: { path: 'choice:4' } }]]);
@@ -402,7 +402,7 @@ describe('Interaction handler', () => {
             const handler = InteractionHandler(utils as any);
 
             expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
-            expect(runtime.getAction.callCount).to.eql(1);
+            expect(runtime.getAction.callCount).to.eql(2);
             expect(utils.findEventMatcher.args).to.eql([[{ event: node.interactions[0].event, runtime }]]);
             expect(sideEffect.callCount).to.eql(1);
             expect(runtime.trace.addTrace.args).to.eql([[{ type: 'path', payload: { path: 'choice:1' } }]]);


### PR DESCRIPTION
**Fixes or implements BUG-81**

### Brief description. What is this change?

Fixes bug where user would get a path not connected error if starting a prototype from a buttons step. 