### PR TITLE
[Merged by Bors] - fix: log integration usage (PL-000)

### DIFF
--- a/runtime/lib/Handlers/integrations/index.ts
+++ b/runtime/lib/Handlers/integrations/index.ts
@@ -4,6 +4,7 @@ import axios from 'axios';
 import safeJSONStringify from 'json-stringify-safe';
 import _ from 'lodash';
 
+import log from '@/logger';
 import { HandlerFactory } from '@/runtime/lib/Handler';
 
 import { ENDPOINTS_MAP, resultMappings } from './utils';
@@ -38,6 +39,15 @@ const IntegrationsHandler: HandlerFactory<BaseNode.Integration.Node, Integration
       const { data } = await axios.post(
         `${integrationsEndpoint}${ENDPOINTS_MAP[selectedIntegration][selectedAction]}`,
         actionBodyData
+      );
+
+      log.warn(
+        log.vars({
+          integration: selectedIntegration,
+          action: selectedAction,
+          versionID: runtime.getVersionID(),
+          projectID: runtime.project?._id,
+        })
       );
 
       // map result data to variables

--- a/tests/runtime/lib/Handlers/integrations/integrations.unit.ts
+++ b/tests/runtime/lib/Handlers/integrations/integrations.unit.ts
@@ -122,7 +122,7 @@ describe('integrationsHandler unit tests', () => {
       const axiosPost = sinon.stub(axios, 'post').resolves(resultVariables);
 
       const node = { success_id: 'success-id', selected_integration: 'Zapier', selected_action: 'Start a Zap' };
-      const runtime = { trace: { debug: sinon.stub() } };
+      const runtime = { trace: { debug: sinon.stub() }, getVersionID: sinon.stub() };
       const variables = { getState: sinon.stub().returns({}), merge: sinon.stub() };
 
       expect(await integrationsHandler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(


### PR DESCRIPTION
I want to log and track any integration step (super legacy) usage so we can communicate to any affected users should we choose to turn it off, or think of a potential migration or something. 

This is important because I want to get rid of the `integrations` service.