### PR TITLE
[Merged by Bors] - fix: add last_response on addOutputTrace [bugfix] (BUG-291)

### DIFF
--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -14,6 +14,7 @@ import _ from 'lodash';
 import { hasElicit, setElicit } from '@/lib/services/runtime/handlers/utils/entity';
 import { inputToString } from '@/lib/services/runtime/handlers/utils/output';
 import log from '@/logger';
+import { Store } from '@/runtime';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { Context, ContextHandler, VersionTag } from '@/types';
 
@@ -190,7 +191,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
       debugLogging.refreshContext(context);
 
       if (!hasElicit(incomingRequest) && prompt) {
-        const variables = getEntitiesMap(dmStateStore!.intentRequest);
+        const variables = new Store(getEntitiesMap(dmStateStore!.intentRequest));
 
         const output = VoiceflowUtils.prompt.isIntentVoicePrompt(prompt)
           ? fillStringEntities(

--- a/lib/services/runtime/handlers/generative.ts
+++ b/lib/services/runtime/handlers/generative.ts
@@ -1,7 +1,6 @@
 import { BaseNode } from '@voiceflow/base-types';
 import { replaceVariables, sanitizeVariables } from '@voiceflow/common';
 import { VoiceNode } from '@voiceflow/voice-types';
-import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import axios from 'axios';
 
 import Config from '@/config';
@@ -47,14 +46,13 @@ const GenerativeHandler: HandlerFactory<VoiceNode.Generative.Node> = () => ({
     );
 
     runtime.stack.top().storage.set<Output>(FrameType.OUTPUT, output);
-    variables.set(VoiceflowConstants.BuiltInVariable.LAST_RESPONSE, output);
 
     outputTrace({
       addTrace: runtime.trace.addTrace.bind(runtime.trace),
       debugLogging: runtime.debugLogging,
       node,
       output,
-      variables: variables.getState(),
+      variables,
       ai: true,
     });
 

--- a/lib/services/runtime/handlers/noMatch/index.ts
+++ b/lib/services/runtime/handlers/noMatch/index.ts
@@ -114,7 +114,7 @@ export const NoMatchHandler = (utils: typeof utilsObj) => ({
       debugLogging: runtime.debugLogging,
       node,
       output: output.output,
-      variables: variables.getState(),
+      variables,
       ai: output.ai,
     });
 

--- a/lib/services/runtime/handlers/noMatch/noMatch.alexa.ts
+++ b/lib/services/runtime/handlers/noMatch/noMatch.alexa.ts
@@ -28,7 +28,7 @@ export const NoMatchAlexaHandler = () => ({
       debugLogging: runtime.debugLogging,
       node,
       output: output.output,
-      variables: variables.getState(),
+      variables,
     });
 
     if (node.noMatch?.nodeID) {

--- a/lib/services/runtime/handlers/noReply/index.ts
+++ b/lib/services/runtime/handlers/noReply/index.ts
@@ -121,7 +121,7 @@ export const NoReplyHandler = (utils: typeof utilsObj) => ({
       debugLogging: runtime.debugLogging,
       node,
       output,
-      variables: variables.getState(),
+      variables,
     });
 
     utils.addButtonsIfExists(node, runtime, variables);

--- a/lib/services/runtime/handlers/repeat.ts
+++ b/lib/services/runtime/handlers/repeat.ts
@@ -42,6 +42,7 @@ export const RepeatHandler = (utils: typeof utilsObj) => ({
       output,
       addTrace: runtime.trace.addTrace.bind(runtime.trace),
       debugLogging: runtime.debugLogging,
+      variables: runtime.variables,
     });
 
     return top.getNodeID() || null;

--- a/lib/services/runtime/init.ts
+++ b/lib/services/runtime/init.ts
@@ -37,6 +37,7 @@ const init = (client: Client) => {
       addTrace: runtime.trace.addTrace.bind(runtime.trace),
       debugLogging: runtime.debugLogging,
       output,
+      variables: runtime.variables,
     });
   });
 

--- a/lib/services/runtime/utils.ts
+++ b/lib/services/runtime/utils.ts
@@ -200,15 +200,15 @@ export const removeEmptyPrompts = (
 
 interface OutputParams<V> {
   output?: V;
-  variables?: Record<string, unknown>;
+  variables?: Store;
   node?: BaseModels.BaseNode;
   debugLogging: DebugLogging;
   addTrace: AddTraceFn;
   ai?: boolean;
 }
 
-export function outputTrace({ node, addTrace, debugLogging, output, variables = {}, ai }: OutputParams<Output>): void {
-  const sanitizedVars = sanitizeVariables(variables);
+export function outputTrace({ node, addTrace, debugLogging, output, variables, ai }: OutputParams<Output>): void {
+  const sanitizedVars = sanitizeVariables(variables?.getState() ?? {});
 
   if (Array.isArray(output)) {
     const content = slateInjectVariables(output, sanitizedVars);
@@ -223,6 +223,7 @@ export function outputTrace({ node, addTrace, debugLogging, output, variables = 
       plainContent,
       richContent,
     });
+    variables?.set(VoiceflowConstants.BuiltInVariable.LAST_RESPONSE, plainContent);
   } else {
     const message = replaceVariables(output || '', sanitizedVars);
 
@@ -231,6 +232,7 @@ export function outputTrace({ node, addTrace, debugLogging, output, variables = 
       payload: { message, type: BaseNode.Speak.TraceSpeakType.MESSAGE },
     });
     debugLogging.recordStepLog(RuntimeLogs.Kinds.StepLogKind.SPEAK, node, { text: message });
+    variables?.set(VoiceflowConstants.BuiltInVariable.LAST_RESPONSE, message);
   }
 }
 

--- a/tests/lib/services/runtime/handlers/noMatch/noMatch.alexa.unit.ts
+++ b/tests/lib/services/runtime/handlers/noMatch/noMatch.alexa.unit.ts
@@ -25,6 +25,7 @@ describe('noMatch handler unit tests', () => {
         },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -49,6 +50,7 @@ describe('noMatch handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({ counter: 5.2345 }),
       };
 
@@ -88,6 +90,7 @@ describe('noMatch handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({ counter: 5.2345 }),
       };
 
@@ -129,6 +132,7 @@ describe('noMatch handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({ counter: 5.2345 }),
       };
 
@@ -176,6 +180,7 @@ describe('noMatch handler unit tests', () => {
         },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({ counter: 5.2345 }),
       };
 
@@ -220,6 +225,7 @@ describe('noMatch handler unit tests', () => {
       };
 
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -252,6 +258,7 @@ describe('noMatch handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -280,6 +287,7 @@ describe('noMatch handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -306,6 +314,7 @@ describe('noMatch handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -332,6 +341,7 @@ describe('noMatch handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 

--- a/tests/lib/services/runtime/handlers/noMatch/noMatch.unit.ts
+++ b/tests/lib/services/runtime/handlers/noMatch/noMatch.unit.ts
@@ -37,6 +37,7 @@ describe('noMatch handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({ counter: 5.2345 }),
       };
 
@@ -99,6 +100,7 @@ describe('noMatch handler unit tests', async () => {
         },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -127,6 +129,7 @@ describe('noMatch handler unit tests', async () => {
         },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -162,6 +165,7 @@ describe('noMatch handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -224,6 +228,7 @@ describe('noMatch handler unit tests', async () => {
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
 
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -287,6 +292,7 @@ describe('noMatch handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -321,6 +327,7 @@ describe('noMatch handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -355,6 +362,7 @@ describe('noMatch handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -395,6 +403,7 @@ describe('noMatch handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -435,6 +444,7 @@ describe('noMatch handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -470,6 +480,7 @@ describe('noMatch handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({ counter: 5.2345 }),
       };
 
@@ -528,6 +539,7 @@ describe('noMatch handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -560,6 +572,7 @@ describe('noMatch handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -592,6 +605,7 @@ describe('noMatch handler unit tests', async () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 

--- a/tests/lib/services/runtime/handlers/noReply/noReply.google.unit.ts
+++ b/tests/lib/services/runtime/handlers/noReply/noReply.google.unit.ts
@@ -53,6 +53,7 @@ describe('noInput handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
       const noInputHandler = NoReplyGoogleHandler();
@@ -76,6 +77,7 @@ describe('noInput handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({ counter: 5.2345 }),
       };
 
@@ -130,6 +132,7 @@ describe('noInput handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({ counter: 5.2345 }),
       };
 
@@ -193,6 +196,7 @@ describe('noInput handler unit tests', () => {
         },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -245,6 +249,7 @@ describe('noInput handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -269,6 +274,7 @@ describe('noInput handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -296,6 +302,7 @@ describe('noInput handler unit tests', () => {
         debugLogging: { recordStepLog: sinon.stub() },
       };
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 

--- a/tests/lib/services/runtime/handlers/noReply/noReply.unit.ts
+++ b/tests/lib/services/runtime/handlers/noReply/noReply.unit.ts
@@ -1,4 +1,3 @@
-import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -33,6 +32,7 @@ describe('noReply handler unit tests', () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({ counter: 5.2345 }),
       };
 
@@ -91,6 +91,7 @@ describe('noReply handler unit tests', () => {
 
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -123,6 +124,7 @@ describe('noReply handler unit tests', () => {
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
 
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -157,6 +159,7 @@ describe('noReply handler unit tests', () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -191,6 +194,7 @@ describe('noReply handler unit tests', () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -225,6 +229,7 @@ describe('noReply handler unit tests', () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -265,6 +270,7 @@ describe('noReply handler unit tests', () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({}),
       };
 
@@ -298,6 +304,7 @@ describe('noReply handler unit tests', () => {
       };
       runtime.debugLogging = new DebugLogging(runtime.trace.addTrace);
       const variables = {
+        set: sinon.stub(),
         getState: sinon.stub().returns({ counter: 5.2345 }),
       };
 


### PR DESCRIPTION
I realized for chat projects, the `last_response` variable gets assigned the slate rich-text format. So when the user tries to use it in the speak step as a variable, it just shows up as `[Object object]`

Also, there are many places where the bot is actually saying something back but we are not recording it as part of `last_response`: `noMatch` `noReply` etc.

