### PR TITLE
[Merged by Bors] - fix: allow public origins (CT-000)

### DIFF
--- a/backend/api/routers/public.ts
+++ b/backend/api/routers/public.ts
@@ -7,6 +7,8 @@ import { ControllerMap, MiddlewareMap } from '@/lib';
 export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   const router = express.Router();
 
+  router.use(middlewares.project.checkPublicAccessControlOrigin);
+
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
 
   const interactMiddleware = [middlewares.project.resolvePublicProjectID, middlewares.rateLimit.versionConsume];

--- a/config.ts
+++ b/config.ts
@@ -121,6 +121,8 @@ const CONFIG: Config = {
   // Unleash
   UNLEASH_API_KEY: getOptionalProcessEnv('UNLEASH_API_KEY'),
   UNLEASH_URL: getOptionalProcessEnv('UNLEASH_URL'),
+
+  ALLOWED_PUBLIC_ORIGINS: getOptionalProcessEnv('ALLOWED_PUBLIC_ORIGINS'),
 };
 
 export default CONFIG;

--- a/lib/middlewares/project.ts
+++ b/lib/middlewares/project.ts
@@ -21,7 +21,7 @@ const VALIDATIONS = {
 class Project extends AbstractMiddleware {
   static VALIDATIONS = VALIDATIONS;
 
-  async checkPublicAccessControlOrigin(req: Request, res: Response, next: NextFunction): Promise<void> {
+  checkPublicAccessControlOrigin(req: Request, res: Response, next: NextFunction): void {
     if (
       this.config.ALLOWED_PUBLIC_ORIGINS &&
       !this.config.ALLOWED_PUBLIC_ORIGINS.split(',').includes(req.headers.origin ?? '')

--- a/lib/middlewares/project.ts
+++ b/lib/middlewares/project.ts
@@ -21,6 +21,18 @@ const VALIDATIONS = {
 class Project extends AbstractMiddleware {
   static VALIDATIONS = VALIDATIONS;
 
+  async checkPublicAccessControlOrigin(req: Request, res: Response, next: NextFunction): Promise<void> {
+    if (
+      this.config.ALLOWED_PUBLIC_ORIGINS &&
+      !this.config.ALLOWED_PUBLIC_ORIGINS.split(',').includes(req.headers.origin ?? '')
+    ) {
+      res.status(403).send('Forbidden: Invalid Origin');
+      return;
+    }
+
+    next();
+  }
+
   @validate({
     HEADER_VERSION_ID: VALIDATIONS.HEADERS.VERSION_ID,
     PARAMS_VERSION_ID: VALIDATIONS.PARAMS.VERSION_ID,

--- a/types.ts
+++ b/types.ts
@@ -101,6 +101,8 @@ export interface Config extends RateLimitConfig {
   // Unleash
   UNLEASH_URL: string | null;
   UNLEASH_API_KEY: string | null;
+
+  ALLOWED_PUBLIC_ORIGINS: string | null;
 }
 
 export interface Request<


### PR DESCRIPTION
for the webchat we use these `/public/` endpoints that anyone can hit.

For private clouds, we can set an environment variable that restricts what origins requests can come in from.

Obviously one bad actor and spoof their origin in the request - but they can't propagate this to other unknowning users as long as they use a standard browser. 

I don't think this is the most beautiful implementation of a check ever, but for now this is very specific to only one client. We can re-evaluate this when there are more use cases