### PR TITLE
[Merged by Bors] - fix: add new workspaceID (NLU-000)

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -5,7 +5,6 @@ status = [
   "ci/circleci: run-e2e-tests",
   "ci/circleci: provision-env",
   "ci/circleci: prepare-env",
-  "ci/circleci: old_e2e_tests",
 ]
 delete_merged_branches = true
 use_squash_merge = true

--- a/lib/services/runtime/handlers/utils/knowledgeBase/index.ts
+++ b/lib/services/runtime/handlers/utils/knowledgeBase/index.ts
@@ -25,7 +25,7 @@ export interface KnowledgeBaseResponse {
   chunks: KnowledegeBaseChunk[];
 }
 
-export const FLAGGED_WORSPACE_IDS = [80627];
+export const FLAGGED_WORSPACE_IDS = ['80627', 'Brk8AaGjlQ'];
 
 const { KL_RETRIEVER_SERVICE_HOST: host, KL_RETRIEVER_SERVICE_PORT: port } = Config;
 const scheme = process.env.NODE_ENV === 'e2e' ? 'https' : 'http';
@@ -33,7 +33,7 @@ export const RETRIEVE_ENDPOINT = host && port ? new URL(`${scheme}://${host}:${p
 export const { KNOWLEDGE_BASE_LAMBDA_ENDPOINT } = Config;
 
 export const getAnswerEndpoint = (workspaceID: string | undefined): string | null => {
-  if (workspaceID && FLAGGED_WORSPACE_IDS.includes(parseInt(workspaceID, 10))) {
+  if (workspaceID && FLAGGED_WORSPACE_IDS.includes(String(workspaceID))) {
     return RETRIEVE_ENDPOINT;
   }
   if (!KNOWLEDGE_BASE_LAMBDA_ENDPOINT) return null;


### PR DESCRIPTION
Fixes or implements NLU-000

Depending on the endpoint that is called, the `teamID` may be passed through hashed or unhashed.

This PR adds the flagged workspace's hashed ID alongside its unhashed teamID so that we may test the new KB retriever regardless of whether or not the endpoint hashed the ID.