### PR TITLE
[Merged by Bors] - feat: add new env names for kl-retriever (NLU-825)

### DIFF
--- a/lib/services/runtime/handlers/utils/knowledgeBase/index.ts
+++ b/lib/services/runtime/handlers/utils/knowledgeBase/index.ts
@@ -29,6 +29,7 @@ export interface KnowledgeBaseResponse {
 const FLAGGED_WORKSPACES_MAP = new Map<string, string[]>([
   [CloudEnv.Public, []],
   [CloudEnv.USBank, []],
+  [CloudEnv.VFTEST76, []],
 ]);
 
 const { KL_RETRIEVER_SERVICE_HOST: host, KL_RETRIEVER_SERVICE_PORT: port } = Config;

--- a/lib/services/runtime/handlers/utils/knowledgeBase/types.ts
+++ b/lib/services/runtime/handlers/utils/knowledgeBase/types.ts
@@ -1,4 +1,7 @@
 export enum CloudEnv {
   Public = 'public',
   USBank = 'usbank',
+  JPMC = 'jpmc',
+  CISCO = 'cisco',
+  VFTEST76 = 'vftest-76',
 }


### PR DESCRIPTION

**Fixes or implements NLU-825**

### Brief description. What is this change?
Add new cloud env names in general-runtime to access kl-retriever.

### Implementation details. How do you make this change?
New Types added for new envs.

