### PR TITLE
fix: llm turn timeout (BUG-522)

### DIFF
--- a/lib/clients/ai/anthropic/utils.ts
+++ b/lib/clients/ai/anthropic/utils.ts
@@ -50,6 +50,7 @@ export abstract class AnthropicAIModel extends AIModel {
     messages: BaseUtils.ai.Message[],
     params: AIModelParams
   ): Promise<CompletionOutput | null> {
+    const startTime = Date.now();
     let topSystem = '';
     if (messages[0]?.role === BaseUtils.ai.Role.SYSTEM) {
       topSystem = messages.shift()!.content;
@@ -83,6 +84,7 @@ export abstract class AnthropicAIModel extends AIModel {
       tokens: queryTokens + answerTokens,
       queryTokens,
       answerTokens,
+      time: Date.now() - startTime,
     };
   }
 }

--- a/lib/clients/ai/openai/gpt3.ts
+++ b/lib/clients/ai/openai/gpt3.ts
@@ -31,6 +31,7 @@ export class GPT3 extends GPTAIModel {
   }
 
   async generateCompletion(prompt: string, params: AIModelParams) {
+    const startTime = Date.now();
     const result = await this.client
       .createCompletion(
         {
@@ -56,6 +57,7 @@ export class GPT3 extends GPTAIModel {
       tokens: this.calculateTokenMultiplier(tokens),
       queryTokens: this.calculateTokenMultiplier(queryTokens),
       answerTokens: this.calculateTokenMultiplier(answerTokens),
+      time: Date.now() - startTime,
     };
   }
 

--- a/lib/clients/ai/openai/gpt3_5.ts
+++ b/lib/clients/ai/openai/gpt3_5.ts
@@ -24,6 +24,7 @@ export class GPT3_5 extends GPTAIModel {
     client = this.client
   ): Promise<CompletionOutput | null> {
     try {
+      const startTime = Date.now();
       const result = await client.createChatCompletion(
         {
           model: this.gptModelName,
@@ -44,6 +45,7 @@ export class GPT3_5 extends GPTAIModel {
         tokens: this.calculateTokenMultiplier(tokens),
         queryTokens: this.calculateTokenMultiplier(queryTokens),
         answerTokens: this.calculateTokenMultiplier(answerTokens),
+        time: Date.now() - startTime,
       };
     } catch (error) {
       const truncatedMessages = messages.slice(0, 10).map(({ content, ...rest }) => ({

--- a/lib/clients/ai/openai/gpt4.ts
+++ b/lib/clients/ai/openai/gpt4.ts
@@ -26,6 +26,7 @@ export class GPT4 extends GPTAIModel {
   }
 
   async generateChatCompletion(messages: BaseUtils.ai.Message[], params: AIModelParams) {
+    const startTime = Date.now();
     const result = await this.client
       .createChatCompletion(
         {
@@ -51,6 +52,7 @@ export class GPT4 extends GPTAIModel {
       tokens: this.calculateTokenMultiplier(tokens),
       queryTokens: this.calculateTokenMultiplier(queryTokens),
       answerTokens: this.calculateTokenMultiplier(answerTokens),
+      time: Date.now() - startTime,
     };
   }
 }

--- a/lib/clients/ai/types.ts
+++ b/lib/clients/ai/types.ts
@@ -20,6 +20,7 @@ export interface CompletionOutput {
   tokens: number;
   queryTokens: number;
   answerTokens: number;
+  time: number;
 }
 
 export const GPT4_ABLE_PLAN = new Set(['old_pro', 'old_team', 'pro', 'team', 'enterprise']);

--- a/lib/controllers/test.ts
+++ b/lib/controllers/test.ts
@@ -56,15 +56,11 @@ class TestController extends AbstractController {
 
     if (!answer?.output) return { output: null };
 
-    if (typeof answer.tokens === 'number' && answer.tokens > 0) {
-      await this.services.billing
-        .consumeQuota(req.params.workspaceID, QuotaName.OPEN_API_TOKENS, answer.tokens)
-        .catch((err: Error) =>
-          log.warn(
-            `[KB Prompt Test] Error consuming quota for workspace ${req.params.workspaceID}: ${log.vars({ err })}`
-          )
-        );
-    }
+    await this.services.billing
+      .consumeQuota(req.params.workspaceID, QuotaName.OPEN_API_TOKENS, answer.tokens)
+      .catch((err: Error) =>
+        log.warn(`[KB Prompt Test] Error consuming quota for workspace ${req.params.workspaceID}: ${log.vars({ err })}`)
+      );
 
     return { output: answer.output };
   }
@@ -94,13 +90,11 @@ class TestController extends AbstractController {
 
     if (!answer?.output) return { output: null, chunks };
 
-    if (typeof answer.tokens === 'number' && answer.tokens > 0) {
-      await this.services.billing
-        .consumeQuota(req.params.workspaceID, QuotaName.OPEN_API_TOKENS, answer.tokens)
-        .catch((err: Error) =>
-          log.warn(`[KB Test] Error consuming quota for workspace ${req.params.workspaceID}: ${log.vars({ err })}`)
-        );
-    }
+    await this.services.billing
+      .consumeQuota(req.params.workspaceID, QuotaName.OPEN_API_TOKENS, answer?.tokens ?? 0)
+      .catch((err: Error) =>
+        log.warn(`[KB Test] Error consuming quota for workspace ${req.params.workspaceID}: ${log.vars({ err })}`)
+      );
 
     return { output: answer.output, chunks };
   }
@@ -115,15 +109,13 @@ class TestController extends AbstractController {
 
     const { output, tokens } = await fetchPrompt(req.body);
 
-    if (typeof tokens === 'number' && tokens > 0) {
-      await this.services.billing
-        .consumeQuota(req.params.workspaceID, QuotaName.OPEN_API_TOKENS, tokens)
-        .catch((err: Error) =>
-          log.warn(
-            `[Completion Test] Error consuming quota for workspace ${req.params.workspaceID}: ${log.vars({ err })}`
-          )
-        );
-    }
+    await this.services.billing
+      .consumeQuota(req.params.workspaceID, QuotaName.OPEN_API_TOKENS, tokens ?? 0)
+      .catch((err: Error) =>
+        log.warn(
+          `[Completion Test] Error consuming quota for workspace ${req.params.workspaceID}: ${log.vars({ err })}`
+        )
+      );
 
     return { output };
   }

--- a/lib/services/billing.ts
+++ b/lib/services/billing.ts
@@ -36,6 +36,8 @@ export class BillingService extends AbstractManager {
   }
 
   async consumeQuota(workspaceID: string, quotaName: QuotaName, count: number) {
+    if (typeof count !== 'number' || count < 1) return null;
+
     const client = await this.getClient();
     if (!client) return null;
 

--- a/lib/services/runtime/handlers/utils/ai.ts
+++ b/lib/services/runtime/handlers/utils/ai.ts
@@ -1,9 +1,13 @@
-import { BaseUtils } from '@voiceflow/base-types';
+import { BaseNode, BaseUtils } from '@voiceflow/base-types';
 import { replaceVariables, sanitizeVariables } from '@voiceflow/common';
 
 import AI from '@/lib/clients/ai';
+import AIAssist from '@/lib/services/aiAssist';
+import { QuotaName } from '@/lib/services/billing';
+import log from '@/logger';
+import { Runtime } from '@/runtime';
 
-import AIAssist from '../../../aiAssist';
+import { TurnType } from '../../types';
 
 export const getMemoryMessages = (variablesState: Record<string, unknown>) => [
   ...((variablesState?.[AIAssist.StorageKey] as BaseUtils.ai.Message[]) || []),
@@ -19,17 +23,26 @@ export interface AIResponse {
   output: string | null;
   messages?: BaseUtils.ai.Message[];
   prompt?: string;
-  tokens?: number;
-  queryTokens?: number;
-  answerTokens?: number;
+  queryTokens: number;
+  answerTokens: number;
+  tokens: number;
+  time: number;
 }
+
+export const EMPTY_AI_RESPONSE = {
+  output: null,
+  tokens: 0,
+  time: 0,
+  queryTokens: 0,
+  answerTokens: 0,
+};
 
 export const fetchChat = async (
   params: BaseUtils.ai.AIModelParams & { messages: BaseUtils.ai.Message[] },
   variablesState: Record<string, unknown> = {}
 ): Promise<AIResponse> => {
   const model = AI.get(params.model);
-  if (!model) return { output: null };
+  if (!model) return EMPTY_AI_RESPONSE;
 
   const sanitizedVars = sanitizeVariables(variablesState);
   const messages = params.messages.map((message) => ({
@@ -40,14 +53,10 @@ export const fetchChat = async (
   const system = replaceVariables(params.system, sanitizedVars);
   if (system) messages.unshift({ role: BaseUtils.ai.Role.SYSTEM, content: system });
 
-  const { output, tokens, queryTokens, answerTokens } = (await model.generateChatCompletion(messages, params)) ?? {
-    output: null,
-    tokens: 0,
-    queryTokens: 0,
-    answerTokens: 0,
-  };
+  const { output, tokens, queryTokens, answerTokens, time } =
+    (await model.generateChatCompletion(messages, params)) ?? EMPTY_AI_RESPONSE;
 
-  return { messages, output, tokens, queryTokens, answerTokens };
+  return { messages, output, tokens, queryTokens, answerTokens, time };
 };
 
 export const fetchPrompt = async (
@@ -55,7 +64,7 @@ export const fetchPrompt = async (
   variablesState: Record<string, unknown> = {}
 ): Promise<AIResponse> => {
   const model = AI.get(params.model);
-  if (!model) return { output: null };
+  if (!model) return EMPTY_AI_RESPONSE;
 
   const sanitizedVars = sanitizeVariables(variablesState);
 
@@ -66,38 +75,61 @@ export const fetchPrompt = async (
     const messages = getMemoryMessages(variablesState);
     if (system) messages.unshift({ role: BaseUtils.ai.Role.SYSTEM, content: system });
 
-    const { output, tokens, queryTokens, answerTokens } = (await model.generateChatCompletion(messages, params)) ?? {
-      output: null,
-      tokens: 0,
-      queryTokens: 0,
-      answerTokens: 0,
-    };
+    const { output, tokens, queryTokens, answerTokens, time } =
+      (await model.generateChatCompletion(messages, params)) ?? EMPTY_AI_RESPONSE;
 
-    return { output, tokens, queryTokens, answerTokens };
+    return { output, tokens, queryTokens, answerTokens, time };
   }
   if (params.mode === BaseUtils.ai.PROMPT_MODE.MEMORY_PROMPT) {
     const messages = getMemoryMessages(variablesState);
     if (system) messages.unshift({ role: BaseUtils.ai.Role.SYSTEM, content: system });
     if (prompt) messages.push({ role: BaseUtils.ai.Role.USER, content: prompt });
 
-    const { output, tokens, queryTokens, answerTokens } = (await model.generateChatCompletion(messages, params)) ?? {
-      output: null,
-      tokens: 0,
-      queryTokens: 0,
-      answerTokens: 0,
-    };
+    const { output, tokens, queryTokens, answerTokens, time } =
+      (await model.generateChatCompletion(messages, params)) ?? EMPTY_AI_RESPONSE;
 
-    return { output, tokens, queryTokens, answerTokens };
+    return { output, tokens, messages, time, queryTokens, answerTokens };
   }
 
-  if (!prompt) return { output: null };
+  if (!prompt) return EMPTY_AI_RESPONSE;
 
-  const { output, tokens, queryTokens, answerTokens } = (await model.generateCompletion(prompt, params)) ?? {
-    output: null,
-    tokens: 0,
-    queryTokens: 0,
-    answerTokens: 0,
-  };
+  const { output, tokens, queryTokens, answerTokens, time } =
+    (await model.generateCompletion(prompt, params)) ?? EMPTY_AI_RESPONSE;
 
-  return { output, tokens, queryTokens, answerTokens };
+  return { prompt, output, tokens, queryTokens, answerTokens, time };
+};
+
+export const consumeResources = async (
+  reference: string,
+  runtime: Runtime,
+  resources: { tokens?: number; time?: number } | null
+) => {
+  const { tokens = 0, time = 0 } = resources ?? {};
+
+  const workspaceID = runtime.project?.teamID;
+  runtime.turn.set(TurnType.ELAPSED_AI_TIME, runtime.turn.get(TurnType.ELAPSED_AI_TIME) ?? 0 + time);
+  await runtime.services.billing
+    .consumeQuota(workspaceID, QuotaName.OPEN_API_TOKENS, tokens)
+    .catch((err: Error) =>
+      log.error(`[${reference}] Error consuming quota for workspace ${workspaceID}: ${log.vars({ err })}`)
+    );
+};
+
+export const checkTokens = async (runtime: Runtime, nodeType?: BaseNode.NodeType): Promise<boolean> => {
+  const workspaceID = runtime.project?.teamID;
+
+  if (await runtime.services.billing.checkQuota(workspaceID, QuotaName.OPEN_API_TOKENS)) return true;
+
+  runtime.trace.debug('token quota exceeded', nodeType);
+  return false;
+};
+
+// 90 seconds
+export const MAX_ELAPSED_AI_TIME = 90 * 1000;
+
+export const checkLLMTurnTimeout = (runtime: Runtime, nodeType?: BaseNode.NodeType): boolean => {
+  if ((runtime.turn.get<number>(TurnType.ELAPSED_AI_TIME) ?? 0) < MAX_ELAPSED_AI_TIME) return true;
+
+  runtime.trace.debug('llm turn timeout', nodeType);
+  return false;
 };

--- a/lib/services/runtime/handlers/utils/generativeNoMatch.ts
+++ b/lib/services/runtime/handlers/utils/generativeNoMatch.ts
@@ -4,7 +4,7 @@ import { GPT4_ABLE_PLAN } from '@/lib/clients/ai/types';
 import { Runtime } from '@/runtime';
 
 import { Output } from '../../types';
-import { fetchChat, getMemoryMessages } from './ai';
+import { EMPTY_AI_RESPONSE, fetchChat, getMemoryMessages } from './ai';
 import { generateOutput } from './output';
 
 // get current UTC time, default to 1 newline after
@@ -15,14 +15,14 @@ export const getCurrentTime = ({ newlines = 1 }: { newlines?: number } = {}) => 
 export const generateNoMatch = async (
   runtime: Runtime,
   context: BaseUtils.ai.AIModelParams
-): Promise<{ output: Output; tokens: number } | null> => {
+): Promise<{ output: Output; tokens: number; time: number } | null> => {
   if (context.model === BaseUtils.ai.GPT_MODEL.GPT_4 && runtime.plan && !GPT4_ABLE_PLAN.has(runtime.plan)) {
     return {
+      ...EMPTY_AI_RESPONSE,
       output: generateOutput(
         'GPT-4 is only available on the Pro plan. Please upgrade to use this feature.',
         runtime.project
       ),
-      tokens: 0,
     };
   }
 
@@ -51,6 +51,7 @@ export const generateNoMatch = async (
 
   return {
     output: generateOutput(response.output, runtime.project),
-    tokens: response.tokens ?? 0,
+    tokens: response.tokens,
+    time: response.time,
   };
 };

--- a/lib/services/runtime/handlers/utils/knowledgeBase/answer.ts
+++ b/lib/services/runtime/handlers/utils/knowledgeBase/answer.ts
@@ -1,7 +1,7 @@
 import { BaseUtils } from '@voiceflow/base-types';
 import dedent from 'dedent';
 
-import { AIResponse, fetchChat, fetchPrompt } from '../ai';
+import { AIResponse, EMPTY_AI_RESPONSE, fetchChat, fetchPrompt } from '../ai';
 import { getCurrentTime } from '../generativeNoMatch';
 import type { KnowledgeBaseResponse } from '.';
 
@@ -20,7 +20,7 @@ export const answerSynthesis = async ({
   variables?: Record<string, any>;
   options?: Partial<BaseUtils.ai.AIModelParams>;
 }): Promise<AIResponse | null> => {
-  let response: AIResponse = { output: null };
+  let response: AIResponse = EMPTY_AI_RESPONSE;
 
   const systemWithTime = `${system}\n\n${getCurrentTime()}`.trim();
 
@@ -80,7 +80,7 @@ export const answerSynthesis = async ({
   const output = response.output?.trim().toUpperCase();
 
   if (output?.includes('NOT_FOUND') || output?.startsWith("I'M SORRY,") || output?.includes('AS AN AI'))
-    return { output: null };
+    return { ...response, output: null };
 
   return response;
 };

--- a/lib/services/runtime/handlers/utils/knowledgeBase/question.ts
+++ b/lib/services/runtime/handlers/utils/knowledgeBase/question.ts
@@ -1,7 +1,7 @@
 import { BaseUtils } from '@voiceflow/base-types';
 import dedent from 'dedent';
 
-import { AIResponse, fetchChat } from '../ai';
+import { AIResponse, EMPTY_AI_RESPONSE, fetchChat } from '../ai';
 
 export const questionSynthesis = async (question: string, memory: BaseUtils.ai.Message[]): Promise<AIResponse> => {
   if (memory.length > 1) {
@@ -30,6 +30,7 @@ export const questionSynthesis = async (question: string, memory: BaseUtils.ai.M
   }
 
   return {
+    ...EMPTY_AI_RESPONSE,
     output: question,
   };
 };

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -113,6 +113,7 @@ export enum TurnType {
   PREVIOUS_OUTPUT = 'lastOutput',
   STOP_ALL = 'stopAll',
   STOP_TYPES = 'stopTypes',
+  ELAPSED_AI_TIME = 'elapsedAITime',
 }
 
 export type Output = BaseText.SlateTextValue | string;


### PR DESCRIPTION
The goal of this PR is to have a TURN counter (1 API request, aka one interaction/turn) of how much total time has been spent waiting on LLMs.

This is to prevent infinite loops from consuming all the tokens
<img width="830" alt="Screenshot 2023-08-01 at 10 25 59 AM" src="https://github.com/voiceflow/general-runtime/assets/5643574/92a001df-f667-4bd3-8112-c881983178d0">

I've done some abstractions to bundle it with quota checks and token consumption.
