### PR TITLE
fix: azure has latency spikes (FIX-000)

### DIFF
--- a/lib/clients/ai/openai/utils.ts
+++ b/lib/clients/ai/openai/utils.ts
@@ -21,6 +21,13 @@ export abstract class GPTAIModel extends AIModel {
   constructor(config: Partial<Config>) {
     super();
 
+    // prioritize openai until azure latency spikes are figured out
+    if (config.OPENAI_API_KEY) {
+      this.openAIClient = new OpenAIApi(new Configuration({ apiKey: config.OPENAI_API_KEY }));
+
+      return;
+    }
+
     if (config.AZURE_ENDPOINT && config.AZURE_OPENAI_API_KEY && config.AZURE_GPT35_DEPLOYMENTS) {
       // remove trailing slash
       const endpoint = config.AZURE_ENDPOINT.replace(/\/$/, '');
@@ -34,12 +41,6 @@ export abstract class GPTAIModel extends AIModel {
           },
         })
       );
-      return;
-    }
-
-    if (config.OPENAI_API_KEY) {
-      this.openAIClient = new OpenAIApi(new Configuration({ apiKey: config.OPENAI_API_KEY }));
-
       return;
     }
 


### PR DESCRIPTION
Users have been complaining about high latency spikes on KB responses, looks like this is due to the azure openai client. 

Some data I collected (notice in particular the large spikes in Azure that occur at seemingly random times):
<img width="1221" alt="Screenshot 2023-08-04 at 2 18 12 PM" src="https://github.com/voiceflow/general-runtime/assets/23105545/9badf0bf-d00d-4ebe-be0c-2ae72e939ff6">

Notes:
- The openAI table has fewer data points, I tested many more times afterwards and never experienced any large variance or spikes
- The `A` label stands for answer synthesis which generally takes longer than question synthesis `Q` due to response size. 
- Timeout was set to 30 seconds so requests were cut off after that amount of time. I have seen requests take 120 seconds and longer without the timeout.

This PR offers a temporary fix of simply prioritizing the regular openai client, which is a little slower generally but doesn't experience these large spikes.