### PR TITLE
fix: prediction failure (BUG-000)

### DIFF
--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -140,7 +140,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
               hasChannelIntents: project?.platformData?.hasChannelIntents,
               platform: version.prototype.platform as VoiceflowConstants.PlatformType,
               dmRequest: dmStateStore.intentRequest.payload,
-              workspaceID: parseInt(project.teamID, 10),
+              workspaceID: project.teamID,
             })
           : incomingRequest;
 

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -70,7 +70,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     hasChannelIntents: boolean;
     platform: VoiceflowConstants.PlatformType;
     dmRequest?: BaseRequest.IntentRequestPayload;
-    workspaceID: number;
+    workspaceID: string;
   }): Promise<BaseRequest.IntentRequest> {
     // 1. first try restricted regex (no open slots) - exact string match
     if (model && locale) {
@@ -134,7 +134,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
       nlp: project.prototype?.nlp,
       hasChannelIntents: project?.platformData?.hasChannelIntents,
       platform: version?.prototype?.platform as VoiceflowConstants.PlatformType,
-      workspaceID: Number(project.teamID),
+      workspaceID: project.teamID,
     });
 
     return { ...context, request };


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

The `general-runtime` originally received the `teamID` as `number`. The original code then applied the type-cast `Number()` to get around type issues resulting from the `teamID` being typed as `string` even though it was returning a `number` as a value. 

A recent refactor broke this assumption and `general-runtime` now receives a `string` containing a hashstring value. This gets converted by `Number()` into the value `null`, which when passed into `nlu-gateway`, fails validation and breaks prediction.

The issue arose because `teamID` is an inconsistent value in our system and changing the format from hashed/unhashed values can have ramifications for the entire codebase. 

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

Removed the type-cast from `general-runtime` so we pass in the hash string instead, which `nlu-gateway` is still able to handle.

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

N/A

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

N/A

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [x] changes have been validated in an ephemeral environment
- ~~[ ] this is a breaking change and should publish a new major version~~
- ~~[ ] appropriate tests have been written~~
- ~~[ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified~~
