### PR TITLE
[Merged by Bors] - feat: check that tags exist before make a query (NLU-920)

### DIFF
--- a/lib/controllers/test/index.ts
+++ b/lib/controllers/test/index.ts
@@ -58,8 +58,8 @@ class TestController extends AbstractController {
   static generateTagLabelMap(existingTags: Record<string, BaseModels.Project.KBTag>): Record<string, string> {
     const result: Record<string, string> = {};
 
-    Object.keys(existingTags).forEach((tagID) => {
-      result[existingTags[tagID].label] = tagID;
+    Object.entries(existingTags).forEach(([tagID, tag]) => {
+      result[tag.label] = tagID;
     });
 
     return result;
@@ -67,14 +67,7 @@ class TestController extends AbstractController {
 
   static checkKBTagLabelsExists(tagLabelMap: Record<string, string>, tagLabels: string[]) {
     // check that KB tag labels exists, this is not atomic but it prevents a class of bugs
-    const nonExistingTags: string[] = [];
-
-    tagLabels.forEach((label) => {
-      const tagID: string | null | undefined = tagLabelMap?.[label];
-      if (!tagID) {
-        nonExistingTags.push(label);
-      }
-    });
+    const nonExistingTags = tagLabels.filter((label) => !tagLabelMap[label]);
 
     if (nonExistingTags.length > 0) {
       const formattedTags = nonExistingTags.map((tag) => `\`${tag}\``).join(', ');


### PR DESCRIPTION
### Brief description. What is this change?

Check that tags exist before create a doc or attach tags to doc

### Implementation details. How do you make this change?

Now we have implicit behavior, when the user provides a list of tag labels, we convert them into tag objects and if there are no tags with such labels, then we skip them and that’s it. It turns out that the user receives a response with a status of 200, but we may not add anything to his tags. This change will throw a 404 response to the user so that such tags do not exist and this will prompt him to either create a tag or change the label.

### Related PRs

* https://github.com/voiceflow/creator-api/pull/1334