### PR TITLE
[Merged by Bors] - fix: add last response (PL-000)

### DIFF
--- a/lib/services/runtime/handlers/speak.ts
+++ b/lib/services/runtime/handlers/speak.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import { HandlerFactory } from '@/runtime';
 
-import { FrameType, Output } from '../types';
+import { FrameType, Output, Variables } from '../types';
 
 const SpeakHandler: HandlerFactory<VoiceflowNode.Speak.Node> = () => ({
   canHandle: (node) => ('random_speak' in node ? !!node.random_speak : !!node.speak),
@@ -31,6 +31,7 @@ const SpeakHandler: HandlerFactory<VoiceflowNode.Speak.Node> = () => ({
         payload: { message: output, type: BaseNode.Speak.TraceSpeakType.MESSAGE },
       });
       runtime.debugLogging.recordStepLog(RuntimeLogs.Kinds.StepLogKind.SPEAK, node, { text: output });
+      variables.set(Variables.LAST_RESPONSE, output);
     }
 
     return node.nextId ?? null;

--- a/lib/services/runtime/handlers/text.ts
+++ b/lib/services/runtime/handlers/text.ts
@@ -5,7 +5,7 @@ import _sample from 'lodash/sample';
 import log from '@/logger';
 import { HandlerFactory } from '@/runtime';
 
-import { FrameType, Output } from '../types';
+import { FrameType, Output, Variables } from '../types';
 import { slateInjectVariables, slateToPlaintext } from '../utils';
 
 const handlerUtils = {
@@ -35,6 +35,7 @@ export const TextHandler: HandlerFactory<BaseNode.Text.Node, typeof handlerUtils
           plainContent: message,
           richContent,
         });
+        variables.set(Variables.LAST_RESPONSE, message);
       } catch (error) {
         log.error(`[app] [runtime] [${TextHandler.name}] failed to add Slate trace ${log.vars({ error })}`);
       }

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -118,6 +118,7 @@ export type FrameData = Partial<{
 
 export enum Variables {
   TIMESTAMP = 'timestamp',
+  LAST_RESPONSE = 'last_response',
   LAST_UTTERANCE = 'last_utterance',
   INTENT_CONFIDENCE = 'intent_confidence',
   USER_ID = 'user_id',

--- a/tests/lib/services/runtime/handlers/speak.unit.ts
+++ b/tests/lib/services/runtime/handlers/speak.unit.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import SpeakHandler from '@/lib/services/runtime/handlers/speak';
-import { FrameType } from '@/lib/services/runtime/types';
+import { FrameType, Variables } from '@/lib/services/runtime/types';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
@@ -46,7 +46,7 @@ describe('speak handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
 
-      const variables = { getState: sinon.stub().returns({}) };
+      const variables = { getState: sinon.stub().returns({}), set: sinon.stub() };
 
       expect(speakHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.nextId);
       expect(topFrame.storage.set.args[0][0]).to.eql(FrameType.OUTPUT);
@@ -79,6 +79,7 @@ describe('speak handler unit tests', async () => {
           },
         ],
       ]);
+      expect(variables.set.args).to.eql([[Variables.LAST_RESPONSE, spokenPhrase]]);
     });
 
     it('speak', () => {
@@ -100,7 +101,7 @@ describe('speak handler unit tests', async () => {
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
 
       const varState = { var: 1.234, var1: 'here' };
-      const variables = { getState: sinon.stub().returns(varState) };
+      const variables = { getState: sinon.stub().returns(varState), set: sinon.stub() };
 
       expect(speakHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(null);
       // output has vars replaced and numbers turned to 2digits floats
@@ -123,6 +124,7 @@ describe('speak handler unit tests', async () => {
           },
         ],
       ]);
+      expect(variables.set.args).to.eql([[Variables.LAST_RESPONSE, 'random 1.23 or here']]);
     });
 
     it('speak is not string', () => {

--- a/tests/lib/services/runtime/handlers/text.unit.ts
+++ b/tests/lib/services/runtime/handlers/text.unit.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { TextHandler } from '@/lib/services/runtime/handlers/text';
+import { Variables } from '@/lib/services/runtime/types';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
@@ -52,7 +53,7 @@ describe('text handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
 
-      const variables = { getState: sinon.stub().returns('vars') };
+      const variables = { getState: sinon.stub().returns('vars'), set: sinon.stub() };
 
       const textHandler = TextHandler(utils as any);
       expect(textHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.nextId);
@@ -81,6 +82,7 @@ describe('text handler unit tests', async () => {
       expect(utils.slateToPlaintext.args).to.eql([[newSlate.content]]);
       expect(utils.slateInjectVariables.args).to.eql([[[{ children: { text: 'sampledSlate' } }], 'sanitizedVars']]);
       expect(topStorageSet.args).to.eql([['output', newSlate.content]]);
+      expect(variables.set.args).to.eql([[Variables.LAST_RESPONSE, 'plainText']]);
     });
   });
 });


### PR DESCRIPTION
add in a new `last_response` built-in variable.

It just contains the raw string of whatever speak or text step was said last