### PR TITLE
[Merged by Bors] - fix: ssml on entity prompts, alexa events, stream (PL-30)

### DIFF
--- a/lib/services/runtime/handlers/captureV2/captureV2.alexa.ts
+++ b/lib/services/runtime/handlers/captureV2/captureV2.alexa.ts
@@ -3,6 +3,7 @@
  * it uses different command handler
  * it uses different EntityFillingNoMatch handler (response should never be elicit)
  */
+import { AlexaConstants } from '@voiceflow/alexa-types';
 import { VoiceModels } from '@voiceflow/voice-types';
 import { VoiceflowConstants, VoiceflowNode, VoiceflowVersion } from '@voiceflow/voiceflow-types';
 import _ from 'lodash';
@@ -30,13 +31,13 @@ const addPromptIfExists = (node: VoiceflowNode.CaptureV2.Node, runtime: Runtime,
   const unfulfilledEntity = getUnfulfilledEntity(intentRequest, runtime.version.prototype.model);
   if (!unfulfilledEntity) return;
 
-  const prompt = _.sample(unfulfilledEntity.dialog.prompt) as VoiceModels.IntentPrompt<VoiceflowConstants.Voice>;
+  const prompt = _.sample(unfulfilledEntity.dialog.prompt) as VoiceModels.IntentPrompt<AlexaConstants.Voice>;
   if (!prompt) return;
 
-  const output = fillStringEntities(
-    intentRequest,
-    inputToString(prompt, (runtime.version as VoiceflowVersion.VoiceVersion).platformData.settings.defaultVoice)
-  );
+  // in this case, for alexa voices we dont want to add the extra voice wrapper around the output
+  const voice = prompt.voice ?? (runtime.version as VoiceflowVersion.VoiceVersion).platformData.settings.defaultVoice;
+  const trimmedPrompt = voice?.trim() === AlexaConstants.Voice.ALEXA ? { text: prompt.text } : prompt;
+  const output = fillStringEntities(intentRequest, inputToString(trimmedPrompt));
   addOutputTrace(
     runtime,
     getOutputTrace({

--- a/lib/services/runtime/handlers/state/preliminary/index.ts
+++ b/lib/services/runtime/handlers/state/preliminary/index.ts
@@ -2,6 +2,7 @@ import { VoiceflowNode } from '@voiceflow/voiceflow-types';
 
 import { Action, Handler, HandlerFactory, IfV2Handler } from '@/runtime';
 
+import { isAlexaEventIntentRequest } from '../../../types';
 import _V1Handler from '../../_v1';
 import CaptureHandler from '../../capture';
 import CaptureV2Handler from '../../captureV2';
@@ -37,6 +38,7 @@ export const PreliminaryHandler: HandlerFactory<VoiceflowNode.Interaction.Node, 
     const request = runtime.getRequest();
     return (
       !!request &&
+      !isAlexaEventIntentRequest(request) &&
       runtime.getAction() === Action.REQUEST &&
       !utils.eventHandlers.find((h) => h.canHandle(node, runtime, variables, program))
     );

--- a/lib/services/runtime/handlers/utils/stream.ts
+++ b/lib/services/runtime/handlers/utils/stream.ts
@@ -1,0 +1,13 @@
+import { BaseNode } from '@voiceflow/base-types';
+import { match } from 'ts-pattern';
+
+import { StreamAction } from '../../types';
+
+export const mapStreamActions = (action: StreamAction) => {
+  return match(action)
+    .with(StreamAction.START, StreamAction.RESUME, () => BaseNode.Stream.TraceStreamAction.PLAY)
+    .with(StreamAction.LOOP, () => BaseNode.Stream.TraceStreamAction.LOOP)
+    .with(StreamAction.END, () => BaseNode.Stream.TraceStreamAction.END)
+    .with(StreamAction.PAUSE, () => BaseNode.Stream.TraceStreamAction.PAUSE)
+    .otherwise(() => null);
+};

--- a/lib/services/runtime/init.ts
+++ b/lib/services/runtime/init.ts
@@ -1,10 +1,9 @@
 import { BaseNode, BaseTrace, BaseUtils } from '@voiceflow/base-types';
-import { match } from 'ts-pattern';
 
 import log from '@/logger';
 import Client, { EventType } from '@/runtime';
 
-import { FrameType, Output, StorageType, StreamAction, StreamPlayStorage, TurnType } from './types';
+import { FrameType, Output, TurnType } from './types';
 import { addOutputTrace, getOutputTrace } from './utils';
 
 // initialize event behaviors for client
@@ -55,35 +54,6 @@ const init = (client: Client) => {
   });
 
   client.setEvent(EventType.updateDidExecute, ({ runtime }) => {
-    const stream = runtime.storage.get<StreamPlayStorage>(StorageType.STREAM_PLAY);
-
-    if (stream) {
-      const { action, src, token, loop, description, title, iconImage, backgroundImage } = stream;
-
-      const streamAction = match(action)
-        .with(StreamAction.START, StreamAction.RESUME, () => BaseNode.Stream.TraceStreamAction.PLAY)
-        .with(StreamAction.LOOP, () => BaseNode.Stream.TraceStreamAction.LOOP)
-        .with(StreamAction.END, () => BaseNode.Stream.TraceStreamAction.END)
-        .with(StreamAction.PAUSE, () => BaseNode.Stream.TraceStreamAction.PAUSE)
-        .otherwise(() => null);
-
-      if (streamAction) {
-        runtime.trace.addTrace<BaseNode.Stream.TraceFrame>({
-          type: BaseNode.Utils.TraceType.STREAM,
-          payload: {
-            src,
-            token,
-            action: streamAction,
-            loop,
-            description,
-            title,
-            iconImage,
-            backgroundImage,
-          },
-        });
-      }
-    }
-
     if (runtime.stack.isEmpty() && !runtime.turn.get(TurnType.END)) {
       runtime.trace.addTrace<BaseNode.Exit.TraceFrame>({ type: BaseNode.Utils.TraceType.END, payload: undefined });
     }

--- a/tests/lib/services/runtime/handlers/state/preliminary.unit.ts
+++ b/tests/lib/services/runtime/handlers/state/preliminary.unit.ts
@@ -1,3 +1,4 @@
+import { BaseRequest } from '@voiceflow/base-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -46,6 +47,23 @@ describe('preliminary handler unit tests', () => {
           null as any,
           null as any
         )
+      ).to.eql(false);
+    });
+
+    it('alexa intent request', () => {
+      const alexaEventIntentRequest = {
+        type: BaseRequest.RequestType.INTENT,
+        payload: { intent: { name: 'intent' }, entities: [], data: {} },
+      };
+
+      const runtime = {
+        getRequest: sinon.stub().returns(alexaEventIntentRequest),
+        getAction: sinon.stub().returns(Action.REQUEST),
+      };
+      expect(
+        PreliminaryHandlerFactory({
+          eventHandlers: [],
+        } as any).canHandle(null as any, runtime as any, null as any, null as any)
       ).to.eql(false);
     });
 

--- a/tests/lib/services/runtime/handlers/stream.unit.ts
+++ b/tests/lib/services/runtime/handlers/stream.unit.ts
@@ -55,7 +55,11 @@ describe('stream handler unit tests', async () => {
         iconImage: 'icon-image',
         title: 'title',
       };
-      const runtime = { storage: { set: sinon.stub(), get: sinon.stub().returns(null) }, end: sinon.stub() };
+      const runtime = {
+        storage: { set: sinon.stub(), get: sinon.stub().returns(null) },
+        trace: { addTrace: sinon.stub() },
+        end: sinon.stub(),
+      };
       const variablesMap = { var1: 'val1', var2: 'val2' };
       const variables = { getState: sinon.stub().returns(variablesMap) };
 
@@ -81,6 +85,19 @@ describe('stream handler unit tests', async () => {
         ],
       ]);
       expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PAUSE]]);
+      expect(runtime.trace.addTrace.args[0][0]).to.eql({
+        type: BaseNode.Utils.TraceType.STREAM,
+        payload: {
+          src: urlSrc,
+          token: node.id,
+          action: BaseNode.Stream.TraceStreamAction.PLAY,
+          loop: node.loop,
+          description: node.description,
+          title: node.title,
+          iconImage: node.iconImage,
+          backgroundImage: node.backgroundImage,
+        },
+      });
       expect(runtime.end.callCount).to.eql(1);
     });
 
@@ -106,6 +123,7 @@ describe('stream handler unit tests', async () => {
       };
       const runtime = {
         storage: { set: sinon.stub(), get: sinon.stub().returns({ id: 'id2' }), delete: sinon.stub() },
+        trace: { addTrace: sinon.stub() },
         end: sinon.stub(),
       };
       const variablesMap = { var1: 'val1', var2: 'val2' };
@@ -134,6 +152,19 @@ describe('stream handler unit tests', async () => {
       ]);
       expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PAUSE]]);
       expect(runtime.storage.delete.args).to.eql([[StorageType.STREAM_PAUSE]]);
+      expect(runtime.trace.addTrace.args[0][0]).to.eql({
+        type: BaseNode.Utils.TraceType.STREAM,
+        payload: {
+          src: urlSrc,
+          token: node.id,
+          action: BaseNode.Stream.TraceStreamAction.PLAY,
+          loop: node.loop,
+          description: node.description,
+          title: node.title,
+          iconImage: node.iconImage,
+          backgroundImage: node.backgroundImage,
+        },
+      });
       expect(runtime.end.callCount).to.eql(1);
     });
 
@@ -164,8 +195,8 @@ describe('stream handler unit tests', async () => {
           set: sinon.stub(),
           get: sinon.stub().returns(streamPause),
           delete: sinon.stub(),
-          produce: sinon.stub(),
         },
+        trace: { addTrace: sinon.stub() },
         end: sinon.stub(),
       };
       const variablesMap = { var1: 'val1', var2: 'val2' };
@@ -179,8 +210,8 @@ describe('stream handler unit tests', async () => {
             src: urlSrc,
             loop: node.loop,
             token: node.id,
-            action: StreamAction.START,
-            offset: 0,
+            action: StreamAction.PAUSE,
+            offset: streamPause.offset,
             nodeID: node.id,
             nextID: node.nextID,
             pauseID: node.pauseID,
@@ -196,10 +227,19 @@ describe('stream handler unit tests', async () => {
       expect(runtime.storage.delete.args).to.eql([[StorageType.STREAM_PAUSE]]);
       expect(runtime.end.callCount).to.eql(1);
 
-      const produceFn = runtime.storage.produce.args[0][0];
-      const draft = { [StorageType.STREAM_PLAY]: {} };
-      produceFn(draft);
-      expect(draft).to.eql({ [StorageType.STREAM_PLAY]: { offset: streamPause.offset, action: StreamAction.PAUSE } });
+      expect(runtime.trace.addTrace.args[0][0]).to.eql({
+        type: BaseNode.Utils.TraceType.STREAM,
+        payload: {
+          src: urlSrc,
+          token: node.id,
+          action: BaseNode.Stream.TraceStreamAction.PAUSE,
+          loop: node.loop,
+          description: node.description,
+          title: node.title,
+          iconImage: node.iconImage,
+          backgroundImage: node.backgroundImage,
+        },
+      });
     });
   });
 });

--- a/tests/lib/services/runtime/init.unit.ts
+++ b/tests/lib/services/runtime/init.unit.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import init from '@/lib/services/runtime/init';
-import { FrameType, StorageType, StreamAction } from '@/lib/services/runtime/types';
+import { FrameType } from '@/lib/services/runtime/types';
 import { EventType } from '@/runtime';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
@@ -187,342 +187,55 @@ describe('runtime init service unit tests', () => {
   });
 
   describe('EventType.updateDidExecute', () => {
-    describe('falsy stream', () => {
-      it('works with empty stack and turn not end', () => {
-        const client = { setEvent: sinon.stub() };
-        const stream = undefined;
-        const runtime = {
-          stack: { isEmpty: sinon.stub().returns(true) },
-          storage: { get: sinon.stub().returns(stream) },
-          trace: { addTrace: sinon.stub() },
-          turn: { get: sinon.stub().returns(false) },
-        };
-        init(client as any);
+    it('works with empty stack and turn not end', () => {
+      const client = { setEvent: sinon.stub() };
+      const runtime = {
+        stack: { isEmpty: sinon.stub().returns(true) },
+        trace: { addTrace: sinon.stub() },
+        turn: { get: sinon.stub().returns(false) },
+      };
+      init(client as any);
 
-        expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
+      expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
 
-        const fn = client.setEvent.args[3][1];
-        fn({ runtime });
+      const fn = client.setEvent.args[3][1];
+      fn({ runtime });
 
-        expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-        expect(runtime.trace.addTrace.args).to.eql([[{ type: BaseNode.Utils.TraceType.END, payload: undefined }]]);
-      });
-
-      it('works with empty stack and turn is end', () => {
-        const client = { setEvent: sinon.stub() };
-        const stream = undefined;
-        const runtime = {
-          stack: { isEmpty: sinon.stub().returns(true) },
-          storage: { get: sinon.stub().returns(stream) },
-          trace: { addTrace: sinon.stub() },
-          turn: { get: sinon.stub().returns(true) },
-        };
-        init(client as any);
-
-        expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
-
-        const fn = client.setEvent.args[3][1];
-        fn({ runtime });
-
-        expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-        expect(runtime.trace.addTrace.callCount).to.eql(0);
-      });
-
-      it('works with non-empty stack and turn is end', () => {
-        const client = { setEvent: sinon.stub() };
-        const stream = undefined;
-        const runtime = {
-          stack: { isEmpty: sinon.stub().returns(false) },
-          storage: { get: sinon.stub().returns(stream) },
-          trace: { addTrace: sinon.stub() },
-          turn: { get: sinon.stub().returns(true) },
-        };
-        init(client as any);
-
-        expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
-
-        const fn = client.setEvent.args[3][1];
-        fn({ runtime });
-
-        expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-        expect(runtime.trace.addTrace.callCount).to.eql(0);
-      });
+      expect(runtime.trace.addTrace.args).to.eql([[{ type: BaseNode.Utils.TraceType.END, payload: undefined }]]);
     });
 
-    describe('defined stream', () => {
-      describe('START action', () => {
-        it('works', () => {
-          const client = { setEvent: sinon.stub() };
-          const stream = {
-            action: StreamAction.START,
-            src: 'src-val',
-            token: 'token-val',
-            loop: true,
-            backgroundImage: 'background-image-val',
-            description: 'description-val',
-            iconImage: 'icon-image-val',
-            title: 'title-val',
-          };
-          const runtime = {
-            stack: { isEmpty: sinon.stub().returns(true) },
-            storage: { get: sinon.stub().returns(stream) },
-            trace: { addTrace: sinon.stub() },
-            turn: { get: sinon.stub().returns(false) },
-          };
-          init(client as any);
+    it('works with empty stack and turn is end', () => {
+      const client = { setEvent: sinon.stub() };
+      const runtime = {
+        stack: { isEmpty: sinon.stub().returns(true) },
+        trace: { addTrace: sinon.stub() },
+        turn: { get: sinon.stub().returns(true) },
+      };
+      init(client as any);
 
-          expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
+      expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
 
-          const fn = client.setEvent.args[3][1];
-          fn({ runtime });
+      const fn = client.setEvent.args[3][1];
+      fn({ runtime });
 
-          expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.trace.addTrace.args).to.eql([
-            [
-              {
-                type: BaseNode.Utils.TraceType.STREAM,
-                payload: {
-                  src: stream.src,
-                  token: stream.token,
-                  action: BaseNode.Stream.TraceStreamAction.PLAY,
-                  loop: true,
-                  backgroundImage: stream.backgroundImage,
-                  description: stream.description,
-                  iconImage: stream.iconImage,
-                  title: stream.title,
-                },
-              },
-            ],
-            [{ type: BaseNode.Utils.TraceType.END, payload: undefined }],
-          ]);
-        });
-      });
-      describe('RESUME action', () => {
-        it('works', () => {
-          const client = { setEvent: sinon.stub() };
-          const stream = {
-            action: StreamAction.RESUME,
-            src: 'src-val',
-            token: 'token-val',
-            loop: true,
-            backgroundImage: 'background-image-val',
-            description: 'description-val',
-            iconImage: 'icon-image-val',
-            title: 'title-val',
-          };
-          const runtime = {
-            stack: { isEmpty: sinon.stub().returns(true) },
-            storage: { get: sinon.stub().returns(stream) },
-            trace: { addTrace: sinon.stub() },
-            turn: { get: sinon.stub().returns(false) },
-          };
-          init(client as any);
+      expect(runtime.trace.addTrace.callCount).to.eql(0);
+    });
 
-          expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
+    it('works with non-empty stack and turn is end', () => {
+      const client = { setEvent: sinon.stub() };
+      const runtime = {
+        stack: { isEmpty: sinon.stub().returns(false) },
+        trace: { addTrace: sinon.stub() },
+        turn: { get: sinon.stub().returns(true) },
+      };
+      init(client as any);
 
-          const fn = client.setEvent.args[3][1];
-          fn({ runtime });
+      expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
 
-          expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.trace.addTrace.args).to.eql([
-            [
-              {
-                type: BaseNode.Utils.TraceType.STREAM,
-                payload: {
-                  src: stream.src,
-                  token: stream.token,
-                  action: BaseNode.Stream.TraceStreamAction.PLAY,
-                  loop: true,
-                  backgroundImage: stream.backgroundImage,
-                  description: stream.description,
-                  iconImage: stream.iconImage,
-                  title: stream.title,
-                },
-              },
-            ],
-            [{ type: BaseNode.Utils.TraceType.END, payload: undefined }],
-          ]);
-        });
-      });
-      describe('LOOP action', () => {
-        it('works', () => {
-          const client = { setEvent: sinon.stub() };
-          const stream = {
-            action: StreamAction.LOOP,
-            src: 'src-val',
-            token: 'token-val',
-            loop: true,
-            backgroundImage: 'background-image-val',
-            description: 'description-val',
-            iconImage: 'icon-image-val',
-            title: 'title-val',
-          };
-          const runtime = {
-            stack: { isEmpty: sinon.stub().returns(false) },
-            storage: { get: sinon.stub().returns(stream) },
-            trace: { addTrace: sinon.stub() },
-            turn: { get: sinon.stub().returns(false) },
-          };
-          init(client as any);
+      const fn = client.setEvent.args[3][1];
+      fn({ runtime });
 
-          expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
-
-          const fn = client.setEvent.args[3][1];
-          fn({ runtime });
-
-          expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.trace.addTrace.args).to.eql([
-            [
-              {
-                type: BaseNode.Utils.TraceType.STREAM,
-                payload: {
-                  src: stream.src,
-                  token: stream.token,
-                  action: BaseNode.Stream.TraceStreamAction.LOOP,
-                  loop: true,
-                  backgroundImage: stream.backgroundImage,
-                  description: stream.description,
-                  iconImage: stream.iconImage,
-                  title: stream.title,
-                },
-              },
-            ],
-          ]);
-        });
-      });
-      describe('END action', () => {
-        it('works', () => {
-          const client = { setEvent: sinon.stub() };
-          const stream = {
-            action: StreamAction.END,
-            src: 'src-val',
-            token: 'token-val',
-            loop: true,
-            backgroundImage: 'background-image-val',
-            description: 'description-val',
-            iconImage: 'icon-image-val',
-            title: 'title-val',
-          };
-          const runtime = {
-            stack: { isEmpty: sinon.stub().returns(false) },
-            storage: { get: sinon.stub().returns(stream) },
-            trace: { addTrace: sinon.stub() },
-            turn: { get: sinon.stub().returns(false) },
-          };
-          init(client as any);
-
-          expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
-
-          const fn = client.setEvent.args[3][1];
-          fn({ runtime });
-
-          expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.trace.addTrace.args).to.eql([
-            [
-              {
-                type: BaseNode.Utils.TraceType.STREAM,
-                payload: {
-                  src: stream.src,
-                  token: stream.token,
-                  action: BaseNode.Stream.TraceStreamAction.END,
-                  loop: true,
-                  backgroundImage: stream.backgroundImage,
-                  description: stream.description,
-                  iconImage: stream.iconImage,
-                  title: stream.title,
-                },
-              },
-            ],
-          ]);
-        });
-      });
-      describe('PAUSE action', () => {
-        it('works', () => {
-          const client = { setEvent: sinon.stub() };
-          const stream = {
-            action: StreamAction.PAUSE,
-            src: 'src-val',
-            token: 'token-val',
-            loop: true,
-            backgroundImage: 'background-image-val',
-            description: 'description-val',
-            iconImage: 'icon-image-val',
-            title: 'title-val',
-          };
-          const runtime = {
-            stack: { isEmpty: sinon.stub().returns(false) },
-            storage: { get: sinon.stub().returns(stream) },
-            trace: { addTrace: sinon.stub() },
-            turn: { get: sinon.stub().returns(false) },
-          };
-          init(client as any);
-
-          expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
-
-          const fn = client.setEvent.args[3][1];
-          fn({ runtime });
-
-          expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.trace.addTrace.args).to.eql([
-            [
-              {
-                type: BaseNode.Utils.TraceType.STREAM,
-                payload: {
-                  src: stream.src,
-                  token: stream.token,
-                  action: BaseNode.Stream.TraceStreamAction.PAUSE,
-                  loop: true,
-                  backgroundImage: stream.backgroundImage,
-                  description: stream.description,
-                  iconImage: stream.iconImage,
-                  title: stream.title,
-                },
-              },
-            ],
-          ]);
-        });
-      });
-      describe('default action', () => {
-        it('works with at end', () => {
-          const client = { setEvent: sinon.stub() };
-          const stream = { action: 'someaction', src: 'src-val', token: 'token-val', loop: true };
-          const runtime = {
-            stack: { isEmpty: sinon.stub().returns(true) },
-            storage: { get: sinon.stub().returns(stream) },
-            trace: { addTrace: sinon.stub() },
-            turn: { get: sinon.stub().returns(false) },
-          };
-          init(client as any);
-
-          expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
-
-          const fn = client.setEvent.args[3][1];
-          fn({ runtime });
-
-          expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.trace.addTrace.args).to.eql([[{ type: BaseNode.Utils.TraceType.END, payload: undefined }]]);
-        });
-
-        it('works with not at end', () => {
-          const client = { setEvent: sinon.stub() };
-          const stream = { action: 'someaction', src: 'src-val', token: 'token-val', loop: true };
-          const runtime = {
-            stack: { isEmpty: sinon.stub().returns(false) },
-            storage: { get: sinon.stub().returns(stream) },
-            trace: { addTrace: sinon.stub() },
-            turn: { get: sinon.stub().returns(false) },
-          };
-          init(client as any);
-
-          expect(client.setEvent.args[3][0]).to.eql(EventType.updateDidExecute);
-
-          const fn = client.setEvent.args[3][1];
-          fn({ runtime });
-
-          expect(runtime.storage.get.args).to.eql([[StorageType.STREAM_PLAY]]);
-          expect(runtime.trace.addTrace.args).to.eql([]);
-        });
-      });
+      expect(runtime.trace.addTrace.callCount).to.eql(0);
     });
   });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-30**

### Brief description. What is this change?

This aims to fix 3 things:

- [ssml parsing on entity prompt](https://github.com/voiceflow/general-runtime/pull/527/files#diff-9f185c65c82d9dc4ffc2db56973428bb948a54c79adca5c56a4582752b46f323R37-R40): if voice is alexa we should not add the voice wrapper
- [alexa intent event handling](https://github.com/voiceflow/general-runtime/pull/527/files#diff-206010624b0197ce37f3540b4653f88b73c0ea804b4f88c750f139b788c7c6d4R41): update preliminary canHandle so it doesnt catch alexa event intents
- stream actions sent always as last part of trace: I think this makes little sense and pollutes the trace, the traces should be added by the handlers themselves. Also this was causing a bug on guided navitation (eg, if after a stream) where stream end was the last trace and it wouldnt show the if options. (fixes [BUG-426](https://voiceflow.atlassian.net/browse/BUG-426))

Biggest changes/refactor is due to last bullet point.


### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [X] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test

[BUG-426]: https://voiceflow.atlassian.net/browse/BUG-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ