### PR TITLE
[Merged by Bors] - fix: consolidate all text traces add delay (PL-000)

### DIFF
--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -20,7 +20,7 @@ import { Context, ContextHandler, VersionTag } from '@/types';
 
 import { getNoneIntentRequest } from '../nlu/utils';
 import { isIntentRequest, StorageType } from '../runtime/types';
-import { outputTrace } from '../runtime/utils';
+import { addOutputTrace, getOutputTrace } from '../runtime/utils';
 import { AbstractManager, injectServices } from '../utils';
 import { rectifyEntityValue } from './synonym';
 import {
@@ -33,7 +33,8 @@ import {
 } from './utils';
 
 export const utils = {
-  outputTrace,
+  addOutputTrace,
+  getOutputTrace,
   isIntentInScope,
 };
 
@@ -205,12 +206,14 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
             )
           : prompt.content;
 
-        utils.outputTrace({
-          addTrace,
-          debugLogging,
-          output,
-          variables,
-        });
+        utils.addOutputTrace(
+          { trace: { addTrace }, debugLogging },
+          utils.getOutputTrace({
+            output,
+            version,
+            variables,
+          })
+        );
       }
       if (prompt || hasElicit(incomingRequest)) {
         trace.push({

--- a/lib/services/runtime/handlers/aiSet.ts
+++ b/lib/services/runtime/handlers/aiSet.ts
@@ -42,7 +42,7 @@ const AISetHandler: HandlerFactory<BaseNode.AISet.Node> = () => ({
                 model,
               })
               .then(({ data: { result } }) => result)
-              .catch(() => null)
+              .catch((error) => log.error(error))
           );
         })
     );

--- a/lib/services/runtime/handlers/noMatch/index.ts
+++ b/lib/services/runtime/handlers/noMatch/index.ts
@@ -7,10 +7,11 @@ import { Runtime, Store } from '@/runtime';
 import { NoMatchCounterStorage, Output, StorageType } from '../../types';
 import {
   addButtonsIfExists,
+  addOutputTrace,
   getGlobalNoMatchPrompt,
+  getOutputTrace,
   isPromptContentEmpty,
   isPromptContentInitialyzed,
-  outputTrace,
   removeEmptyPrompts,
 } from '../../utils';
 import { addNoReplyTimeoutIfExists } from '../noReply';
@@ -20,7 +21,8 @@ import { generateOutput } from '../utils/output';
 export type NoMatchNode = BaseRequest.NodeButton & VoiceflowNode.Utils.NoMatchNode;
 
 const utilsObj = {
-  outputTrace,
+  getOutputTrace,
+  addOutputTrace,
   addButtonsIfExists,
   addNoReplyTimeoutIfExists,
 };
@@ -109,14 +111,16 @@ export const NoMatchHandler = (utils: typeof utilsObj) => ({
       payload: { path: 'reprompt' },
     });
 
-    utils.outputTrace({
-      addTrace: runtime.trace.addTrace.bind(runtime.trace),
-      debugLogging: runtime.debugLogging,
-      node,
-      output: output.output,
-      variables,
-      ai: output.ai,
-    });
+    utils.addOutputTrace(
+      runtime,
+      utils.getOutputTrace({
+        output: output.output,
+        version: runtime.version,
+        variables,
+        ai: output.ai,
+      }),
+      { node }
+    );
 
     runtime.storage.set(StorageType.NO_MATCHES_COUNTER, noMatchCounter + 1);
 

--- a/lib/services/runtime/handlers/noMatch/noMatch.alexa.ts
+++ b/lib/services/runtime/handlers/noMatch/noMatch.alexa.ts
@@ -7,7 +7,7 @@ import { VoiceflowNode } from '@voiceflow/voiceflow-types';
 import { Runtime, Store } from '@/runtime';
 
 import { NoMatchCounterStorage, StorageType } from '../../types';
-import { addRepromptIfExists, outputTrace } from '../../utils';
+import { addOutputTrace, addRepromptIfExists, getOutputTrace } from '../../utils';
 import { convertDeprecatedNoMatch, getOutput } from '.';
 
 export const NoMatchAlexaHandler = () => ({
@@ -23,13 +23,14 @@ export const NoMatchAlexaHandler = () => ({
       return node.noMatch?.nodeID ?? null;
     }
 
-    outputTrace({
-      addTrace: runtime.trace.addTrace.bind(runtime.trace),
-      debugLogging: runtime.debugLogging,
-      node,
-      output: output.output,
-      variables,
-    });
+    addOutputTrace(
+      runtime,
+      getOutputTrace({
+        output: output.output,
+        variables,
+      }),
+      { node }
+    );
 
     if (node.noMatch?.nodeID) {
       runtime.storage.delete(StorageType.NO_MATCHES_COUNTER);

--- a/lib/services/runtime/handlers/noReply/index.ts
+++ b/lib/services/runtime/handlers/noReply/index.ts
@@ -7,10 +7,11 @@ import { Runtime, Store } from '@/runtime';
 import { NoReplyCounterStorage, StorageType } from '../../types';
 import {
   addButtonsIfExists,
+  addOutputTrace,
   getDefaultNoReplyTimeoutSeconds,
   getGlobalNoReplyPrompt,
+  getOutputTrace,
   isPromptContentEmpty,
-  outputTrace,
   removeEmptyPrompts,
 } from '../../utils';
 
@@ -85,7 +86,8 @@ const getOutput = (runtime: Runtime, node: NoReplyNode, noReplyCounter: number) 
 };
 
 const utilsObj = {
-  outputTrace,
+  addOutputTrace,
+  getOutputTrace,
   addButtonsIfExists,
   addNoReplyTimeoutIfExists,
 };
@@ -116,13 +118,15 @@ export const NoReplyHandler = (utils: typeof utilsObj) => ({
       payload: { path: 'reprompt' },
     });
 
-    utils.outputTrace({
-      addTrace: runtime.trace.addTrace.bind(runtime.trace),
-      debugLogging: runtime.debugLogging,
-      node,
-      output,
-      variables,
-    });
+    utils.addOutputTrace(
+      runtime,
+      utils.getOutputTrace({
+        output,
+        version: runtime.version,
+        variables,
+      }),
+      { node }
+    );
 
     utils.addButtonsIfExists(node, runtime, variables);
     utils.addNoReplyTimeoutIfExists(node, runtime, delay);

--- a/lib/services/runtime/handlers/repeat.ts
+++ b/lib/services/runtime/handlers/repeat.ts
@@ -6,10 +6,11 @@ import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import { Runtime } from '@/runtime';
 
 import { FrameType, isIntentRequest, Output, StorageType, TurnType } from '../types';
-import { outputTrace } from '../utils';
+import { addOutputTrace, getOutputTrace } from '../utils';
 
 const utilsObj = {
-  outputTrace,
+  addOutputTrace,
+  getOutputTrace,
 };
 
 const repeatIntents = new Set<string>([
@@ -38,12 +39,16 @@ export const RepeatHandler = (utils: typeof utilsObj) => ({
         ? runtime.turn.get<Output>(TurnType.PREVIOUS_OUTPUT)
         : top.storage.get<Output>(FrameType.OUTPUT);
 
-    utils.outputTrace({
-      output,
-      addTrace: runtime.trace.addTrace.bind(runtime.trace),
-      debugLogging: runtime.debugLogging,
-      variables: runtime.variables,
-    });
+    if (output) {
+      utils.addOutputTrace(
+        runtime,
+        utils.getOutputTrace({
+          output,
+          version: runtime.version,
+          variables: runtime.variables,
+        })
+      );
+    }
 
     return top.getNodeID() || null;
   },

--- a/lib/services/runtime/init.ts
+++ b/lib/services/runtime/init.ts
@@ -4,7 +4,7 @@ import log from '@/logger';
 import Client, { EventType } from '@/runtime';
 
 import { FrameType, Output, StorageType, StreamAction, StreamPlayStorage, TurnType } from './types';
-import { outputTrace } from './utils';
+import { addOutputTrace, getOutputTrace } from './utils';
 
 // initialize event behaviors for client
 const init = (client: Client) => {
@@ -33,12 +33,14 @@ const init = (client: Client) => {
       return;
     }
 
-    outputTrace({
-      addTrace: runtime.trace.addTrace.bind(runtime.trace),
-      debugLogging: runtime.debugLogging,
-      output,
-      variables: runtime.variables,
-    });
+    addOutputTrace(
+      runtime,
+      getOutputTrace({
+        output,
+        version: runtime.version,
+        variables: runtime.variables,
+      })
+    );
   });
 
   client.setEvent(EventType.handlerWillHandle, ({ runtime, node }) => {

--- a/lib/services/runtime/utils.ts
+++ b/lib/services/runtime/utils.ts
@@ -233,12 +233,16 @@ export function textOutputTrace({
   const richContent = {
     id: cuid.slug(),
     content,
-    messageDelayMilliseconds: delay ?? getVersionMessageDelay(version) ?? DEFAULT_DELAY,
   };
 
   const trace: BaseTrace.Text = {
     type: BaseNode.Utils.TraceType.TEXT,
-    payload: { slate: richContent, message: plainContent, ...(ai && { ai }) },
+    payload: {
+      slate: richContent,
+      message: plainContent,
+      delay: delay ?? getVersionMessageDelay(version) ?? DEFAULT_DELAY,
+      ...(ai && { ai }),
+    },
   };
 
   variables?.set(VoiceflowConstants.BuiltInVariable.LAST_RESPONSE, plainContent);

--- a/lib/services/runtime/utils.ts
+++ b/lib/services/runtime/utils.ts
@@ -1,4 +1,13 @@
-import { BaseModels, BaseNode, BaseRequest, BaseText, BaseTrace, RuntimeLogs, Text } from '@voiceflow/base-types';
+import {
+  BaseModels,
+  BaseNode,
+  BaseRequest,
+  BaseText,
+  BaseTrace,
+  BaseVersion,
+  RuntimeLogs,
+  Text,
+} from '@voiceflow/base-types';
 import { replaceVariables, sanitizeVariables, transformStringVariableToNumber, Utils } from '@voiceflow/common';
 import { VoiceflowConstants, VoiceflowNode } from '@voiceflow/voiceflow-types';
 import cuid from 'cuid';
@@ -198,41 +207,86 @@ export const removeEmptyPrompts = (
       prompt != null && (typeof prompt === 'string' ? prompt !== EMPTY_AUDIO_STRING : !!slateToPlaintext(prompt))
   ) ?? [];
 
+const DEFAULT_DELAY = 1000;
+
+const getVersionMessageDelay = (version?: BaseModels.Version.Model<BaseModels.Version.PlatformData>): number | null => {
+  return version?.platformData?.settings?.messageDelay?.durationMilliseconds ?? null;
+};
+
 interface OutputParams<V> {
-  output?: V;
+  output: V;
   variables?: Store;
-  node?: BaseModels.BaseNode;
-  debugLogging: DebugLogging;
-  addTrace: AddTraceFn;
   ai?: boolean;
+  version?: BaseVersion.Version;
 }
 
-export function outputTrace({ node, addTrace, debugLogging, output, variables, ai }: OutputParams<Output>): void {
+export function textOutputTrace({
+  ai,
+  delay,
+  output,
+  version,
+  variables,
+}: OutputParams<BaseText.SlateTextValue> & { delay?: number }) {
   const sanitizedVars = sanitizeVariables(variables?.getState() ?? {});
+  const content = slateInjectVariables(output, sanitizedVars);
+  const plainContent = slateToPlaintext(content);
+  const richContent = {
+    id: cuid.slug(),
+    content,
+    messageDelayMilliseconds: delay ?? getVersionMessageDelay(version) ?? DEFAULT_DELAY,
+  };
 
+  const trace: BaseTrace.Text = {
+    type: BaseNode.Utils.TraceType.TEXT,
+    payload: { slate: richContent, message: plainContent, ...(ai && { ai }) },
+  };
+
+  variables?.set(VoiceflowConstants.BuiltInVariable.LAST_RESPONSE, plainContent);
+
+  return trace;
+}
+
+export function speakOutputTrace({ variables, output }: OutputParams<string>) {
+  const sanitizedVars = sanitizeVariables(variables?.getState() ?? {});
+  const message = replaceVariables(output || '', sanitizedVars);
+
+  const trace: BaseTrace.Speak = {
+    type: BaseNode.Utils.TraceType.SPEAK,
+    payload: { message, type: BaseNode.Speak.TraceSpeakType.MESSAGE },
+  };
+
+  variables?.set(VoiceflowConstants.BuiltInVariable.LAST_RESPONSE, message);
+
+  return trace;
+}
+
+/** from a slate object or SSML string generate a full output trace with variables baked in */
+export function getOutputTrace(params: OutputParams<Output>): BaseTrace.Speak | BaseTrace.Text {
+  const { output } = params;
   if (Array.isArray(output)) {
-    const content = slateInjectVariables(output, sanitizedVars);
-    const plainContent = slateToPlaintext(content);
-    const richContent = { id: cuid.slug(), content };
+    return textOutputTrace({ ...params, output });
+  }
+  return speakOutputTrace({ ...params, output });
+}
 
-    addTrace({
-      type: BaseNode.Utils.TraceType.TEXT,
-      payload: { slate: richContent, message: plainContent, ai },
-    });
-    debugLogging.recordStepLog(RuntimeLogs.Kinds.StepLogKind.TEXT, node, {
-      plainContent,
-      richContent,
-    });
-    variables?.set(VoiceflowConstants.BuiltInVariable.LAST_RESPONSE, plainContent);
-  } else {
-    const message = replaceVariables(output || '', sanitizedVars);
+export function addOutputTrace(
+  runtime: { trace: { addTrace: AddTraceFn }; debugLogging: DebugLogging },
+  trace: BaseTrace.Speak | BaseTrace.Text,
+  { node }: { node?: BaseModels.BaseNode } = {}
+) {
+  runtime.trace.addTrace(trace);
 
-    addTrace({
-      type: BaseNode.Utils.TraceType.SPEAK,
-      payload: { message, type: BaseNode.Speak.TraceSpeakType.MESSAGE },
+  if (trace.type === BaseNode.Utils.TraceType.SPEAK) {
+    runtime.debugLogging?.recordStepLog(RuntimeLogs.Kinds.StepLogKind.SPEAK, node, {
+      text: trace.payload.message,
     });
-    debugLogging.recordStepLog(RuntimeLogs.Kinds.StepLogKind.SPEAK, node, { text: message });
-    variables?.set(VoiceflowConstants.BuiltInVariable.LAST_RESPONSE, message);
+  }
+
+  if (trace.type === BaseNode.Utils.TraceType.TEXT) {
+    runtime.debugLogging?.recordStepLog(RuntimeLogs.Kinds.StepLogKind.TEXT, node, {
+      plainContent: trace.payload.message,
+      richContent: trace.payload.slate,
+    });
   }
 }
 

--- a/lib/services/runtime/utils.ts
+++ b/lib/services/runtime/utils.ts
@@ -230,9 +230,11 @@ export function textOutputTrace({
   const sanitizedVars = sanitizeVariables(variables?.getState() ?? {});
   const content = slateInjectVariables(output, sanitizedVars);
   const plainContent = slateToPlaintext(content);
+  const messageDelayMilliseconds = delay ?? getVersionMessageDelay(version) ?? DEFAULT_DELAY;
   const richContent = {
     id: cuid.slug(),
     content,
+    messageDelayMilliseconds,
   };
 
   const trace: BaseTrace.Text = {
@@ -240,7 +242,7 @@ export function textOutputTrace({
     payload: {
       slate: richContent,
       message: plainContent,
-      delay: delay ?? getVersionMessageDelay(version) ?? DEFAULT_DELAY,
+      delay: messageDelayMilliseconds,
       ...(ai && { ai }),
     },
   };

--- a/tests/lib/services/runtime/handlers/noMatch/noMatch.unit.ts
+++ b/tests/lib/services/runtime/handlers/noMatch/noMatch.unit.ts
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 
 import { NoMatchHandler } from '@/lib/services/runtime/handlers/noMatch';
 import { StorageType } from '@/lib/services/runtime/types';
-import { EMPTY_AUDIO_STRING, outputTrace } from '@/lib/services/runtime/utils';
+import { addOutputTrace, EMPTY_AUDIO_STRING, getOutputTrace } from '@/lib/services/runtime/utils';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
@@ -42,7 +42,8 @@ describe('noMatch handler unit tests', async () => {
       };
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -105,7 +106,8 @@ describe('noMatch handler unit tests', async () => {
       };
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -134,7 +136,8 @@ describe('noMatch handler unit tests', async () => {
       };
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -172,7 +175,8 @@ describe('noMatch handler unit tests', async () => {
       const addButtonsIfExists = sinon.stub();
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists,
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -235,7 +239,8 @@ describe('noMatch handler unit tests', async () => {
       const addButtonsIfExists = sinon.stub();
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists,
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -297,7 +302,8 @@ describe('noMatch handler unit tests', async () => {
       };
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -332,7 +338,8 @@ describe('noMatch handler unit tests', async () => {
       };
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -367,7 +374,8 @@ describe('noMatch handler unit tests', async () => {
       };
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -408,7 +416,8 @@ describe('noMatch handler unit tests', async () => {
       };
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -449,7 +458,8 @@ describe('noMatch handler unit tests', async () => {
       };
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -485,7 +495,8 @@ describe('noMatch handler unit tests', async () => {
       };
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -544,7 +555,8 @@ describe('noMatch handler unit tests', async () => {
       };
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -577,7 +589,8 @@ describe('noMatch handler unit tests', async () => {
       };
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -610,7 +623,8 @@ describe('noMatch handler unit tests', async () => {
       };
 
       const noMatchHandler = NoMatchHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });

--- a/tests/lib/services/runtime/handlers/noReply/noReply.unit.ts
+++ b/tests/lib/services/runtime/handlers/noReply/noReply.unit.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 
 import { NoReplyHandler } from '@/lib/services/runtime/handlers/noReply';
 import { StorageType } from '@/lib/services/runtime/types';
-import { EMPTY_AUDIO_STRING, outputTrace } from '@/lib/services/runtime/utils';
+import { addOutputTrace, EMPTY_AUDIO_STRING, getOutputTrace } from '@/lib/services/runtime/utils';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
@@ -37,7 +37,8 @@ describe('noReply handler unit tests', () => {
       };
 
       const noMatchHandler = NoReplyHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -96,7 +97,8 @@ describe('noReply handler unit tests', () => {
       };
 
       const noMatchHandler = NoReplyHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -129,7 +131,8 @@ describe('noReply handler unit tests', () => {
       };
 
       const noMatchHandler = NoReplyHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -164,7 +167,8 @@ describe('noReply handler unit tests', () => {
       };
 
       const noMatchHandler = NoReplyHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -199,7 +203,8 @@ describe('noReply handler unit tests', () => {
       };
 
       const noMatchHandler = NoReplyHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -234,7 +239,8 @@ describe('noReply handler unit tests', () => {
       };
 
       const noMatchHandler = NoReplyHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -275,7 +281,8 @@ describe('noReply handler unit tests', () => {
       };
 
       const noMatchHandler = NoReplyHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });
@@ -309,7 +316,8 @@ describe('noReply handler unit tests', () => {
       };
 
       const noMatchHandler = NoReplyHandler({
-        outputTrace,
+        addOutputTrace,
+        getOutputTrace,
         addButtonsIfExists: sinon.stub(),
         addNoReplyTimeoutIfExists: sinon.stub(),
       });

--- a/tests/lib/services/runtime/handlers/repeat.unit.ts
+++ b/tests/lib/services/runtime/handlers/repeat.unit.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 
 import { RepeatHandler } from '@/lib/services/runtime/handlers/repeat';
 import { FrameType, StorageType, TurnType } from '@/lib/services/runtime/types';
+import { addOutputTrace } from '@/lib/services/runtime/utils';
 
 describe('repeat handler', () => {
   const intentRequest = {
@@ -74,8 +75,8 @@ describe('repeat handler', () => {
       };
 
       const TRACE = '_trace1';
-      const outputTrace = () => runtime.trace.addTrace(TRACE);
-      const repeatHandler = RepeatHandler({ outputTrace } as any);
+      const getOutputTrace = () => TRACE;
+      const repeatHandler = RepeatHandler({ getOutputTrace, addOutputTrace } as any);
 
       repeatHandler.handle(runtime as any);
 
@@ -108,8 +109,8 @@ describe('repeat handler', () => {
       };
 
       const TRACE = '_trace2';
-      const outputTrace = () => runtime.trace.addTrace(TRACE);
-      const repeatHandler = RepeatHandler({ outputTrace } as any);
+      const getOutputTrace = () => TRACE;
+      const repeatHandler = RepeatHandler({ getOutputTrace, addOutputTrace } as any);
 
       repeatHandler.handle(runtime as any);
 


### PR DESCRIPTION
we had this weird pattern of injecting `addTrace` into the `outputTrace` function.

Instead the `outputTrace` fn is now an immutable function called `getOutputTrace` that just returns the trace.
I've added a new function called `addOutputTrace` that emulates the API of the `runtime` so we can add debug traces AFTER the actual text/speak trace.

Added a new `version` param so that we can extract the `messageDelay` settings. The important thing is that this is standardized so ALL places that have an output will do all the peripheral stuff: adding debug traces, saving a message to `{last_response}` etc.

we now use the `delay` field: https://github.com/voiceflow/libs/pull/427