### PR TITLE
fix: don't override kb no match (nlu-781)

### DIFF
--- a/lib/services/runtime/handlers/utils/knowledgeBase/answer.ts
+++ b/lib/services/runtime/handlers/utils/knowledgeBase/answer.ts
@@ -9,6 +9,14 @@ const generateContext = (data: KnowledgeBaseResponse) => {
   return data.chunks.map(({ content }, index) => `<${index + 1}>${content}</${index + 1}>`).join('\n');
 };
 
+export const filterNotFound = (output: string) => {
+  const upperCase = output?.toUpperCase();
+  if (upperCase?.includes('NOT_FOUND') || upperCase?.startsWith("I'M SORRY,") || upperCase?.includes('AS AN AI')) {
+    return null;
+  }
+  return output;
+};
+
 export const answerSynthesis = async ({
   question,
   data,
@@ -77,10 +85,9 @@ export const answerSynthesis = async ({
     response = await fetchPrompt({ ...options, prompt, mode: BaseUtils.ai.PROMPT_MODE.PROMPT }, variables);
   }
 
-  const output = response.output?.trim().toUpperCase();
-
-  if (output?.includes('NOT_FOUND') || output?.startsWith("I'M SORRY,") || output?.includes('AS AN AI'))
-    return { ...response, output: null };
+  if (response.output) {
+    response.output = filterNotFound(response.output.trim());
+  }
 
   return response;
 };


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements NLU-781**

Generative no-match was always overwriting kb no-match regardless of whether or not the kb no-match was successful. We  were also undercharging for tokens since we were running both KB and GenAI but only charging for GenAI.

Current bug - gen no match is taking over when it should be kb no match ([full report on notion](https://www.notion.so/voiceflow/KB-answering-in-Preview-but-not-in-flow-d2ff1ceb8d2d427285ca758f5dd7a0db#8c7bd916dcc14d4c8f699106206b037e)):
<p align="center">
<img width="387" alt="Screenshot 2023-08-03 at 10 41 58 AM" src="https://github.com/voiceflow/general-runtime/assets/23105545/7c52d0c5-12f7-44d0-987d-597d49e93276">
<p>

New example:
<p align="center">
<img src='https://github.com/voiceflow/general-runtime/assets/23105545/fb98ebbe-28b4-468a-aeac-21ab54307de1' width='350'>
</p>
