### PR TITLE
[Merged by Bors] - fix: google handlers (BUG-186) [bugfix]

### DIFF
--- a/lib/services/runtime/handlers/capture/capture.google.ts
+++ b/lib/services/runtime/handlers/capture/capture.google.ts
@@ -49,13 +49,15 @@ export const CaptureGoogleHandler: HandlerFactory<VoiceflowNode.Capture.Node, ty
       return utils.noReplyHandler.handle(node, runtime, variables);
     }
 
-    const { input } = request.payload;
+    const { input, query } = request.payload;
 
-    if (input) {
-      const num = utils.wordsToNumbers(input);
+    // TODO: refactor on adapter code
+    // prototype tool sends input on query, dialogflow sends on input
+    if (input ?? query) {
+      const num = utils.wordsToNumbers(input ?? query);
 
       if (typeof num !== 'number' || Number.isNaN(num)) {
-        variables.set(node.variable, input);
+        variables.set(node.variable, input ?? query);
       } else {
         variables.set(node.variable, num);
       }

--- a/lib/services/runtime/handlers/captureV2/captureV2.google.ts
+++ b/lib/services/runtime/handlers/captureV2/captureV2.google.ts
@@ -8,7 +8,7 @@ import { VoiceflowConstants, VoiceflowNode } from '@voiceflow/voiceflow-types';
 
 import { Action, HandlerFactory } from '@/runtime';
 
-import { addRepromptIfExists } from '../../utils';
+import { addRepromptIfExists, mapEntities } from '../../utils';
 import { isGooglePlatform, mapSlots } from '../../utils.google';
 import CommandHandler from '../command';
 import { addNoReplyTimeoutIfExists } from '../noReply';
@@ -53,16 +53,14 @@ export const CaptureV2GoogleHandler: HandlerFactory<VoiceflowNode.CaptureV2.Node
     if (utils.noReplyHandler.canHandle(runtime)) {
       return utils.noReplyHandler.handle(node, runtime, variables);
     }
-    const { slots, input, intent, entities } = request.payload;
 
-    // when using prototype tool intent.slots is empty, so instead we rely on entities
-    if (intent.name === node.intent?.name && node.intent?.entities && (entities || slots)) {
+    const { input, intent, entities } = request.payload;
+    if (intent.name === node.intent?.name && node.intent?.entities) {
       variables.merge(
-        mapSlots({
-          mappings: node.intent.entities.map((slot) => ({ slot, variable: slot })),
-          slots,
-          entities,
-        })
+        mapEntities(
+          node.intent.entities.map((slot) => ({ slot, variable: slot })),
+          entities
+        )
       );
 
       return node.nextId ?? null;

--- a/lib/services/runtime/handlers/captureV2/captureV2.google.ts
+++ b/lib/services/runtime/handlers/captureV2/captureV2.google.ts
@@ -9,7 +9,7 @@ import { VoiceflowConstants, VoiceflowNode } from '@voiceflow/voiceflow-types';
 import { Action, HandlerFactory } from '@/runtime';
 
 import { addRepromptIfExists, mapEntities } from '../../utils';
-import { isGooglePlatform, mapSlots } from '../../utils.google';
+import { isGooglePlatform } from '../../utils.google';
 import CommandHandler from '../command';
 import { addNoReplyTimeoutIfExists } from '../noReply';
 import NoReplyHandler from '../noReply/noReply.google';

--- a/tests/lib/services/runtime/handlers/captureV2/captureV2.google.unit.ts
+++ b/tests/lib/services/runtime/handlers/captureV2/captureV2.google.unit.ts
@@ -220,10 +220,10 @@ describe('captureV2 handler unit tests', async () => {
             type: BaseRequest.RequestType.INTENT,
             payload: {
               intent: { name: 'intent-name' },
-              slots: {
-                [slotID]: 'slot-value',
-                [slotID3]: 'slot-value3',
-              },
+              entities: [
+                { name: slotID, value: 'slot-value' },
+                { name: slotID3, value: 'slot-value3' },
+              ],
             },
           };
           const runtime = {

--- a/tests/lib/services/runtime/handlers/interaction/interaction.google.unit.ts
+++ b/tests/lib/services/runtime/handlers/interaction/interaction.google.unit.ts
@@ -70,40 +70,11 @@ describe('interaction handler unit tests', async () => {
             id: 'block-id',
             interactions: [
               { event: { intent: '' } },
-              { event: { type: BaseNode.Utils.EventType.INTENT, intent: buttonName }, nextId: 'next-id' },
+              { event: { name: buttonName }, nextId: 'next-id' },
               { event: { intent: '' } },
             ],
           };
-          const request = { type: BaseRequest.RequestType.INTENT, payload: { intent: { name: buttonName } } };
-          const runtime = {
-            trace: { addTrace: sinon.stub() },
-            storage: { delete: sinon.stub() },
-            getRequest: sinon.stub().returns(request),
-            getAction: sinon.stub().returns(Action.REQUEST),
-          };
-          const variablesState = { foo: 'bar' };
-          const variables = { getState: sinon.stub().returns(variablesState) };
-
-          expect(interactionHandler.handle(block as any, runtime as any, variables as any, null as any)).to.eql(
-            block.interactions[1].nextId
-          );
-        });
-
-        it('INTENT_PATH', async () => {
-          const buttonName = 'button_name';
-          const utils = {};
-
-          const interactionHandler = InteractionGoogleHandler(utils as any);
-
-          const block = {
-            id: 'block-id',
-            interactions: [
-              { event: { intent: '' } },
-              { event: { type: BaseRequest.RequestType.INTENT, intent: buttonName }, nextId: 'next-id' },
-              { event: { intent: '' } },
-            ],
-          };
-          const request = { type: BaseRequest.RequestType.INTENT, payload: { intent: { name: buttonName } } };
+          const request = { type: BaseRequest.RequestType.INTENT, payload: { label: buttonName } };
           const runtime = {
             trace: { addTrace: sinon.stub() },
             storage: { delete: sinon.stub() },
@@ -429,7 +400,7 @@ describe('interaction handler unit tests', async () => {
 
         it('choice with mappings', () => {
           const intentName = 'random-intent';
-          const mappedSlots = { slot1: 'slot-1' };
+          const mappedEntities = { slot1: 'slot-1' };
 
           const utils = {
             commandHandler: {
@@ -438,7 +409,7 @@ describe('interaction handler unit tests', async () => {
             noMatchHandler: {
               canHandle: sinon.stub().returns(false),
             },
-            mapSlots: sinon.stub().returns(mappedSlots),
+            mapEntities: sinon.stub().returns(mappedEntities),
             noReplyHandler: {
               canHandle: sinon.stub().returns(false),
             },
@@ -458,7 +429,7 @@ describe('interaction handler unit tests', async () => {
           };
           const request = {
             type: BaseRequest.RequestType.INTENT,
-            payload: { intent: { name: intentName }, slots: { foo2: 'bar2' } },
+            payload: { intent: { name: intentName }, entities: [{ name: 'foo2', value: 'bar2' }] },
           };
           const runtime = {
             trace: { addTrace: sinon.stub() },
@@ -471,10 +442,8 @@ describe('interaction handler unit tests', async () => {
           expect(interactionHandler.handle(block as any, runtime as any, variables as any, null as any)).to.eql(
             block.interactions[0].nextId
           );
-          expect(utils.mapSlots.args).to.eql([
-            [{ mappings: block.interactions[0].event.mappings, slots: request.payload.slots }],
-          ]);
-          expect(variables.merge.args).to.eql([[mappedSlots]]);
+          expect(utils.mapEntities.args).to.eql([[block.interactions[0].event.mappings, request.payload.entities]]);
+          expect(variables.merge.args).to.eql([[mappedEntities]]);
         });
 
         // eslint-disable-next-line sonarjs/no-identical-functions


### PR DESCRIPTION
When merging google handlers into general-runtime we missed that the payload sent by the prototype tool doesnt match what dialogflow sends.

This PR makes the handlers correctly support the prototype-tool.

When we create the new adapters we will refactor/clean this so that the payload coming from dialogflow->adapter->runtime matches the one from prototype-tool->runtime