### PR TITLE
[Merged by Bors] - feat: disable channel handlers (BUG-245)

### DIFF
--- a/lib/services/runtime/handlers/capture/index.ts
+++ b/lib/services/runtime/handlers/capture/index.ts
@@ -1,5 +1,3 @@
 import CaptureGeneralHandler from './capture';
-// import CaptureAlexaHandler from './capture.alexa';
-// import CaptureGoogleHandler from './capture.google';
 
-export default () => [/* CaptureGoogleHandler(), CaptureAlexaHandler(), */ CaptureGeneralHandler()];
+export default () => [CaptureGeneralHandler()];

--- a/lib/services/runtime/handlers/capture/index.ts
+++ b/lib/services/runtime/handlers/capture/index.ts
@@ -1,5 +1,5 @@
 import CaptureGeneralHandler from './capture';
-import CaptureAlexaHandler from './capture.alexa';
-import CaptureGoogleHandler from './capture.google';
+// import CaptureAlexaHandler from './capture.alexa';
+// import CaptureGoogleHandler from './capture.google';
 
-export default () => [CaptureGoogleHandler(), CaptureAlexaHandler(), CaptureGeneralHandler()];
+export default () => [/* CaptureGoogleHandler(), CaptureAlexaHandler(), */ CaptureGeneralHandler()];

--- a/lib/services/runtime/handlers/captureV2/index.ts
+++ b/lib/services/runtime/handlers/captureV2/index.ts
@@ -1,5 +1,5 @@
 import CaptureV2GeneralHandler from './captureV2';
-import CaptureV2AlexaHandler from './captureV2.alexa';
-import CaptureV2GoogleHandler from './captureV2.google';
+// import CaptureV2AlexaHandler from './captureV2.alexa';
+// import CaptureV2GoogleHandler from './captureV2.google';
 
-export default () => [CaptureV2GoogleHandler(), CaptureV2AlexaHandler(), CaptureV2GeneralHandler()];
+export default () => [/* CaptureV2GoogleHandler(), CaptureV2AlexaHandler(), */ CaptureV2GeneralHandler()];

--- a/lib/services/runtime/handlers/captureV2/index.ts
+++ b/lib/services/runtime/handlers/captureV2/index.ts
@@ -1,5 +1,3 @@
 import CaptureV2GeneralHandler from './captureV2';
-// import CaptureV2AlexaHandler from './captureV2.alexa';
-// import CaptureV2GoogleHandler from './captureV2.google';
 
-export default () => [/* CaptureV2GoogleHandler(), CaptureV2AlexaHandler(), */ CaptureV2GeneralHandler()];
+export default () => [CaptureV2GeneralHandler()];

--- a/lib/services/runtime/handlers/cardV2/index.ts
+++ b/lib/services/runtime/handlers/cardV2/index.ts
@@ -1,5 +1,3 @@
 import CardV2GeneralHandler from './cardV2';
-// import CardV2AlexaHandler from './cardV2.alexa';
-// import CardV2GoogleHandler from './cardV2.google';
 
-export default () => [/* CardV2GoogleHandler(), CardV2AlexaHandler(), */ CardV2GeneralHandler()];
+export default () => [CardV2GeneralHandler()];

--- a/lib/services/runtime/handlers/cardV2/index.ts
+++ b/lib/services/runtime/handlers/cardV2/index.ts
@@ -1,5 +1,5 @@
 import CardV2GeneralHandler from './cardV2';
-import CardV2AlexaHandler from './cardV2.alexa';
-import CardV2GoogleHandler from './cardV2.google';
+// import CardV2AlexaHandler from './cardV2.alexa';
+// import CardV2GoogleHandler from './cardV2.google';
 
-export default () => [CardV2GoogleHandler(), CardV2AlexaHandler(), CardV2GeneralHandler()];
+export default () => [/* CardV2GoogleHandler(), CardV2AlexaHandler(), */ CardV2GeneralHandler()];

--- a/lib/services/runtime/handlers/caroussel/index.ts
+++ b/lib/services/runtime/handlers/caroussel/index.ts
@@ -1,5 +1,3 @@
 import CarousselGeneralHandler from './carousel';
-// import CarousselAlexaHandler from './carousel.alexa';
-// import CarousselGoogleHandler from './carousel.google';
 
-export default () => [/* CarousselGoogleHandler(), CarousselAlexaHandler(), */ CarousselGeneralHandler()];
+export default () => [CarousselGeneralHandler()];

--- a/lib/services/runtime/handlers/caroussel/index.ts
+++ b/lib/services/runtime/handlers/caroussel/index.ts
@@ -1,5 +1,5 @@
 import CarousselGeneralHandler from './carousel';
-import CarousselAlexaHandler from './carousel.alexa';
-import CarousselGoogleHandler from './carousel.google';
+// import CarousselAlexaHandler from './carousel.alexa';
+// import CarousselGoogleHandler from './carousel.google';
 
-export default () => [CarousselGoogleHandler(), CarousselAlexaHandler(), CarousselGeneralHandler()];
+export default () => [/* CarousselGoogleHandler(), CarousselAlexaHandler(), */ CarousselGeneralHandler()];

--- a/lib/services/runtime/handlers/goTo/index.ts
+++ b/lib/services/runtime/handlers/goTo/index.ts
@@ -1,4 +1,3 @@
 import GoToGeneralHandler from './goTo';
-// import GoToAlexaHandler from './goTo.alexa';
 
-export default () => [/* GoToAlexaHandler(), */ GoToGeneralHandler()];
+export default () => [GoToGeneralHandler()];

--- a/lib/services/runtime/handlers/goTo/index.ts
+++ b/lib/services/runtime/handlers/goTo/index.ts
@@ -1,4 +1,4 @@
 import GoToGeneralHandler from './goTo';
-import GoToAlexaHandler from './goTo.alexa';
+// import GoToAlexaHandler from './goTo.alexa';
 
-export default () => [GoToAlexaHandler(), GoToGeneralHandler()];
+export default () => [/* GoToAlexaHandler(), */ GoToGeneralHandler()];

--- a/lib/services/runtime/handlers/interaction/index.ts
+++ b/lib/services/runtime/handlers/interaction/index.ts
@@ -1,5 +1,5 @@
 import InteractionGeneralHandler from './interaction';
-import InteractionAlexaHandler from './interaction.alexa';
-import InteractionGoogleHandler from './interaction.google';
+// import InteractionAlexaHandler from './interaction.alexa';
+// import InteractionGoogleHandler from './interaction.google';
 
-export default () => [InteractionGoogleHandler(), InteractionAlexaHandler(), InteractionGeneralHandler()];
+export default () => [/* InteractionGoogleHandler(), InteractionAlexaHandler(), */ InteractionGeneralHandler()];

--- a/lib/services/runtime/handlers/interaction/index.ts
+++ b/lib/services/runtime/handlers/interaction/index.ts
@@ -1,5 +1,3 @@
 import InteractionGeneralHandler from './interaction';
-// import InteractionAlexaHandler from './interaction.alexa';
-// import InteractionGoogleHandler from './interaction.google';
 
-export default () => [/* InteractionGoogleHandler(), InteractionAlexaHandler(), */ InteractionGeneralHandler()];
+export default () => [InteractionGeneralHandler()];

--- a/lib/services/runtime/handlers/state/index.ts
+++ b/lib/services/runtime/handlers/state/index.ts
@@ -1,13 +1,5 @@
 import oneShotHandler from './oneShot';
 import preliminaryHandler from './preliminary';
-// import preliminaryAlexaHandler from './preliminary/preliminary.alexa';
 import streamStateHandler from './stream';
-// import streamStateAlexaHandler from './stream/stream.alexa';
 
-export default () => [
-  // streamStateAlexaHandler(),
-  streamStateHandler(),
-  oneShotHandler(),
-  // preliminaryAlexaHandler(),
-  preliminaryHandler(),
-];
+export default () => [streamStateHandler(), oneShotHandler(), preliminaryHandler()];

--- a/lib/services/runtime/handlers/state/index.ts
+++ b/lib/services/runtime/handlers/state/index.ts
@@ -1,13 +1,13 @@
 import oneShotHandler from './oneShot';
 import preliminaryHandler from './preliminary';
-import preliminaryAlexaHandler from './preliminary/preliminary.alexa';
+// import preliminaryAlexaHandler from './preliminary/preliminary.alexa';
 import streamStateHandler from './stream';
-import streamStateAlexaHandler from './stream/stream.alexa';
+// import streamStateAlexaHandler from './stream/stream.alexa';
 
 export default () => [
-  streamStateAlexaHandler(),
+  // streamStateAlexaHandler(),
   streamStateHandler(),
   oneShotHandler(),
-  preliminaryAlexaHandler(),
+  // preliminaryAlexaHandler(),
   preliminaryHandler(),
 ];

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "build": "ttsc --project ./tsconfig.build.json && cpy app.config.js yarn.lock build/",
     "commit": "cz",
     "connect:cli": "vfcli mesh connect general-runtime -c \"/bin/bash\"",
-    "dev": "ts-node-dev --files --respawn --exit-child --transpile-only -r tsconfig-paths/register -- start.ts",
+    "dev": "ts-node-dev --files --respawn --exit-child --transpile-only -r tsconfig-paths/register --inspect -- start.ts",
     "docs:gen": "typedoc ./lib ./config.ts",
     "e2e": "yarn kill:e2e && NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_ENV=e2e yarn start:base",
     "e2e:check-deps": "npx wait-on https://localhost:8011/health",


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements BUG-245**

### Brief description. What is this change?

The plan is to move alexa and google to running through the general runtime through adapters. We moved over the channel specific handlers to retain functionality, but that actually breaks these projects inside the prototype tool.

Disabling these channel specific handlers for now until we can focus more on the adapters and runtime merging. Ideally we shouldn't even need these.