### PR TITLE
[Merged by Bors] - fix: carousel buttons [bugfix] (BUG-621)

### DIFF
--- a/lib/services/runtime/handlers/cardV2/cardV2.ts
+++ b/lib/services/runtime/handlers/cardV2/cardV2.ts
@@ -1,6 +1,7 @@
 import { AnyRecord, BaseNode, BaseText, BaseTrace } from '@voiceflow/base-types';
 import { deepVariableSubstitution, replaceVariables, sanitizeVariables } from '@voiceflow/common';
 import { VoiceflowNode } from '@voiceflow/voiceflow-types';
+import _cloneDeep from 'lodash/cloneDeep';
 
 import { Action, HandlerFactory } from '@/runtime';
 
@@ -72,7 +73,7 @@ export const CardV2Handler: HandlerFactory<VoiceflowNode.CardV2.Node, typeof uti
       const title = replaceVariables(node.title, variablesMap);
       const imageUrl = replaceVariables(node.imageUrl, variablesMap);
 
-      const buttons = node.buttons.map((button) => utils.deepVariableSubstitution(button, variablesMap));
+      const buttons = _cloneDeep(node.buttons).map((button) => utils.deepVariableSubstitution(button, variablesMap));
 
       if (title || buttons.length || description.text || imageUrl) {
         runtime.trace.addTrace<BaseNode.CardV2.TraceFrame>({

--- a/lib/services/runtime/handlers/carousel.ts
+++ b/lib/services/runtime/handlers/carousel.ts
@@ -1,5 +1,6 @@
 import { BaseNode, BaseTrace } from '@voiceflow/base-types';
 import { deepVariableSubstitution, replaceVariables, sanitizeVariables } from '@voiceflow/common';
+import _cloneDeep from 'lodash/cloneDeep';
 
 import { Action, HandlerFactory } from '@/runtime';
 
@@ -41,7 +42,7 @@ export const CarouselHandler: HandlerFactory<BaseNode.Carousel.Node, typeof util
             slate,
             text,
           },
-          buttons: card.buttons.map((button) => deepVariableSubstitution(button, variablesMap)),
+          buttons: _cloneDeep(card.buttons).map((button) => deepVariableSubstitution(button, variablesMap)),
         };
 
         if (item.title || item.imageUrl || item.description.text || item.buttons.length) {

--- a/runtime/lib/Handlers/api/index.ts
+++ b/runtime/lib/Handlers/api/index.ts
@@ -1,7 +1,7 @@
 import { BaseNode, RuntimeLogs } from '@voiceflow/base-types';
 import { deepVariableSubstitution } from '@voiceflow/common';
 import safeJSONStringify from 'json-stringify-safe';
-import _ from 'lodash';
+import _cloneDeep from 'lodash/cloneDeep';
 
 import Handler from '@/runtime/lib/Handler';
 
@@ -80,7 +80,7 @@ const APIHandler = (config: Partial<APIHandlerConfig>): Handler<BaseNode.Integra
   handle: async (node, runtime, variables) => {
     let nextId: string | null = null;
 
-    const actionBodyData = deepVariableSubstitution(_.cloneDeep(node.action_data), variables.getState()) as APINodeData;
+    const actionBodyData = deepVariableSubstitution(_cloneDeep(node.action_data), variables.getState()) as APINodeData;
 
     // override user agent
     const headers = actionBodyData.headers || [];

--- a/runtime/lib/Handlers/integrations/index.ts
+++ b/runtime/lib/Handlers/integrations/index.ts
@@ -2,7 +2,7 @@ import { BaseNode } from '@voiceflow/base-types';
 import { deepVariableSubstitution } from '@voiceflow/common';
 import axios from 'axios';
 import safeJSONStringify from 'json-stringify-safe';
-import _ from 'lodash';
+import _cloneDeep from 'lodash/cloneDeep';
 
 import log from '@/logger';
 import { HandlerFactory } from '@/runtime/lib/Handler';
@@ -34,7 +34,7 @@ const IntegrationsHandler: HandlerFactory<BaseNode.Integration.Node, Integration
     try {
       const { selected_action: selectedAction, selected_integration: selectedIntegration } = node;
 
-      const actionBodyData = deepVariableSubstitution(_.cloneDeep(node.action_data), variables.getState());
+      const actionBodyData = deepVariableSubstitution(_cloneDeep(node.action_data), variables.getState());
 
       const { data } = await axios.post(
         `${integrationsEndpoint}${ENDPOINTS_MAP[selectedIntegration][selectedAction]}`,


### PR DESCRIPTION
`deepVariableSubstitution` mutates the object. 
What was happening was the first call would mutate the object and write the variable into the `node.buttons`, and all subsequent calls would not see the variable temple `{button}`.

You can see for all other places we use `deepVariableSubstitution` we are also doing `cloneDeep`