### PR TITLE
[Merged by Bors] - fix: increase timeout tolerance (PL-000)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -17,7 +17,7 @@ const CONFIG: Config = {
   NODE_ENV,
   PORT: getRequiredProcessEnv('PORT'),
   PORT_METRICS: getOptionalProcessEnv('PORT_METRICS'),
-  ERROR_RESPONSE_MS: Number(getOptionalProcessEnv('ERROR_RESPONSE_MS', (10 * 1000).toString())),
+  ERROR_RESPONSE_MS: Number(getOptionalProcessEnv('ERROR_RESPONSE_MS', (20 * 1000).toString())),
 
   CLOUD_ENV,
 


### PR DESCRIPTION
before we would only allow 10 seconds for the "interact" request to get back before resolving a 408 error.

I'm increasing this tolerance to 20 seconds.

https://github.com/voiceflow/general-runtime/blob/f8c826cc5b96cd1125e63521d2353761c3f099c1/backend/expressMiddleware.ts#L45

https://www.npmjs.com/package/connect-timeout