### PR TITLE
[Merged by Bors] - fix(runtime): set as running state if no request (BUG-304)

### DIFF
--- a/lib/services/runtime/handlers/cardV2/cardV2.ts
+++ b/lib/services/runtime/handlers/cardV2/cardV2.ts
@@ -56,11 +56,10 @@ export const CardV2Handler: HandlerFactory<VoiceflowNode.CardV2.Node, typeof han
   canHandle: (node) => node.type === BaseNode.NodeType.CARD_V2,
 
   handle: (node, runtime, variables) => {
-    const isStartingFromCardV2Step = runtime.getAction() === Action.REQUEST && !runtime.getRequest();
     const defaultPath = node.nextId || null;
     const { isBlocking } = node;
 
-    if (runtime.getAction() === Action.RUNNING || isStartingFromCardV2Step) {
+    if (runtime.getAction() === Action.RUNNING) {
       const variablesMap = variables.getState();
       const description = getDescription(
         variablesMap,

--- a/lib/services/runtime/handlers/caroussel/carousel.ts
+++ b/lib/services/runtime/handlers/caroussel/carousel.ts
@@ -21,12 +21,10 @@ export const handlerUtils = {
 
 export const CarouselHandler: HandlerFactory<BaseNode.Carousel.Node, typeof handlerUtils> = (utils) => ({
   canHandle: (node) => node.type === BaseNode.NodeType.CAROUSEL,
-  // eslint-disable-next-line sonarjs/cognitive-complexity
   handle: (node, runtime, variables) => {
     const defaultPath = node.nextId || null;
-    const isStartingFromCarouselStep = runtime.getAction() === Action.REQUEST && !runtime.getRequest();
 
-    if (runtime.getAction() === Action.RUNNING || isStartingFromCarouselStep) {
+    if (runtime.getAction() === Action.RUNNING) {
       const variablesMap = variables.getState();
       const sanitizedVars = utils.sanitizeVariables(variables.getState());
       const cards: BaseNode.Carousel.TraceCarouselCard[] = [];

--- a/lib/services/runtime/handlers/interaction/interaction.ts
+++ b/lib/services/runtime/handlers/interaction/interaction.ts
@@ -25,9 +25,8 @@ export const InteractionHandler: HandlerFactory<VoiceflowNode.Interaction.Node, 
   canHandle: (node) => !!node.interactions,
   handle: (node, runtime, variables) => {
     const runtimeAction = runtime.getAction();
-    const isStartingFromButtonsStep = runtimeAction === Action.REQUEST && !runtime.getRequest();
 
-    if (runtimeAction === Action.RUNNING || isStartingFromButtonsStep) {
+    if (runtimeAction === Action.RUNNING) {
       utils.addButtonsIfExists(node, runtime, variables);
       utils.addNoReplyTimeoutIfExists(node, runtime);
 

--- a/runtime/lib/Runtime/index.ts
+++ b/runtime/lib/Runtime/index.ts
@@ -206,8 +206,12 @@ class Runtime<
         throw new Error('runtime updated twice');
       }
 
-      // request coming in
-      this.setAction(Action.REQUEST);
+      if (this.getRequest() !== null) {
+        // request coming in
+        this.setAction(Action.REQUEST);
+      } else {
+        this.setAction(Action.RUNNING);
+      }
 
       await cycleStack(this);
 

--- a/tests/runtime/lib/Runtime/index.unit.ts
+++ b/tests/runtime/lib/Runtime/index.unit.ts
@@ -199,7 +199,7 @@ describe('Runtime unit', () => {
         [EventType.updateWillExecute, {}],
         [EventType.updateDidExecute, {}],
       ]);
-      expect(setActionStub.args).to.eql([[Action.REQUEST]]);
+      expect(setActionStub.args).to.eql([[Action.RUNNING]]);
       expect(cycleStackStub.args).to.eql([[runtime]]);
     });
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements BUG-304**

### Brief description. What is this change?

When we start from a block in canvas we send a null request with a stack containing the node we want to start from.
The runtime would automatically start in a `REQUEST` state, which causes the capture step to think the request is the user's response to the capture step, causing a no match to trigger.
Instead, if we don't get a request from the user (`null`), then start the runtime in a `RUNNING` state instead. This tells the capture block that we're entering the block and to wait for the user reply instead.