### PR TITLE
[Merged by Bors] - feat: add workspaceId param to kb-python-retriever (NLU-836)

### DIFF
--- a/lib/services/runtime/handlers/utils/knowledgeBase/index.ts
+++ b/lib/services/runtime/handlers/utils/knowledgeBase/index.ts
@@ -61,6 +61,7 @@ export const fetchKnowledgeBase = async (
 
     const { data } = await axios.post<KnowledgeBaseResponse>(answerEndpoint, {
       projectID,
+      workspaceID,
       question,
       settings,
     });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Implements VF-836**

### Brief description. What is this change?

This change will ensure general-runtime provides workspace id as input to python version of kl-retriever.
This will then be used to determine if the specific workspace can be switched to qdrant for testing.
If everything works fine, the whole ENV can switch to qdrant. 

### Implementation details. How do you make this change?

Included the workspace id as input while calling the KB end point.


### Related PRs



### Checklist

- [ ] Breaking changes have been communicated, including:
    - This input param will be processed in KB python code
