### PR TITLE
[Merged by Bors] - fix: openai client layout (CT-000)

### DIFF
--- a/lib/clients/ai/ai-model.interface.ts
+++ b/lib/clients/ai/ai-model.interface.ts
@@ -17,7 +17,7 @@ export interface AIModelContext {
   projectID?: string;
 }
 export interface CompletionOptions {
-  context?: AIModelContext;
+  context: AIModelContext;
   retries?: number;
   retryDelay?: number;
 }

--- a/lib/clients/ai/ai-model.interface.ts
+++ b/lib/clients/ai/ai-model.interface.ts
@@ -12,14 +12,14 @@ export interface CompletionOutput {
   answerTokens: number;
 }
 
-export interface CompletionOptions {
-  retries?: number;
-  retryDelay?: number;
-}
-
 export interface AIModelContext {
   workspaceID?: string;
   projectID?: string;
+}
+export interface CompletionOptions {
+  context?: AIModelContext;
+  retries?: number;
+  retryDelay?: number;
 }
 
 export const GPT4_ABLE_PLAN = new Set([

--- a/lib/clients/ai/ai-model.ts
+++ b/lib/clients/ai/ai-model.ts
@@ -22,12 +22,12 @@ export abstract class AIModel {
   abstract generateCompletion(
     prompt: string,
     params: BaseUtils.ai.AIModelParams,
-    options?: CompletionOptions
+    options: CompletionOptions
   ): Promise<CompletionOutput | null>;
 
   abstract generateChatCompletion(
     messages: BaseUtils.ai.Message[],
     params: BaseUtils.ai.AIModelParams,
-    options?: CompletionOptions
+    options: CompletionOptions
   ): Promise<CompletionOutput | null>;
 }

--- a/lib/clients/ai/anthropic/anthropic.ts
+++ b/lib/clients/ai/anthropic/anthropic.ts
@@ -52,7 +52,7 @@ export abstract class AnthropicAIModel extends AIModel {
   async generateChatCompletion(
     messages: BaseUtils.ai.Message[],
     params: AIModelParams,
-    options?: CompletionOptions
+    options: CompletionOptions
   ): Promise<CompletionOutput | null> {
     let topSystem = '';
     if (messages[0]?.role === BaseUtils.ai.Role.SYSTEM) {
@@ -63,7 +63,7 @@ export abstract class AnthropicAIModel extends AIModel {
       (message) => `${AnthropicAIModel.RoleMap[message.role]} ${message.content}`
     )}${AI_PROMPT}`;
 
-    await this.contentModerationClient?.checkModeration(prompt, options?.context);
+    await this.contentModerationClient?.checkModeration(prompt, options.context);
 
     const queryTokens = this.calculateTokenUsage(prompt);
 

--- a/lib/clients/ai/anthropic/anthropic.ts
+++ b/lib/clients/ai/anthropic/anthropic.ts
@@ -6,7 +6,7 @@ import { AIModelParams } from '@voiceflow/base-types/build/cjs/utils/ai';
 import log from '@/logger';
 
 import { AIModel } from '../ai-model';
-import { AIModelContext, CompletionOutput } from '../ai-model.interface';
+import { CompletionOptions, CompletionOutput } from '../ai-model.interface';
 import { ContentModerationClient } from '../contentModeration';
 import { AnthropicConfig } from './anthropic.interface';
 import { AnthropicAIClient } from './api-client';
@@ -14,15 +14,14 @@ import { AnthropicAIClient } from './api-client';
 export abstract class AnthropicAIModel extends AIModel {
   protected abstract anthropicModel: string;
 
+  protected readonly client: AnthropicAIClient;
+
   protected maxTokens = 128;
 
-  constructor(
-    config: AnthropicConfig,
-    protected readonly client: AnthropicAIClient,
-    protected readonly contentModerationClient: ContentModerationClient,
-    protected context: AIModelContext
-  ) {
+  constructor(config: AnthropicConfig, protected readonly contentModerationClient: ContentModerationClient | null) {
     super(config);
+
+    this.client = new AnthropicAIClient(config);
   }
 
   static RoleMap = {
@@ -31,11 +30,15 @@ export abstract class AnthropicAIModel extends AIModel {
     [BaseUtils.ai.Role.ASSISTANT]: AI_PROMPT,
   };
 
-  generateCompletion(prompt: string, params: AIModelParams): Promise<CompletionOutput | null> {
+  generateCompletion(
+    prompt: string,
+    params: AIModelParams,
+    options: CompletionOptions
+  ): Promise<CompletionOutput | null> {
     const messages: BaseUtils.ai.Message[] = [{ role: BaseUtils.ai.Role.USER, content: prompt }];
     if (params.system) messages.unshift({ role: BaseUtils.ai.Role.SYSTEM, content: params.system });
 
-    return this.generateChatCompletion(messages, params);
+    return this.generateChatCompletion(messages, params, options);
   }
 
   /**
@@ -48,7 +51,8 @@ export abstract class AnthropicAIModel extends AIModel {
 
   async generateChatCompletion(
     messages: BaseUtils.ai.Message[],
-    params: AIModelParams
+    params: AIModelParams,
+    options?: CompletionOptions
   ): Promise<CompletionOutput | null> {
     let topSystem = '';
     if (messages[0]?.role === BaseUtils.ai.Role.SYSTEM) {
@@ -59,7 +63,7 @@ export abstract class AnthropicAIModel extends AIModel {
       (message) => `${AnthropicAIModel.RoleMap[message.role]} ${message.content}`
     )}${AI_PROMPT}`;
 
-    await this.contentModerationClient.checkModeration(prompt, this.context);
+    await this.contentModerationClient?.checkModeration(prompt, options?.context);
 
     const queryTokens = this.calculateTokenUsage(prompt);
 

--- a/lib/clients/ai/anthropic/api-client.ts
+++ b/lib/clients/ai/anthropic/api-client.ts
@@ -1,15 +1,11 @@
 import Client from '@anthropic-ai/sdk';
 
-import { Config } from '@/types';
+import { AnthropicConfig } from './anthropic.interface';
 
-import { AbstractClient } from '../../utils';
-
-export class AnthropicAIClient extends AbstractClient {
+export class AnthropicAIClient {
   client: Client;
 
-  constructor(config: Config) {
-    super(config);
-
+  constructor(config: AnthropicConfig) {
     if (!config.ANTHROPIC_API_KEY) {
       throw new Error(`Anthropic client not initialized`);
     }

--- a/lib/clients/ai/contentModeration/index.ts
+++ b/lib/clients/ai/contentModeration/index.ts
@@ -9,7 +9,7 @@ export abstract class ContentModerationClient extends AbstractClient {
     super(config);
   }
 
-  abstract checkModeration(input: string | string[], context: AIModelContext): Promise<void>;
+  abstract checkModeration(input: string | string[], context?: AIModelContext): Promise<void>;
 }
 
 export default ContentModerationClient;

--- a/lib/clients/ai/contentModeration/openai/openai.ts
+++ b/lib/clients/ai/contentModeration/openai/openai.ts
@@ -20,7 +20,7 @@ export class OpenAIModerationClient extends ContentModerationClient {
     }
   }
 
-  async checkModeration(input: string | string[], context: AIModelContext) {
+  async checkModeration(input: string | string[], context?: AIModelContext) {
     if (!this.openAIClient) return;
 
     if (!input?.length) return;

--- a/lib/clients/ai/index.ts
+++ b/lib/clients/ai/index.ts
@@ -1,5 +1,4 @@
 import { BaseUtils } from '@voiceflow/base-types';
-import { match } from 'ts-pattern';
 
 import log from '@/logger';
 import type { Config } from '@/types';
@@ -7,14 +6,10 @@ import type { Config } from '@/types';
 import Unleash from '../unleash';
 import { AbstractClient } from '../utils';
 import { AIModel } from './ai-model';
-import { AIModelContext } from './ai-model.interface';
-import { AnthropicAIClient } from './anthropic/api-client';
 import { ClaudeV1 } from './anthropic/claude_v1';
 import { ClaudeV1Instant } from './anthropic/claude_v1_instant';
 import { ClaudeV2 } from './anthropic/claude_v2';
-import ContentModerationClient from './contentModeration';
 import { OpenAIModerationClient } from './contentModeration/openai/openai';
-import { OpenAIClient } from './openai/api-client';
 import { GPT3 } from './openai/gpt3';
 import { GPT3_5 } from './openai/gpt3_5';
 import { GPT4 } from './openai/gpt4';
@@ -22,50 +17,37 @@ import { GPT4 } from './openai/gpt4';
 export class AIClient extends AbstractClient {
   private DEFAULT_MODEL = BaseUtils.ai.GPT_MODEL.GPT_3_5_turbo;
 
-  private openAIClient: OpenAIClient;
-
-  private anthropicClient: AnthropicAIClient;
-
-  private contentModerationClient: ContentModerationClient;
+  models: Partial<Record<BaseUtils.ai.GPT_MODEL, AIModel>> = {};
 
   constructor(config: Config, unleash: Unleash) {
     super(config);
 
-    this.openAIClient = new OpenAIClient(config);
-    this.anthropicClient = new AnthropicAIClient(config);
-    this.contentModerationClient = new OpenAIModerationClient(config, unleash);
+    const contentModerationClient = new OpenAIModerationClient(config, unleash);
+
+    const setModel = (modelName: BaseUtils.ai.GPT_MODEL, getModel: () => AIModel) => {
+      try {
+        this.models[modelName] = getModel();
+      } catch (error) {
+        log.warn(`failed to initialize ${modelName} ${log.vars({ error })}`);
+      }
+    };
+
+    setModel(BaseUtils.ai.GPT_MODEL.DaVinci_003, () => new GPT3(config, contentModerationClient));
+    setModel(BaseUtils.ai.GPT_MODEL.GPT_3_5_turbo, () => new GPT3_5(config, contentModerationClient));
+    setModel(BaseUtils.ai.GPT_MODEL.GPT_4, () => new GPT4(config, contentModerationClient));
+    setModel(BaseUtils.ai.GPT_MODEL.CLAUDE_V1, () => new ClaudeV1(config, contentModerationClient));
+    setModel(BaseUtils.ai.GPT_MODEL.CLAUDE_V2, () => new ClaudeV2(config, contentModerationClient));
+    setModel(BaseUtils.ai.GPT_MODEL.CLAUDE_INSTANT_V1, () => new ClaudeV1Instant(config, contentModerationClient));
   }
 
-  get(modelName: BaseUtils.ai.GPT_MODEL, context: AIModelContext): AIModel | null {
-    return match(modelName ?? this.DEFAULT_MODEL)
-      .with(
-        BaseUtils.ai.GPT_MODEL.DaVinci_003,
-        () => new GPT3(this.config, this.openAIClient, this.contentModerationClient, context)
-      )
-      .with(
-        BaseUtils.ai.GPT_MODEL.GPT_3_5_turbo,
-        () => new GPT3_5(this.config, this.openAIClient, this.contentModerationClient, context)
-      )
-      .with(
-        BaseUtils.ai.GPT_MODEL.GPT_4,
-        () => new GPT4(this.config, this.openAIClient, this.contentModerationClient, context)
-      )
-      .with(
-        BaseUtils.ai.GPT_MODEL.CLAUDE_V1,
-        () => new ClaudeV1(this.config, this.anthropicClient, this.contentModerationClient, context)
-      )
-      .with(
-        BaseUtils.ai.GPT_MODEL.CLAUDE_V2,
-        () => new ClaudeV2(this.config, this.anthropicClient, this.contentModerationClient, context)
-      )
-      .with(
-        BaseUtils.ai.GPT_MODEL.CLAUDE_INSTANT_V1,
-        () => new ClaudeV1Instant(this.config, this.anthropicClient, this.contentModerationClient, context)
-      )
-      .otherwise(() => {
-        log.warn(`no model found for ${modelName ?? this.DEFAULT_MODEL}`);
-        return null;
-      });
+  get(modelName: BaseUtils.ai.GPT_MODEL = this.DEFAULT_MODEL): AIModel | null {
+    const model = this.models[modelName];
+
+    if (!model) {
+      log.warn(`no model found for ${modelName}`);
+    }
+
+    return model ?? null;
   }
 }
 

--- a/lib/clients/ai/openai/gpt.ts
+++ b/lib/clients/ai/openai/gpt.ts
@@ -4,12 +4,13 @@ import { ChatCompletionRequestMessageRoleEnum } from '@voiceflow/openai';
 import { Config } from '@/types';
 
 import { AIModel } from '../ai-model';
-import { AIModelContext } from '../ai-model.interface';
 import { ContentModerationClient } from '../contentModeration';
 import { OpenAIClient } from './api-client';
 
 export abstract class GPTAIModel extends AIModel {
   protected abstract gptModelName: string;
+
+  protected readonly client: OpenAIClient;
 
   static RoleMapping = {
     [BaseUtils.ai.Role.ASSISTANT]: ChatCompletionRequestMessageRoleEnum.Assistant,
@@ -17,13 +18,9 @@ export abstract class GPTAIModel extends AIModel {
     [BaseUtils.ai.Role.USER]: ChatCompletionRequestMessageRoleEnum.User,
   };
 
-  constructor(
-    config: Config,
-    protected readonly client: OpenAIClient,
-    protected readonly contentModerationClient: ContentModerationClient,
-    protected context: AIModelContext
-  ) {
+  constructor(config: Config, protected readonly contentModerationClient: ContentModerationClient | null) {
     super(config);
+    this.client = new OpenAIClient(config);
   }
 
   protected calculateTokenMultiplier(tokens: number): number {

--- a/lib/clients/ai/openai/gpt3.ts
+++ b/lib/clients/ai/openai/gpt3.ts
@@ -3,6 +3,7 @@ import { AIModelParams } from '@voiceflow/base-types/build/cjs/utils/ai';
 
 import log from '@/logger';
 
+import { CompletionOptions } from '../ai-model.interface';
 import { GPTAIModel } from './gpt';
 
 export class GPT3 extends GPTAIModel {
@@ -30,8 +31,8 @@ export class GPT3 extends GPTAIModel {
     return `${transcript.trim()}\nuser: `;
   }
 
-  async generateCompletion(prompt: string, params: AIModelParams) {
-    await this.contentModerationClient.checkModeration(prompt, this.context);
+  async generateCompletion(prompt: string, params: AIModelParams, options?: CompletionOptions) {
+    await this.contentModerationClient?.checkModeration(prompt, options?.context);
 
     const result = await this.client.client
       .createCompletion(
@@ -62,7 +63,7 @@ export class GPT3 extends GPTAIModel {
   }
 
   // turn messages into a singular prompt
-  async generateChatCompletion(messages: BaseUtils.ai.Message[], params: AIModelParams) {
-    return this.generateCompletion(GPT3.messagesToPrompt(messages), params);
+  async generateChatCompletion(messages: BaseUtils.ai.Message[], params: AIModelParams, options?: CompletionOptions) {
+    return this.generateCompletion(GPT3.messagesToPrompt(messages), params, options);
   }
 }

--- a/lib/clients/ai/openai/gpt3.ts
+++ b/lib/clients/ai/openai/gpt3.ts
@@ -31,8 +31,8 @@ export class GPT3 extends GPTAIModel {
     return `${transcript.trim()}\nuser: `;
   }
 
-  async generateCompletion(prompt: string, params: AIModelParams, options?: CompletionOptions) {
-    await this.contentModerationClient?.checkModeration(prompt, options?.context);
+  async generateCompletion(prompt: string, params: AIModelParams, options: CompletionOptions) {
+    await this.contentModerationClient?.checkModeration(prompt, options.context);
 
     const result = await this.client.client
       .createCompletion(
@@ -63,7 +63,7 @@ export class GPT3 extends GPTAIModel {
   }
 
   // turn messages into a singular prompt
-  async generateChatCompletion(messages: BaseUtils.ai.Message[], params: AIModelParams, options?: CompletionOptions) {
+  async generateChatCompletion(messages: BaseUtils.ai.Message[], params: AIModelParams, options: CompletionOptions) {
     return this.generateCompletion(GPT3.messagesToPrompt(messages), params, options);
   }
 }

--- a/lib/clients/ai/openai/gpt3_5.ts
+++ b/lib/clients/ai/openai/gpt3_5.ts
@@ -12,7 +12,7 @@ export class GPT3_5 extends GPTAIModel {
 
   protected gptModelName = 'gpt-3.5-turbo';
 
-  async generateCompletion(prompt: string, params: AIModelParams, options?: CompletionOptions) {
+  async generateCompletion(prompt: string, params: AIModelParams, options: CompletionOptions) {
     const messages: BaseUtils.ai.Message[] = [{ role: BaseUtils.ai.Role.USER, content: prompt }];
     if (params.system) messages.unshift({ role: BaseUtils.ai.Role.SYSTEM, content: params.system });
 
@@ -22,12 +22,12 @@ export class GPT3_5 extends GPTAIModel {
   async generateChatCompletion(
     messages: BaseUtils.ai.Message[],
     params: AIModelParams,
-    options?: CompletionOptions,
+    options: CompletionOptions,
     client = this.client.client
   ): Promise<CompletionOutput | null> {
     await this.contentModerationClient?.checkModeration(
       messages.map((message) => message.content),
-      options?.context
+      options.context
     );
 
     const resolveCompletion = () =>

--- a/lib/clients/ai/openai/gpt3_5.ts
+++ b/lib/clients/ai/openai/gpt3_5.ts
@@ -25,9 +25,9 @@ export class GPT3_5 extends GPTAIModel {
     options?: CompletionOptions,
     client = this.client.client
   ): Promise<CompletionOutput | null> {
-    await this.contentModerationClient.checkModeration(
+    await this.contentModerationClient?.checkModeration(
       messages.map((message) => message.content),
-      this.context
+      options?.context
     );
 
     const resolveCompletion = () =>

--- a/lib/clients/ai/openai/gpt4.ts
+++ b/lib/clients/ai/openai/gpt4.ts
@@ -4,7 +4,7 @@ import { AIModelParams } from '@voiceflow/base-types/build/cjs/utils/ai';
 import log from '@/logger';
 import { Config } from '@/types';
 
-import { AIModelContext } from '../ai-model.interface';
+import { CompletionOptions } from '../ai-model.interface';
 import { ContentModerationClient } from '../contentModeration';
 import { OpenAIClient } from './api-client';
 import { GPTAIModel } from './gpt';
@@ -16,26 +16,25 @@ export class GPT4 extends GPTAIModel {
 
   protected gptModelName = 'gpt-4';
 
-  constructor(
-    config: Config,
-    protected readonly client: OpenAIClient,
-    protected readonly contentModerationClient: ContentModerationClient,
-    protected context: AIModelContext
-  ) {
-    super(config, client, contentModerationClient, context);
+  protected readonly client: OpenAIClient;
+
+  constructor(config: Config, protected readonly contentModerationClient: ContentModerationClient | null) {
+    super(config, contentModerationClient);
+
+    this.client = new OpenAIClient(config);
   }
 
-  async generateCompletion(prompt: string, params: AIModelParams) {
+  async generateCompletion(prompt: string, params: AIModelParams, options?: CompletionOptions) {
     const messages: BaseUtils.ai.Message[] = [{ role: BaseUtils.ai.Role.USER, content: prompt }];
     if (params.system) messages.unshift({ role: BaseUtils.ai.Role.SYSTEM, content: params.system });
 
-    return this.generateChatCompletion(messages, params);
+    return this.generateChatCompletion(messages, params, options);
   }
 
-  async generateChatCompletion(messages: BaseUtils.ai.Message[], params: AIModelParams) {
-    await this.contentModerationClient.checkModeration(
+  async generateChatCompletion(messages: BaseUtils.ai.Message[], params: AIModelParams, options?: CompletionOptions) {
+    await this.contentModerationClient?.checkModeration(
       messages.map((message) => message.content),
-      this.context
+      options?.context
     );
 
     // we dont have access to GPT 4 on Azure yet, use OpenAI API instead

--- a/lib/clients/ai/openai/gpt4.ts
+++ b/lib/clients/ai/openai/gpt4.ts
@@ -24,17 +24,17 @@ export class GPT4 extends GPTAIModel {
     this.client = new OpenAIClient(config);
   }
 
-  async generateCompletion(prompt: string, params: AIModelParams, options?: CompletionOptions) {
+  async generateCompletion(prompt: string, params: AIModelParams, options: CompletionOptions) {
     const messages: BaseUtils.ai.Message[] = [{ role: BaseUtils.ai.Role.USER, content: prompt }];
     if (params.system) messages.unshift({ role: BaseUtils.ai.Role.SYSTEM, content: params.system });
 
     return this.generateChatCompletion(messages, params, options);
   }
 
-  async generateChatCompletion(messages: BaseUtils.ai.Message[], params: AIModelParams, options?: CompletionOptions) {
+  async generateChatCompletion(messages: BaseUtils.ai.Message[], params: AIModelParams, options: CompletionOptions) {
     await this.contentModerationClient?.checkModeration(
       messages.map((message) => message.content),
-      options?.context
+      options.context
     );
 
     // we dont have access to GPT 4 on Azure yet, use OpenAI API instead

--- a/lib/controllers/test/index.ts
+++ b/lib/controllers/test/index.ts
@@ -164,12 +164,17 @@ class TestController extends AbstractController {
   async testCompletion(
     req: Request<BaseUtils.ai.AIModelParams & BaseUtils.ai.AIContextParams & { workspaceID: string }>
   ) {
-    const model = this.services.ai.get(req.body.model, { workspaceID: req.params.workspaceID });
+    const model = this.services.ai.get(req.body.model);
 
     if (!model) throw new VError('invalid model', VError.HTTP_STATUS.BAD_REQUEST);
     if (typeof req.body.prompt !== 'string') throw new VError('invalid prompt', VError.HTTP_STATUS.BAD_REQUEST);
 
-    const { output, tokens } = await fetchPrompt(req.body, model);
+    const { output, tokens } = await fetchPrompt(
+      req.body,
+      model,
+      {},
+      { context: { workspaceID: req.params.workspaceID } }
+    );
 
     if (typeof tokens === 'number' && tokens > 0) {
       await this.services.billing

--- a/lib/controllers/test/index.ts
+++ b/lib/controllers/test/index.ts
@@ -172,8 +172,8 @@ class TestController extends AbstractController {
     const { output, tokens } = await fetchPrompt(
       req.body,
       model,
-      {},
-      { context: { workspaceID: req.params.workspaceID } }
+      { context: { workspaceID: req.params.workspaceID } },
+      {}
     );
 
     if (typeof tokens === 'number' && tokens > 0) {

--- a/lib/services/aiSynthesis.ts
+++ b/lib/services/aiSynthesis.ts
@@ -91,10 +91,16 @@ class AISynthesis extends AbstractManager {
         },
       ];
 
-      response = await fetchChat({ ...options, messages }, generativeModel, variables, {
-        retries: this.DEFAULT_ANSWER_SYNTHESIS_RETRIES,
-        retryDelay: this.DEFAULT_ANSWER_SYNTHESIS_RETRY_DELAY_MS,
-      });
+      response = await fetchChat(
+        { ...options, messages },
+        generativeModel,
+        {
+          retries: this.DEFAULT_ANSWER_SYNTHESIS_RETRIES,
+          retryDelay: this.DEFAULT_ANSWER_SYNTHESIS_RETRY_DELAY_MS,
+          context,
+        },
+        variables
+      );
     } else if ([BaseUtils.ai.GPT_MODEL.DaVinci_003].includes(model)) {
       // for GPT-3 completion model
       const prompt = dedent`
@@ -107,8 +113,8 @@ class AISynthesis extends AbstractManager {
       response = await fetchPrompt(
         { ...options, prompt, mode: BaseUtils.ai.PROMPT_MODE.PROMPT },
         generativeModel,
-        variables,
-        { context }
+        { context },
+        variables
       );
     } else if (
       [
@@ -130,8 +136,8 @@ class AISynthesis extends AbstractManager {
       response = await fetchPrompt(
         { ...options, prompt, mode: BaseUtils.ai.PROMPT_MODE.PROMPT },
         generativeModel,
-        variables,
-        { context }
+        { context },
+        variables
       );
     }
 
@@ -205,11 +211,16 @@ class AISynthesis extends AbstractManager {
     ];
 
     const generativeModel = this.services.ai.get(options.model);
-    return fetchChat({ ...options, messages: questionMessages }, generativeModel, variables, {
-      context,
-      retries: this.DEFAULT_ANSWER_SYNTHESIS_RETRIES,
-      retryDelay: this.DEFAULT_ANSWER_SYNTHESIS_RETRY_DELAY_MS,
-    });
+    return fetchChat(
+      { ...options, messages: questionMessages },
+      generativeModel,
+      {
+        context,
+        retries: this.DEFAULT_ANSWER_SYNTHESIS_RETRIES,
+        retryDelay: this.DEFAULT_ANSWER_SYNTHESIS_RETRY_DELAY_MS,
+      },
+      variables
+    );
   }
 
   async promptSynthesis(
@@ -381,11 +392,16 @@ class AISynthesis extends AbstractManager {
     ];
 
     const generativeModel = this.services.ai.get(options.model);
-    return fetchChat({ ...options, messages: questionMessages }, generativeModel, variables, {
-      context,
-      retries: this.DEFAULT_QUESTION_SYNTHESIS_RETRIES,
-      retryDelay: this.DEFAULT_QUESTION_SYNTHESIS_RETRY_DELAY_MS,
-    });
+    return fetchChat(
+      { ...options, messages: questionMessages },
+      generativeModel,
+      {
+        context,
+        retries: this.DEFAULT_QUESTION_SYNTHESIS_RETRIES,
+        retryDelay: this.DEFAULT_QUESTION_SYNTHESIS_RETRY_DELAY_MS,
+      },
+      variables
+    );
   }
 }
 

--- a/lib/services/aiSynthesis.ts
+++ b/lib/services/aiSynthesis.ts
@@ -61,7 +61,7 @@ class AISynthesis extends AbstractManager {
   }): Promise<AIResponse | null> {
     let response: AIResponse = EMPTY_AI_RESPONSE;
 
-    const generativeModel = this.services.ai.get(model, context);
+    const generativeModel = this.services.ai.get(model);
 
     const systemWithTime = `${system}\n\n${getCurrentTime()}`.trim();
 
@@ -84,7 +84,7 @@ class AISynthesis extends AbstractManager {
           role: BaseUtils.ai.Role.USER,
           content: dedent`
             Answer the following question using ONLY the provided <context>, if you don't know the answer say exactly "NOT_FOUND".
-  
+
             Question:
             ${question}
           `,
@@ -101,13 +101,14 @@ class AISynthesis extends AbstractManager {
         <context>
           ${synthesisContext}
         </context>
-  
+
         If you don't know the answer say exactly "NOT_FOUND".\n\nQ: ${question}\nA: `;
 
       response = await fetchPrompt(
         { ...options, prompt, mode: BaseUtils.ai.PROMPT_MODE.PROMPT },
         generativeModel,
-        variables
+        variables,
+        { context }
       );
     } else if (
       [
@@ -120,16 +121,17 @@ class AISynthesis extends AbstractManager {
         <information>
           ${synthesisContext}
         </information>
-  
+
         If the question is not relevant to the provided <information>, print("NOT_FOUND") and return.
         Otherwise, you may - very concisely - answer the user using only the relevant <information>.
-  
+
         <question>${question}</question>`;
 
       response = await fetchPrompt(
         { ...options, prompt, mode: BaseUtils.ai.PROMPT_MODE.PROMPT },
         generativeModel,
-        variables
+        variables,
+        { context }
       );
     }
 
@@ -176,22 +178,22 @@ class AISynthesis extends AbstractManager {
       <Conversation_History>
         ${history}
       </Conversation_History>
-  
+
       <Knowledge>
         ${knowledge}
       </Knowledge>
-  
+
       <Instructions>${prompt}</Instructions>
-  
+
       Using <Conversation_History> as context, fulfill <Instructions> ONLY using information found in <Knowledge>.`;
     } else {
       content = dedent`
       <Knowledge>
         ${knowledge}
       </Knowledge>
-  
+
       <Instructions>${prompt}</Instructions>
-  
+
       Fulfill <Instructions> ONLY using information found in <Knowledge>.`;
     }
 
@@ -202,8 +204,9 @@ class AISynthesis extends AbstractManager {
       },
     ];
 
-    const generativeModel = this.services.ai.get(options.model, context);
+    const generativeModel = this.services.ai.get(options.model);
     return fetchChat({ ...options, messages: questionMessages }, generativeModel, variables, {
+      context,
       retries: this.DEFAULT_ANSWER_SYNTHESIS_RETRIES,
       retryDelay: this.DEFAULT_ANSWER_SYNTHESIS_RETRY_DELAY_MS,
     });
@@ -311,7 +314,7 @@ class AISynthesis extends AbstractManager {
         });
       }
 
-      const generativeModel = this.services.ai.get(BaseUtils.ai.GPT_MODEL.GPT_3_5_turbo, context);
+      const generativeModel = this.services.ai.get(BaseUtils.ai.GPT_MODEL.GPT_3_5_turbo);
       const response = await fetchChat(
         {
           temperature: 0.1,
@@ -321,6 +324,7 @@ class AISynthesis extends AbstractManager {
         },
         generativeModel,
         {
+          context,
           retries: this.DEFAULT_QUESTION_SYNTHESIS_RETRIES,
           retryDelay: this.DEFAULT_QUESTION_SYNTHESIS_RETRY_DELAY_MS,
         }
@@ -358,14 +362,14 @@ class AISynthesis extends AbstractManager {
       <Conversation_History>
         ${history}
       </Conversation_History>
-  
+
       <Instructions>${prompt}</Instructions>
-  
+
       Using <Conversation_History> as context, you are searching a text knowledge base to fulfill <Instructions>. Write a sentence to search against.`;
     } else {
       content = dedent`
       <Instructions>${prompt}</Instructions>
-  
+
       You can search a text knowledge base to fulfill <Instructions>. Write a sentence to search against.`;
     }
 
@@ -376,8 +380,9 @@ class AISynthesis extends AbstractManager {
       },
     ];
 
-    const generativeModel = this.services.ai.get(options.model, context);
+    const generativeModel = this.services.ai.get(options.model);
     return fetchChat({ ...options, messages: questionMessages }, generativeModel, variables, {
+      context,
       retries: this.DEFAULT_QUESTION_SYNTHESIS_RETRIES,
       retryDelay: this.DEFAULT_QUESTION_SYNTHESIS_RETRY_DELAY_MS,
     });

--- a/lib/services/runtime/handlers/aiResponse.ts
+++ b/lib/services/runtime/handlers/aiResponse.ts
@@ -17,11 +17,8 @@ const AIResponseHandler: HandlerFactory<VoiceNode.AIResponse.Node> = () => ({
     const nextID = node.nextId ?? null;
     const projectID = runtime.project?._id;
     const workspaceID = runtime.project?.teamID;
-    const generativeModel = runtime.services.ai.get(node.model, { projectID, workspaceID });
-    const kbModel = runtime.services.ai.get(runtime.project?.knowledgeBase?.settings?.summarization.model, {
-      projectID,
-      workspaceID,
-    });
+    const generativeModel = runtime.services.ai.get(node.model);
+    const kbModel = runtime.services.ai.get(runtime.project?.knowledgeBase?.settings?.summarization.model);
 
     if (!(await checkTokens(runtime, node.type))) {
       addOutputTrace(
@@ -78,7 +75,9 @@ const AIResponseHandler: HandlerFactory<VoiceNode.AIResponse.Node> = () => ({
           answerTokens: 0,
         };
       } else {
-        response = await fetchPrompt(node, generativeModel, variables.getState());
+        response = await fetchPrompt(node, generativeModel, variables.getState(), {
+          context: { projectID, workspaceID },
+        });
       }
 
       await consumeResources('AI Response', runtime, generativeModel, response);

--- a/lib/services/runtime/handlers/aiSet.ts
+++ b/lib/services/runtime/handlers/aiSet.ts
@@ -13,7 +13,7 @@ const AISetHandler: HandlerFactory<BaseNode.AISet.Node> = () => ({
     const nextID = node.nextId ?? null;
     const workspaceID = runtime.project?.teamID;
     const projectID = runtime.project?._id;
-    const generativeModel = runtime.services.ai.get(node.model, { projectID, workspaceID });
+    const generativeModel = runtime.services.ai.get(node.model);
     const kbModel = runtime.services.ai.get(runtime.project?.knowledgeBase?.settings?.summarization.model, {
       projectID,
       workspaceID,
@@ -62,7 +62,9 @@ const AISetHandler: HandlerFactory<BaseNode.AISet.Node> = () => ({
                 return emptyResult;
               }
 
-              const response = await fetchPrompt({ ...node, prompt, mode }, generativeModel, variables.getState());
+              const response = await fetchPrompt({ ...node, prompt, mode }, generativeModel, variables.getState(), {
+                context: { projectID, workspaceID },
+              });
               const tokens = response?.tokens ?? 0;
               const queryTokens = response?.queryTokens ?? 0;
               const answerTokens = response?.answerTokens ?? 0;

--- a/lib/services/runtime/handlers/utils/ai.ts
+++ b/lib/services/runtime/handlers/utils/ai.ts
@@ -38,8 +38,8 @@ export const EMPTY_AI_RESPONSE: AIResponse = {
 export const fetchChat = async (
   params: BaseUtils.ai.AIModelParams & { messages: BaseUtils.ai.Message[] },
   model: AIModel | null,
-  variablesState: Record<string, unknown> = {},
-  options: CompletionOptions = {}
+  options: CompletionOptions,
+  variablesState: Record<string, unknown> = {}
 ): Promise<AIResponse> => {
   if (!model) return EMPTY_AI_RESPONSE;
 
@@ -61,8 +61,8 @@ export const fetchChat = async (
 export const fetchPrompt = async (
   params: BaseUtils.ai.AIModelParams & { mode: BaseUtils.ai.PROMPT_MODE; prompt: string },
   model: AIModel | null,
-  variablesState: Record<string, unknown> = {},
-  options: CompletionOptions = {}
+  options: CompletionOptions,
+  variablesState: Record<string, unknown> = {}
 ): Promise<AIResponse> => {
   if (!model) return EMPTY_AI_RESPONSE;
 

--- a/lib/services/runtime/handlers/utils/generativeNoMatch.ts
+++ b/lib/services/runtime/handlers/utils/generativeNoMatch.ts
@@ -34,11 +34,13 @@ export const generateNoMatch = async (
     },
   ];
 
-  const model = runtime.services.ai.get(context.model, {
-    projectID: runtime.project?._id,
-    workspaceID: runtime.project?.teamID,
+  const model = runtime.services.ai.get(context.model);
+  const response = await fetchChat({ ...context, messages }, model, {
+    context: {
+      projectID: runtime.project?._id,
+      workspaceID: runtime.project?.teamID,
+    },
   });
-  const response = await fetchChat({ ...context, messages }, model);
   if (!response.output) return null;
 
   return {


### PR DESCRIPTION
Overall the business need is to be able to turn off models based on ENV VAR configuration.
For example if no Anthropic API Key is given, runtime should still work, but any calls to "anthropic" will fail.
Today the whole thing will crash if any LLM env vars are not set.

So ultimately what is happening here is we are moving `AIModelContext` as part of `CompletionOptions` which is only triggered on calls to `getCompletion` or `getChatCompletion`.

So instead of injecting the `{ workspaceID, projectID }` as part of the GET to the model, it is now being passed when we make the actual calls. I think this makes sense because the context is part of the call and relevant to moderation, but has nothing to do with the model itself.

On the models side, we are no longer instantiating a new client every time someone calls `services.ai.get(model)` - but rather all models are instantiated at initalization and there is a fixed pool.
The clients are now living inside the model instead of being decoupled. 
