### PR TITLE
[Merged by Bors] - feat: support setting variables in interact (BUG-439)

### DIFF
--- a/lib/controllers/stateManagement/index.ts
+++ b/lib/controllers/stateManagement/index.ts
@@ -37,7 +37,7 @@ class StateManagementController extends AbstractController {
     req: Request<
       { userID: string },
       any,
-      { projectID: string; authorization: string; versionID: string },
+      { projectID: string; authorization: string; versionID: string; state: Pick<State, 'variables'> },
       { verbose?: boolean; logs?: RuntimeLogs.LogLevel }
     >
   ) {

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -64,9 +64,6 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
         ...initializeStore(version.variables),
         ...state.variables,
         timestamp: this.services.utils.getTime(), // unix time in seconds
-        // Hidden system variable for manipulating the response.
-        // This is legacy support for Alexa.
-        _response: null,
       },
     };
   }

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -64,6 +64,9 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
         ...initializeStore(version.variables),
         ...state.variables,
         timestamp: this.services.utils.getTime(), // unix time in seconds
+        // Hidden system variable for manipulating the response.
+        // This is legacy support for Alexa.
+        _response: null,
       },
     };
   }

--- a/lib/services/stateManagement.ts
+++ b/lib/services/stateManagement.ts
@@ -18,7 +18,9 @@ class StateManagement extends AbstractManager {
       state = await this.reset(data);
     }
 
-    data.body.state = state;
+    data.body.state = _.merge(state, {
+      variables: data.body.state?.variables,
+    });
 
     const { state: updatedState, trace, request } = await this.services.interact.handler(data);
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

To support some alexa system variables, we can accept variables from the stateful interact request and merge with our saved state. 
Not only does this allow the alexa adapter to control these legacy system state values, it also makes our interact more flexible!