### PR TITLE
[Merged by Bors] - fix: append form-data headers (BUG-151)

### DIFF
--- a/runtime/lib/Handlers/api/utils.ts
+++ b/runtime/lib/Handlers/api/utils.ts
@@ -254,7 +254,7 @@ export const createRequest = async (
   actionData: BaseNode.Api.NodeData['action_data'],
   config: APIHandlerConfig
 ): Promise<Request> => {
-  let headers = new Headers(
+  const headers = new Headers(
     actionData.headers
       // Filter out invalid headers - avoid an Error: " is not a legal HTTP header name"
       .filter((header) => header.key && header.val)
@@ -278,7 +278,7 @@ export const createRequest = async (
         actionData.body.forEach(({ key, val }) => formData.append(key, val));
         body = formData;
 
-        headers = new Headers(formData.getHeaders(headers));
+        Object.entries(formData.getHeaders(headers)).map(([key, val]) => headers.set(key, val));
         break;
       }
       default:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements [BUG-151](https://voiceflow.atlassian.net/browse/BUG-151)**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Previously, any `multipart/form-data` requests would completely override the headers. This changes so the `FormData` headers (just `content-type`) gets _added_ to the existing headers instead.

_Side bar: the whole API handler is terrible and needs to be completely re-written_

[BUG-151]: https://voiceflow.atlassian.net/browse/BUG-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ