### PR TITLE
fix: add openai path

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -111,6 +111,7 @@ const CONFIG: Config = {
   AZURE_GPT35_DEPLOYMENTS: getOptionalProcessEnv('AZURE_GPT35_DEPLOYMENTS') || null,
 
   OPENAI_API_KEY: getOptionalProcessEnv('OPENAI_API_KEY') || null,
+  OPENAI_API_ENDPOINT: getOptionalProcessEnv('OPENAI_API_ENDPOINT') || null,
 
   ANTHROPIC_API_KEY: getOptionalProcessEnv('ANTHROPIC_API_KEY') || null,
 

--- a/lib/clients/ai/contentModeration/openai/openai.ts
+++ b/lib/clients/ai/contentModeration/openai/openai.ts
@@ -16,11 +16,14 @@ export class OpenAIModerationClient extends ContentModerationClient {
   constructor(config: Config, unleashClient: UnleashClient) {
     super(config, unleashClient);
     if (config.OPENAI_API_KEY) {
-      this.openAIClient = new OpenAIApi(new Configuration({ apiKey: config.OPENAI_API_KEY }));
+      this.openAIClient = new OpenAIApi(
+        new Configuration({ apiKey: config.OPENAI_API_KEY, basePath: config.OPENAI_API_ENDPOINT ?? undefined })
+      );
     }
   }
 
   async checkModeration(input: string | string[], context?: AIModelContext) {
+    if (!this.unleashClient.isEnabled(FeatureFlag.LLM_MODERATION_FAIL_FF)) return;
     if (!this.openAIClient) return;
 
     if (!input?.length) return;
@@ -53,7 +56,7 @@ export class OpenAIModerationClient extends ContentModerationClient {
       );
     });
 
-    if (this.unleashClient.isEnabled(FeatureFlag.LLM_MODERATION_FAIL_FF) && failedModeration.length) {
+    if (failedModeration.length) {
       throw new ContentModerationError(failedModeration);
     }
   }

--- a/lib/clients/ai/openai/api-client.ts
+++ b/lib/clients/ai/openai/api-client.ts
@@ -29,7 +29,9 @@ export class OpenAIClient extends AbstractClient {
     }
 
     if (isOpenAIGPTConfig(config)) {
-      this.openAIClient = new OpenAIApi(new Configuration({ apiKey: config.OPENAI_API_KEY }));
+      this.openAIClient = new OpenAIApi(
+        new Configuration({ apiKey: config.OPENAI_API_KEY, basePath: config.OPENAI_API_ENDPOINT || undefined })
+      );
     }
 
     if (!this.openAIClient && !this.azureClient) {

--- a/types.ts
+++ b/types.ts
@@ -91,6 +91,7 @@ export interface Config extends RateLimitConfig {
   AZURE_GPT35_DEPLOYMENTS: string | null;
 
   OPENAI_API_KEY: string | null;
+  OPENAI_API_ENDPOINT: string | null;
 
   ANTHROPIC_API_KEY: string | null;
 


### PR DESCRIPTION
Add a new (optional) `OPENAI_API_ENDPOINT` env var. If not set the client just uses the default OpenAI API so this is very low risk.

We can use the FF to disable moderation for a private cloud. Just moved it up higher. It's turned on for 100% of users right now.