### PR TITLE
[Merged by Bors] - fix: mongodb directly write variables (PL-000)

### DIFF
--- a/lib/controllers/stateManagement/index.ts
+++ b/lib/controllers/stateManagement/index.ts
@@ -70,16 +70,7 @@ class StateManagementController extends AbstractController {
 
   @validate({ BODY_UPDATE_VARIABLES: VALIDATIONS.BODY.OBJECT, HEADERS_PROJECT_ID: VALIDATIONS.HEADERS.PROJECT_ID })
   async updateVariables(req: Request<{ userID: string }, Record<string, any>, { projectID: string }>) {
-    const state = await this.services.session.getFromDb<State>(req.headers.projectID, req.params.userID);
-
-    const newState = {
-      ...state,
-      variables: { ...state.variables, ...req.body },
-    };
-
-    await this.services.session.saveToDb(req.headers.projectID, req.params.userID, newState);
-
-    return newState;
+    return this.services.session.updateVariables(req.headers.projectID, req.params.userID, req.body);
   }
 }
 

--- a/lib/services/session/index.ts
+++ b/lib/services/session/index.ts
@@ -9,4 +9,6 @@ export interface Session {
   getFromDb<T extends Record<string, any> = Record<string, any>>(projectID: string, userID: string): Promise<T>;
 
   deleteFromDb(projectID: string, userID: string): Promise<void>;
+
+  updateVariables(projectID: string, userID: string, variables?: Record<string, unknown>): Promise<State>;
 }

--- a/lib/services/session/local.ts
+++ b/lib/services/session/local.ts
@@ -1,8 +1,9 @@
 import { State } from '@/runtime';
 
 import { AbstractManager } from '../utils';
+import type { Session } from '.';
 
-class SessionManager extends AbstractManager {
+class SessionManager extends AbstractManager implements Session {
   public table: Record<string, any> = {};
 
   private getSessionID(projectID: string, userID: string) {
@@ -19,6 +20,19 @@ class SessionManager extends AbstractManager {
 
   async deleteFromDb(projectID: string, userID: string) {
     delete this.table[this.getSessionID(projectID, userID)];
+  }
+
+  async updateVariables(projectID: string, userID: string, variables: Record<string, any>) {
+    const state = await this.getFromDb<State>(projectID, userID);
+
+    const newState = {
+      ...state,
+      variables: { ...state.variables, ...variables },
+    };
+
+    await this.saveToDb(projectID, userID, newState);
+
+    return newState;
   }
 }
 

--- a/tests/lib/controllers/stateManagement.unit.ts
+++ b/tests/lib/controllers/stateManagement.unit.ts
@@ -78,7 +78,7 @@ describe('stateManagement controller unit tests', () => {
   describe('updateVariables', () => {
     it('works', async () => {
       const output = { foo: 'bar', variables: { a: 1, b: 2 } };
-      const services = { session: { getFromDb: sinon.stub().resolves(output), saveToDb: sinon.stub().resolves() } };
+      const services = { session: { updateVariables: sinon.stub().resolves(output) } };
       const controller = new StateManagement(services as any, {} as any);
 
       const body = { b: 3, c: 4 };
@@ -88,10 +88,8 @@ describe('stateManagement controller unit tests', () => {
         body,
       };
 
-      const expectedState = { ...output, variables: { ...output.variables, ...body } };
-      expect(await controller.updateVariables(req as any)).to.eql(expectedState);
-      expect(services.session.getFromDb.args).to.eql([[req.headers.projectID, req.params.userID]]);
-      expect(services.session.saveToDb.args).to.eql([[req.headers.projectID, req.params.userID, expectedState]]);
+      expect(await controller.updateVariables(req as any)).to.eql(output);
+      expect(services.session.updateVariables.args).to.eql([[req.headers.projectID, req.params.userID, body]]);
     });
   });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-000**

### Brief description. What is this change?
for updating variables: https://developer.voiceflow.com/reference/updatestatevariables-1
We are first reading from the DB, then merging it with new values, then writing it back in.

Today this call can lead to some race conditions. 
This allows the update variables action to be very atomic.

I've tested the API calls locally and everything works fine. The `upsert` is pretty nice.