### PR TITLE
[Merged by Bors] - fix: llm rate limit fallback (LLM-002)

### DIFF
--- a/lib/clients/ai/gpt/gpt3_5.ts
+++ b/lib/clients/ai/gpt/gpt3_5.ts
@@ -38,7 +38,7 @@ export class GPT3_5 extends GPTAIModel {
       log.warn(`GPT3.5 completion ${log.vars({ error: error?.response ?? error, messages, params })})}`);
 
       // if we fail on the azure instance due to rate limiting, retry with OpenAI API
-      if (this.azureClient && error?.response?.status === 429 && this.openAIClient) {
+      if (client === this.azureClient && error?.response?.status === 429 && this.openAIClient) {
         return this.generateChatCompletion(messages, params, this.openAIClient);
       }
 

--- a/lib/clients/ai/gpt/gpt3_5.ts
+++ b/lib/clients/ai/gpt/gpt3_5.ts
@@ -17,9 +17,13 @@ export class GPT3_5 extends GPTAIModel {
     return this.generateChatCompletion(messages, params);
   }
 
-  async generateChatCompletion(messages: Message[], params: AIModelParams) {
-    const result = await this.client
-      .createChatCompletion(
+  async generateChatCompletion(
+    messages: Message[],
+    params: AIModelParams,
+    client = this.client
+  ): Promise<string | null> {
+    try {
+      const result = await client.createChatCompletion(
         {
           model: this.modelName,
           max_tokens: params.maxTokens,
@@ -27,12 +31,18 @@ export class GPT3_5 extends GPTAIModel {
           messages,
         },
         { timeout: this.TIMEOUT }
-      )
-      .catch((error) => {
-        log.warn(`GPT3_5 completion ${log.vars({ error, messages, params, data: error?.response?.data?.error })})}`);
-        return null;
-      });
+      );
 
-    return result?.data.choices[0].message?.content ?? null;
+      return result?.data.choices[0].message?.content ?? null;
+    } catch (error) {
+      log.warn(`GPT3.5 completion ${log.vars({ error: error?.response ?? error, messages, params })})}`);
+
+      // if we fail on the azure instance due to rate limiting, retry with OpenAI API
+      if (this.azureClient && error?.response?.status === 429 && this.openAIClient) {
+        return this.generateChatCompletion(messages, params, this.openAIClient);
+      }
+
+      return null;
+    }
   }
 }

--- a/lib/clients/ai/gpt/utils.ts
+++ b/lib/clients/ai/gpt/utils.ts
@@ -7,7 +7,9 @@ import { AIModel } from '../types';
 export abstract class GPTAIModel extends AIModel {
   protected TIMEOUT = 20000;
 
-  protected client: OpenAIApi;
+  protected azureClient?: OpenAIApi;
+
+  protected openAIClient?: OpenAIApi;
 
   constructor(config: Partial<Config>) {
     super();
@@ -16,7 +18,7 @@ export abstract class GPTAIModel extends AIModel {
       // remove trailing slash
       const endpoint = config.AZURE_ENDPOINT.replace(/\/$/, '');
 
-      this.client = new OpenAIApi(
+      this.azureClient = new OpenAIApi(
         new Configuration({
           azure: {
             endpoint,
@@ -29,11 +31,16 @@ export abstract class GPTAIModel extends AIModel {
     }
 
     if (config.OPENAI_API_KEY) {
-      this.client = new OpenAIApi(new Configuration({ apiKey: config.OPENAI_API_KEY }));
+      this.openAIClient = new OpenAIApi(new Configuration({ apiKey: config.OPENAI_API_KEY }));
 
       return;
     }
 
     throw new Error(`OpenAI client not initialized`);
+  }
+
+  get client(): OpenAIApi {
+    // one of them is guaranteed to be initialized, otherwise there would be an error
+    return (this.azureClient || this.openAIClient)!;
   }
 }


### PR DESCRIPTION
So from my testing, we may get throttled and rate limited on azure at around 20-30 concurrent requests. The 427 error that we get back is nearly instantaneous - this gives us an opportunity to defer the call to the openAI API as a fallback.

Frank is applying for a rate limit increase, but from what we've heard Microsoft is insanely slow on this stuff.


For the time being, I think we only need to set this up on 3.5 - its our default model across the entire tool 
