### PR TITLE
fix: add inference rate limit (PL-000)

### DIFF
--- a/backend/api/routers/nlu.ts
+++ b/backend/api/routers/nlu.ts
@@ -16,7 +16,7 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
       { kind: 'project', id: req.headers.projectID },
       { kind: 'version', id: req.headers.versionID },
     ]),
-    middlewares.rateLimit.versionConsume,
+    middlewares.inferenceLimit.consumeResource((req) => req.headers.authorization || req.cookies.auth_vf, 'inference'),
     controllers.nlu.inference
   );
 

--- a/lib/middlewares/index.ts
+++ b/lib/middlewares/index.ts
@@ -4,6 +4,7 @@ import { Config, MiddlewareGroup } from '@/types';
 import { FullServiceMap } from '../services';
 import Auth from './auth';
 import { BillingMiddleware } from './billing';
+import InferenceLimit from './inferenceLimit';
 import LLMLimit from './llmLimit';
 import Project from './project';
 import RateLimit from './rateLimit';
@@ -14,6 +15,7 @@ export interface MiddlewareMap {
   project: Project;
   rateLimit: RateLimit;
   llmLimit: LLMLimit;
+  inferenceLimit: InferenceLimit;
 }
 
 export interface MiddlewareClass<T = MiddlewareGroup> {
@@ -30,6 +32,7 @@ const buildMiddleware = (services: FullServiceMap, config: Config) => {
     project: new Project(services, config),
     rateLimit: new RateLimit(services, config),
     llmLimit: new LLMLimit(services, config),
+    inferenceLimit: new InferenceLimit(services, config),
   };
 
   // everything before this will be route-wrapped

--- a/lib/middlewares/inferenceLimit.ts
+++ b/lib/middlewares/inferenceLimit.ts
@@ -1,0 +1,51 @@
+import { RateLimitClient, RateLimitMiddleware } from '@voiceflow/backend-utils';
+import VError from '@voiceflow/verror';
+import { NextFunction, Response } from 'express';
+
+import { Request } from '@/types';
+
+import { AbstractMiddleware } from './utils';
+
+class InferenceLimit extends AbstractMiddleware {
+  private rateLimitClient: ReturnType<typeof RateLimitClient>;
+
+  private MAX_POINTS = 25;
+
+  constructor(...args: ConstructorParameters<typeof AbstractMiddleware>) {
+    super(...args);
+
+    this.rateLimitClient = RateLimitClient('general-runtime', args[0].redis, {
+      RATE_LIMITER_DURATION_PRIVATE: 5,
+      RATE_LIMITER_DURATION_PUBLIC: 5,
+      RATE_LIMITER_POINTS_PRIVATE: this.MAX_POINTS,
+      RATE_LIMITER_POINTS_PUBLIC: this.MAX_POINTS,
+    });
+  }
+
+  consumeResource = (getResource: (req: Request) => string | undefined, prefix?: string) => {
+    return async (req: Request, res: Response, next: NextFunction) => {
+      const resource = getResource(req);
+
+      if (!resource) {
+        res.sendStatus(401);
+        return;
+      }
+
+      try {
+        const rateLimiterRes = await this.rateLimitClient.private.consume(prefix ? `${prefix}:${resource}` : resource);
+
+        RateLimitMiddleware.setHeaders(res, rateLimiterRes, this.MAX_POINTS);
+      } catch (rateLimiterRes) {
+        res.setHeader('Retry-After', Math.floor(rateLimiterRes.msBeforeNext / 1000));
+
+        RateLimitMiddleware.setHeaders(res, rateLimiterRes, this.MAX_POINTS);
+
+        res.status(VError.HTTP_STATUS.TOO_MANY_REQUESTS).send('Too Many Requests');
+      }
+
+      next();
+    };
+  };
+}
+
+export default InferenceLimit;


### PR DESCRIPTION
This is not the best implementation, but today `general-runtime` was crashed by a client testing inference.

His version was a large document (1.1MB) and that would cause the `general-runtime` MongoDB connection to completely crash. This is because we were fetching the entire document for every inference call. 

I had to make an emergency patch https://github.com/voiceflow/general-runtime/commit/6d40e2589948a7e921cff8ebd882e70aaaed189f 

this more aggressive rate-limit should also prevent it from short circuiting. 
This is not the prettiest implementation but it is the same pattern as the llm rate limit. We'll need to do a larger rate limit refactor for general runtime in the near future.