### PR TITLE
[Merged by Bors] - fix(captureV2): check for variable on intent (BUG-313) (BUG-294)

### DIFF
--- a/lib/services/runtime/handlers/captureV2/captureV2.ts
+++ b/lib/services/runtime/handlers/captureV2/captureV2.ts
@@ -19,7 +19,7 @@ const isConfidenceScoreAbove = (threshold: number, confidence: number) =>
   typeof confidence !== 'number' || confidence > threshold;
 
 const isNodeCapturingEntity = (node: VoiceflowNode.CaptureV2.Node): node is CaptureWithIntent =>
-  typeof node.intent?.name === 'string' && typeof node.intent?.entities != null;
+  typeof node.intent?.name === 'string' && typeof node.intent?.entities != null && !node.variable;
 
 const isNodeCapturingEntireResponse = (node: VoiceflowNode.CaptureV2.Node): node is CaptureWithVariable =>
   typeof node.variable === 'string';
@@ -110,6 +110,8 @@ export const CaptureV2Handler: HandlerFactory<VoiceflowNode.CaptureV2.Node, type
             ])
           ),
         });
+
+        return handleCapturePath();
       }
 
       if (isNodeCapturingEntireResponse(node)) {
@@ -123,9 +125,9 @@ export const CaptureV2Handler: HandlerFactory<VoiceflowNode.CaptureV2.Node, type
             },
           },
         });
-      }
 
-      return handleCapturePath();
+        return handleCapturePath();
+      }
     }
 
     const noMatchHandler = utils.entityFillingNoMatchHandler.handle(node, runtime, variables);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements BUG-313, BUG-294**

### Brief description. What is this change?

We only want to `handleCapturePath` if we match the intent we're looking for or it's a full reply capture. The previous fix (https://github.com/voiceflow/general-runtime/commit/b76f63d2a5728611b7f50a534482117a23729130) caused the runtime to think a capture was successful even if it didn't match the intent specified. This change undoes that but also adds an additional `!node.variable` check to the `isNodeCapturingEntity`. This is specifically for Alexa as it's entire user reply has an intent, entity, and variable.

Replaces https://github.com/voiceflow/general-runtime/pull/497 to keep fixed BUG-294 as well.