### PR TITLE
feat: track requests that are made with deprecated workspace keys (PL-446)

### DIFF
--- a/lib/clients/metrics.ts
+++ b/lib/clients/metrics.ts
@@ -12,6 +12,9 @@ export class Metrics extends VFMetrics.Client.Metrics {
     sdk: {
       request: Counter;
     };
+    deprecatedAPIKeys: {
+      request: Counter;
+    };
   };
 
   constructor(config: Config) {
@@ -28,6 +31,11 @@ export class Metrics extends VFMetrics.Client.Metrics {
       sdk: {
         request: this.meter.createCounter('sdk_request', { description: 'SDK requests' }),
       },
+      deprecatedAPIKeys: {
+        request: this.meter.createCounter('deprecated_api_keys', {
+          description: 'Requests made with deprecated Workspace API Keys',
+        }),
+      },
     };
   }
 
@@ -37,6 +45,10 @@ export class Metrics extends VFMetrics.Client.Metrics {
 
   sdkRequest(): void {
     this.counters.sdk.request.add(1);
+  }
+
+  deprecatedAPIKey(apiKey: string): void {
+    this.counters.deprecatedAPIKeys.request.add(1, { apiKey });
   }
 }
 

--- a/lib/services/interact/index.ts
+++ b/lib/services/interact/index.ts
@@ -64,6 +64,9 @@ class Interact extends AbstractManager<{ utils: typeof utils }> {
 
     metrics.generalRequest();
     if (authorization?.startsWith('VF.')) metrics.sdkRequest();
+    // If we are using a non-DM key, assume this is a deprecated Workspace API Key.
+    if (authorization?.startsWith('VF.') && !authorization?.startsWith('VF.DM'))
+      metrics.deprecatedAPIKey(authorization);
 
     const context: PartialContext<Context> = {
       data: {

--- a/tests/lib/clients/metrics.unit.ts
+++ b/tests/lib/clients/metrics.unit.ts
@@ -20,4 +20,12 @@ describe('metrics client unit tests', () => {
 
     await fixture.assert();
   });
+
+  it('deprecatedAPIKey', async () => {
+    const fixture = await metricsAsserter.assertMetric({ expected: /^deprecated_api_keys 1 \d+$/m });
+
+    fixture.metrics.deprecatedAPIKey('somekey');
+
+    await fixture.assert();
+  });
 });


### PR DESCRIPTION
**Fixes or implements PL-446**

### Brief description. What is this change?

Add metrics for requests made with deprecated Workspace API Keys.

### Checklist

- [ ] changes have been validated in an ephemeral environment
- [ ] this is a breaking change and should publish a new major version
- [x] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
