### PR TITLE
[Merged by Bors] - fix: checking quota broken [bugfix] (LLM-000)

### DIFF
--- a/lib/services/billing.ts
+++ b/lib/services/billing.ts
@@ -36,8 +36,6 @@ export class BillingService extends AbstractManager {
   }
 
   async consumeQuota(workspaceID: string, quotaName: QuotaName, count: number) {
-    if (!(typeof count === 'number' && count > 0)) return null;
-
     const client = await this.getClient();
     if (!client) return null;
 

--- a/lib/services/runtime/handlers/utils/ai.ts
+++ b/lib/services/runtime/handlers/utils/ai.ts
@@ -105,11 +105,13 @@ export const consumeResources = async (
 
   const workspaceID = runtime.project?.teamID;
 
-  await runtime.services.billing
-    .consumeQuota(workspaceID, QuotaName.OPEN_API_TOKENS, tokens)
-    .catch((err: Error) =>
-      log.error(`[${reference}] Error consuming quota for workspace ${workspaceID}: ${log.vars({ err })}`)
-    );
+  if (typeof tokens === 'number' && tokens > 0) {
+    await runtime.services.billing
+      .consumeQuota(workspaceID, QuotaName.OPEN_API_TOKENS, tokens)
+      .catch((err: Error) =>
+        log.error(`[${reference}] Error consuming quota for workspace ${workspaceID}: ${log.vars({ err })}`)
+      );
+  }
 
   runtime.trace.debug(
     `__${reference}__ \`tokens: {total: ${tokens}, query: ${queryTokens}, answer: ${answerTokens}}\``


### PR DESCRIPTION
We had this line on `consumeQuota`: `if (!(typeof count === 'number' && count > 0)) return null;`

and `checkQuota` works by seeing if `await this.consumeQuota(workspaceID, quotaName, 0);` throws and error or not.

Right now it will just always return `null` so `checkQuota` is ALWAYS true. I moved that  filter one level higher and tested.