### PR TITLE
[Merged by Bors] - fix: minor prompt optimizations (LLM-001)

### DIFF
--- a/lib/services/runtime/handlers/utils/generativeNoMatch.ts
+++ b/lib/services/runtime/handlers/utils/generativeNoMatch.ts
@@ -8,6 +8,11 @@ import { Runtime } from '@/runtime';
 import { Output } from '../../types';
 import { generateOutput } from './output';
 
+// get current UTC time, default to 1 newline after
+export const getCurrentTime = ({ newlines = 1 }: { newlines?: number } = {}) => {
+  return `Current time: ${new Date().toUTCString()}${newlines ? '\n'.repeat(newlines) : ''}`;
+};
+
 export const generateNoMatch = async (runtime: Runtime): Promise<Output | null> => {
   if (!Config.ML_GATEWAY_ENDPOINT) {
     log.error('ML_GATEWAY_ENDPOINT is not set, skipping generative NoMatch');
@@ -19,13 +24,15 @@ export const generateNoMatch = async (runtime: Runtime): Promise<Output | null> 
 
   const aiAssistTranscript = runtime.variables.get<AIAssistLog>(AIAssist.StorageKey) || [];
 
+  if (!aiAssistTranscript.length) return null;
+
+  const system = getCurrentTime();
+
   const parsedAiAssistTranscript = aiAssistTranscript.reduce((acc, { role, content }) => {
     if (role === 'user') acc += `P2: ${content}\n`;
     if (role === 'assistant') acc += `AI: ${content}\n`;
     return acc;
-  }, '');
-
-  if (!parsedAiAssistTranscript) return null;
+  }, system);
 
   const response = await axios
     .post(autoCompleteEndpoint, {

--- a/lib/services/runtime/handlers/utils/knowledgeBaseNoMatch/answer.ts
+++ b/lib/services/runtime/handlers/utils/knowledgeBaseNoMatch/answer.ts
@@ -1,6 +1,7 @@
 import { BaseUtils } from '@voiceflow/base-types';
 
 import { AIResponse, fetchChat, fetchPrompt } from '../ai';
+import { getCurrentTime } from '../generativeNoMatch';
 
 interface KnowledegeBaseChunk {
   score: number;
@@ -11,10 +12,6 @@ interface KnowledegeBaseChunk {
 interface KnowledgeBaseResponse {
   chunks: KnowledegeBaseChunk[];
 }
-
-const createKnowledgeString = ({ chunks }: KnowledgeBaseResponse) => {
-  return chunks.map((chunk, index) => `${index + 1}: "${chunk.originalText}"\n\n`).join('');
-};
 
 export const answerSynthesis = async ({
   question,
@@ -29,29 +26,37 @@ export const answerSynthesis = async ({
 }): Promise<AIResponse | null> => {
   let response: AIResponse;
 
-  const options = { model, system, temperature, maxTokens };
+  const systemWithTime = `${system}\n\n${getCurrentTime()}`.trim();
+
+  const options = { model, system: systemWithTime, temperature, maxTokens };
+
+  const context = data.chunks.map(({ originalText }) => originalText).join('\n');
 
   if (!BaseUtils.ai.ChatModels.includes(options.model)) {
     // for GPT-3 completion model
-    const prompt = `reference info:\n\n${createKnowledgeString(data)}\n\nQ: ${question}\nA: `;
+    const prompt = `context:\n${context}\n\nIf you don't know the answer say exactly "UNKNOWN".\n\nQ: ${question}\nA: `;
 
     response = await fetchPrompt({ ...options, prompt, mode: BaseUtils.ai.PROMPT_MODE.PROMPT }, variables);
   } else {
     // for GPT-3.5 and 4.0 chat models
-
     const messages = [
       {
         role: 'user' as const,
-        content: `reference info:\n\n${createKnowledgeString(
-          data
-        )}\n\nUse the references to help answer but don't explicitly make reference to the info. If you don't know the answer say exactly "NOT_FOUND".\n\n${question}`,
+        content: `context:\n${context}`,
+      },
+      {
+        role: 'user' as const,
+        content: `If you don't know the answer say exactly "UNKNOWN".\n\n${question}`,
       },
     ];
 
     response = await fetchChat({ ...options, messages }, variables);
   }
 
-  if (response.output?.toUpperCase().includes('NOT_FOUND')) return { ...response, output: null };
+  const output = response.output?.trim().toUpperCase();
+
+  if (output?.includes('UNKNOWN') || output?.startsWith("I'M SORRY,") || output?.includes('AS AN AI'))
+    return { ...response, output: null };
 
   return response;
 };

--- a/lib/services/runtime/handlers/utils/knowledgeBaseNoMatch/answer.ts
+++ b/lib/services/runtime/handlers/utils/knowledgeBaseNoMatch/answer.ts
@@ -34,7 +34,7 @@ export const answerSynthesis = async ({
 
   if (!BaseUtils.ai.ChatModels.includes(options.model)) {
     // for GPT-3 completion model
-    const prompt = `context:\n${context}\n\nIf you don't know the answer say exactly "UNKNOWN".\n\nQ: ${question}\nA: `;
+    const prompt = `context:\n${context}\n\nIf you don't know the answer say exactly "NOT_FOUND".\n\nQ: ${question}\nA: `;
 
     response = await fetchPrompt({ ...options, prompt, mode: BaseUtils.ai.PROMPT_MODE.PROMPT }, variables);
   } else {
@@ -46,7 +46,7 @@ export const answerSynthesis = async ({
       },
       {
         role: 'user' as const,
-        content: `If you don't know the answer say exactly "UNKNOWN".\n\n${question}`,
+        content: `If you don't know the answer say exactly "NOT_FOUND".\n\n${question}`,
       },
     ];
 
@@ -55,7 +55,7 @@ export const answerSynthesis = async ({
 
   const output = response.output?.trim().toUpperCase();
 
-  if (output?.includes('UNKNOWN') || output?.startsWith("I'M SORRY,") || output?.includes('AS AN AI'))
+  if (output?.includes('NOT_FOUND') || output?.startsWith("I'M SORRY,") || output?.includes('AS AN AI'))
     return { ...response, output: null };
 
   return response;


### PR DESCRIPTION
Mono-chunking:
we now combine all the fetched chunks into one single blob of text.
`context: ${chunk1}\n${chunk2}`....

This has the added benefit of: 
less tokens (just barely) 
less reference, ("based on document 1, ....", "based on the provided references, ....")

Time Stamp injection:
https://www.notion.so/voiceflow/v3-KB-Optimization-Prompts-24a947d158fc43af8adeead21a6211c0?pvs=4#ffed22a3847c43b59e9e4f532ea05645
We now provide it with the time

AI Restrictions:
https://www.notion.so/voiceflow/v3-KB-Optimization-Prompts-24a947d158fc43af8adeead21a6211c0?pvs=4#eb1166b77cab443fb494c49b837598c5
GPT-3 is more liberal and can answer more things.