### PR TITLE
[Merged by Bors] - fix: typo (NLU-000)

### DIFF
--- a/lib/services/runtime/handlers/utils/ai.ts
+++ b/lib/services/runtime/handlers/utils/ai.ts
@@ -112,7 +112,7 @@ export const consumeResources = async (
     );
 
   runtime.trace.debug(
-    `__${reference}__ \`tokens: {total: ${tokens} query: ${queryTokens},  answer: ${answerTokens}}\``
+    `__${reference}__ \`tokens: {total: ${tokens}, query: ${queryTokens}, answer: ${answerTokens}}\``
   );
 };
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

typo in debug trace, was missing a comma.

fixed result:
<img width="485" alt="Screenshot 2023-08-02 at 2 01 14 PM" src="https://github.com/voiceflow/general-runtime/assets/23105545/b6d990d4-e14e-439f-9b46-4aaaac0a3c0a">
