### PR TITLE
fix: alexa capture step prototype (BUG-294)

### DIFF
--- a/lib/services/runtime/handlers/captureV2/captureV2.ts
+++ b/lib/services/runtime/handlers/captureV2/captureV2.ts
@@ -110,8 +110,6 @@ export const CaptureV2Handler: HandlerFactory<VoiceflowNode.CaptureV2.Node, type
             ])
           ),
         });
-
-        return handleCapturePath();
       }
 
       if (isNodeCapturingEntireResponse(node)) {
@@ -125,8 +123,9 @@ export const CaptureV2Handler: HandlerFactory<VoiceflowNode.CaptureV2.Node, type
             },
           },
         });
-        return handleCapturePath();
       }
+
+      return handleCapturePath();
     }
 
     const noMatchHandler = utils.entityFillingNoMatchHandler.handle(node, runtime, variables);


### PR DESCRIPTION
we've started special compile patterns for alexa nodes on general-service:
https://github.com/voiceflow/general-service/blob/0ef2b16987e80332f15a43872d0cde534058daff/lib/clients/platform/handlers/captureV2/compiler.alexa.ts#L28-L70

In particular when we are trying to get the entire user response we do this:
```
    if (isQueryCapture(capture)) {
      node.intent = {
        name: QUERY_INTENT_NAME,
        entities: [QUERY_SLOT_NAME],
      };
      node.variable = capture.variable || undefined;
    }
```

because Alexa needs a special slot type and intent to do it. This confuses the prototype tool in thinking that it is no longer a "Entire user reply" query.

![Screenshot 2023-03-04 at 7 24 21 PM](https://user-images.githubusercontent.com/5643574/222934998-91d48ee4-d8a4-4134-a9ea-6b8e3ee6e477.png)

What I've updated is that the runtime will also write the query to variable if it is set.
