### PR TITLE
feat: reset session stack production [bugfix] (PL-000)

### DIFF
--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -108,6 +108,7 @@ export type TurnData = Partial<{
 }>;
 
 export enum FrameType {
+  IS_BASE = 'isBase',
   OUTPUT = 'output',
   CALLED_COMMAND = 'calledCommand',
 }

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -1,6 +1,7 @@
 import { BaseModels, BaseRequest, BaseTrace } from '@voiceflow/base-types';
 import _ from 'lodash';
 
+import { FrameType } from '@/lib/services/runtime/types';
 import { PartialContext, State } from '@/runtime';
 import { Context, InitContextHandler } from '@/types';
 
@@ -81,6 +82,14 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
     // sanitize incoming intents
     if (context.request && BaseRequest.isIntentRequest(context.request) && !context.request.payload.entities) {
       context.request.payload.entities = [];
+    }
+
+    // TODO: this is a hacky way to reset a session's stack after a version upgrade
+    // reset the stack for user if base frameID is not the same as the current version, otherwise they will never update
+    // this is for when the version is labelled as 'production' but can refer to an arbitrary versionID
+    const baseFrame = context.state?.stack?.[0];
+    if (baseFrame?.storage?.[FrameType.IS_BASE] && baseFrame.programID !== context.versionID) {
+      context.state!.stack = [];
     }
 
     // cache per interaction (save version call during request/response cycle)

--- a/runtime/lib/Runtime/index.ts
+++ b/runtime/lib/Runtime/index.ts
@@ -1,5 +1,6 @@
 import * as BaseTypes from '@voiceflow/base-types';
 
+import { FrameType } from '@/lib/services/runtime/types';
 import Handler from '@/runtime/lib/Handler';
 import Lifecycle, { AbstractLifecycle, Event, EventType } from '@/runtime/lib/Lifecycle';
 import cycleStack from '@/runtime/lib/Runtime/cycleStack';
@@ -193,6 +194,7 @@ class Runtime<
         programID: this.versionID,
         commands: [...(program?.commands ?? [])],
         nodeID: null,
+        storage: { [FrameType.IS_BASE]: true },
       })
     );
   }


### PR DESCRIPTION
one major issue we have right now is that existing sessions will never receive new upgrades.

Imagine a project like this, where there is no exit condition:
<img width="793" alt="Screenshot 2023-04-28 at 5 43 37 PM" src="https://user-images.githubusercontent.com/5643574/235273656-e8f6ef0b-6e19-4b81-b76b-8e398f4d30f7.png">

This means that the user's session's stack will ALWAYS be on that version, because it always references the `programID` from that particular version.

What I've done is take advantage of the fact that we have a base trace frame (bottom of the stack) that is the versionID. What we do now is check if the base frame is in sync with whatever version "production" is, if not we reset the session.

This might be a little jarring because it could mean that the user's session resets in the middle of a conversation - but this is better than people getting really frustrated when they test the DMAPI because they never see their new version.