### PR TITLE
[Merged by Bors] - feat: add segment call if user use kb tags filter (NLU-928)

### DIFF
--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -73,6 +73,11 @@ export enum StreamAudioDirective {
   REPLACE_ALL = 'REPLACE_ALL',
 }
 
+export enum SegmentEventType {
+  KB_TAGS_USED = 'AI - KB Tags Used',
+  AI_REQUEST = 'AI Request',
+}
+
 export interface StreamPlayStorage {
   src: string;
   loop: boolean;


### PR DESCRIPTION
### Brief description. What is this change?

Add Segment `AI - KB Tags Used` event

### Implementation details. How do you make this change?

Event name - **_AI - KB Tags Used_**
Event properties:

* `operators` - ex include 
* `tags_searched` - are the tags that the user was trying to find
* `number_of_tags` - is this their number.
 
Ex filter: 
```
”tags” : { 
    “include”: { 
        “items”: [”tag1”, “tag2”],
    } 
}
```

`operators` - [”include”] ; `tags_searched` - [”tag1”, “tag2”] ; `number _of_tags` - 2

### Related Jira ticket

* [NLU-928](https://voiceflow.atlassian.net/browse/NLU-928)

[NLU-928]: https://voiceflow.atlassian.net/browse/NLU-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ