### PR TITLE
[Merged by Bors] - feat: add tokens usage in public api KL query (NLU-849)

### DIFF
--- a/lib/controllers/test/index.ts
+++ b/lib/controllers/test/index.ts
@@ -127,7 +127,13 @@ class TestController extends AbstractController {
         );
     }
 
-    return { output: answer.output, chunks };
+    return {
+      output: answer.output,
+      chunks,
+      queryTokens: answer.queryTokens,
+      answerTokens: answer.answerTokens,
+      totalTokens: answer.tokens,
+    };
   }
 
   async testCompletion(


### PR DESCRIPTION
### Brief description. What is this change?

Add tokens usage in public api KB query

### Implementation details. How do you make this change?

In response to the KB query, in addition to the current `answer` and `chunks` fields, new fields `queryTokens`, `answerTokens`, `totalTokens` were added.

### Deployment Notes

Nothing special.

### Related JIRA ticket:

* [NLU-849](https://voiceflow.atlassian.net/browse/NLU-849)
* [PRD](https://www.notion.so/voiceflow/Add-token-details-to-response-body-in-KB-query-API-endpoint-273b9d5b9bcf4ea79252f54823914044)


[NLU-849]: https://voiceflow.atlassian.net/browse/NLU-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ