### PR TITLE
[Merged by Bors] - fix: make `response.` prefix for extracting variables from API step responses optional [bugfix] (PL-000)

### DIFF
--- a/runtime/lib/Handlers/api/utils.ts
+++ b/runtime/lib/Handlers/api/utils.ts
@@ -43,33 +43,49 @@ export const stringToNumIfNumeric = (str: string): string | number => {
 
 type Variable = string | number;
 
-// eslint-disable-next-line sonarjs/cognitive-complexity
 export const getVariable = (path: string, data: any): Variable | undefined => {
   if (!path || typeof path !== 'string') {
     return undefined;
   }
 
-  const props = path.split('.');
-  let curData: any = { response: data };
+  // Normalized array access syntax (e.g. [0] -> .0)
+  const normalizedPath = path.replace(/\[(\d+|{random})]/g, '.$1');
 
-  props.forEach((prop) => {
-    const propsAndInds = prop.split('[');
-    propsAndInds.forEach((propOrInd) => {
-      if (propOrInd.indexOf(']') >= 0) {
-        const indexStr = propOrInd.slice(0, -1);
-        let index;
-        if (indexStr.toLowerCase() === '{random}') {
-          index = Math.floor(Math.random() * curData.length);
-        } else {
-          index = parseInt(indexStr, 10);
-        }
-        curData = curData ? curData[index] : undefined;
+  // Split the path into its parts
+  const parts = normalizedPath.split('.');
+  let extracted: any = data;
+
+  // Loop through each part of the path
+  // eslint-disable-next-line no-restricted-syntax
+  for (const part of parts) {
+    // If the part is an array index, convert it to a number
+    const index = Number(part);
+
+    if (Number.isNaN(index)) {
+      // If the part is {random}, replace it with a random array index
+      if (part === '{random}' && Array.isArray(extracted)) {
+        extracted = extracted[Math.floor(Math.random() * extracted.length)];
       } else {
-        curData = curData ? curData[propOrInd] : undefined;
+        // If the part is not an array index, just use it as-is
+        extracted = extracted[part];
       }
-    });
-  });
-  return stringToNumIfNumeric(curData);
+    } else {
+      // If the part is an array index, use it as-is
+      extracted = extracted[index];
+    }
+
+    // If the extracted value is undefined, return undefined
+    if (extracted === undefined) {
+      return undefined;
+    }
+
+    // If the extracted value is a string, try to convert it to a number
+    if (typeof extracted === 'string') {
+      extracted = stringToNumIfNumeric(extracted);
+    }
+  }
+
+  return extracted;
 };
 
 export const ReduceKeyValue = (values: { key: string; val: string }[]) =>

--- a/runtime/lib/Handlers/api/utils.ts
+++ b/runtime/lib/Handlers/api/utils.ts
@@ -43,6 +43,7 @@ export const stringToNumIfNumeric = (str: string): string | number => {
 
 type Variable = string | number;
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export const getVariable = (path: string, data: any): Variable | undefined => {
   if (!path || typeof path !== 'string') {
     return undefined;
@@ -53,6 +54,13 @@ export const getVariable = (path: string, data: any): Variable | undefined => {
 
   // Split the path into its parts
   const parts = normalizedPath.split('.');
+
+  // Originally, you were always required to prefix your path with "response."
+  // This makes it optional without breaking backwards compatibility
+  if (parts[0] === 'response') {
+    parts.shift();
+  }
+
   let extracted: any = data;
 
   // Loop through each part of the path

--- a/tests/runtime/lib/Handlers/api/utils.unit.ts
+++ b/tests/runtime/lib/Handlers/api/utils.unit.ts
@@ -92,6 +92,10 @@ describe('Handlers api utils unit tests', () => {
     it('converts string to number if numeric', () => {
       expect(getVariable('f', data)).to.eql(1);
     });
+
+    it('works with legacy response. prefix', () => {
+      expect(getVariable('response.a', data)).to.eql('a');
+    });
   });
 
   describe('ReduceKeyValue', () => {

--- a/tests/runtime/lib/Handlers/api/utils.unit.ts
+++ b/tests/runtime/lib/Handlers/api/utils.unit.ts
@@ -44,12 +44,53 @@ describe('Handlers api utils unit tests', () => {
   });
 
   describe('getVariable', () => {
-    it('returns undefined if path is empty string', () => {
-      expect(getVariable('', {})).to.eql(undefined);
+    const data = {
+      a: 'a',
+      b: {
+        c: 'c',
+      },
+      d: {
+        e: ['e0', 'e1', 'e2'],
+      },
+      f: 1,
+    };
+
+    it('returns undefined if variable is missing from data at top-level', () => {
+      expect(getVariable('z', data)).to.eql(undefined);
     });
 
-    it('returns undefined if path is a number', () => {
-      expect(getVariable(5 as any, {})).to.eql(undefined);
+    it('returns undefined if variable is missing from nested data', () => {
+      expect(getVariable('b.f', data)).to.eql(undefined);
+    });
+
+    it('returns undefined if variable is missing from array', () => {
+      expect(getVariable('d.e[10]', data)).to.eql(undefined);
+    });
+
+    it('resolves {random} to a random array index', () => {
+      const extracted = getVariable('d.e[{random}]', data);
+      expect(extracted).to.be.oneOf(['e0', 'e1', 'e2']);
+    });
+
+    it('resolves the alternate syntax for {random}', () => {
+      const extracted = getVariable('d.e.{random}', data);
+      expect(extracted).to.be.oneOf(['e0', 'e1', 'e2']);
+    });
+
+    it('resolves the alternate syntax for array index', () => {
+      expect(getVariable('d.e.0', data)).to.eql('e0');
+    });
+
+    it('accesses top-level data', () => {
+      expect(getVariable('a', data)).to.eql('a');
+    });
+
+    it('accesses nested data', () => {
+      expect(getVariable('b.c', data)).to.eql('c');
+    });
+
+    it('converts string to number if numeric', () => {
+      expect(getVariable('f', data)).to.eql(1);
     });
   });
 


### PR DESCRIPTION
**Fixes or implements PL-000**

### Brief description. What is this change?

rewrites the function for extracting variables from API step responses.
it makes the function much more readable/maintainable, and also makes it optional to prefix the path with `response.` without breaking reverse compatibility

### Checklist

- [ ] changes have been validated in an ephemeral environment
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
