### PR TITLE
[Merged by Bors] - fix: prediction failing if not training luis (PL-522) [bugfix]

### DIFF
--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -66,7 +66,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     projectID: string;
     versionID: string;
     tag: VersionTag | string;
-    nlp: BaseModels.Project.PrototypeNLP | undefined;
+    nlp?: BaseModels.Project.PrototypeNLP;
     hasChannelIntents: boolean;
     platform: VoiceflowConstants.PlatformType;
     dmRequest?: BaseRequest.IntentRequestPayload;
@@ -81,7 +81,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     }
 
     // 2. next try to resolve with luis NLP
-    if (nlp && nlp.appID && nlp.resourceID) {
+    if (nlp) {
       const { data } = await this.services.axios
         .post<NLUGatewayPredictResponse>(`${this.getNluGatewayEndpoint()}/v1/predict/${versionID}`, {
           utterance: query,

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -66,7 +66,7 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     projectID: string;
     versionID: string;
     tag: VersionTag | string;
-    nlp?: BaseModels.Project.PrototypeNLP;
+    nlp: BaseModels.Project.PrototypeNLP | undefined;
     hasChannelIntents: boolean;
     platform: VoiceflowConstants.PlatformType;
     dmRequest?: BaseRequest.IntentRequestPayload;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-522**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

We are running out of LUIS resources and it is not possible to create more because of LUIS deprecation. To mitigate this issue, we will disable the creation of LUIS applications for free plan users (who are using VFNLU as their main NLU at the moment) to reduce the volume of LUIS apps being created.

To accommodate the above fixes, we need to ensure that `general-runtime` is working even if no LUIS application is trained. However, our existing codebase is very LUIS centric, so `general-runtime` checks if `nlp.appID` and `nlp.resourceID` exists, but this is LUIS-specific data which is no longer created.

This PR simplifies the check on prediction to prevent it from breaking.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

N/A

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

N/A

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/platform/pull/610
- https://github.com/voiceflow/general-runtime/pull/513
- https://github.com/voiceflow/general-service/pull/507

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test