### PR TITLE
fix: custom action json parse (CT-000)

### DIFF
--- a/lib/services/runtime/handlers/_v1.ts
+++ b/lib/services/runtime/handlers/_v1.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable no-restricted-syntax */
 import { BaseNode } from '@voiceflow/base-types';
 import { object, replaceVariables } from '@voiceflow/common';
@@ -12,6 +13,11 @@ const utilsObj = {
   commandHandler: CommandHandler(),
   findEventMatcher,
 };
+
+const isTraceNode = (
+  node: BaseNode._v1.Node
+): node is BaseNode._v1.Node & { payload: { name: string; body: string; bodyType: string } } =>
+  node.type === BaseNode.NodeType.TRACE;
 
 export const _V1Handler: HandlerFactory<BaseNode._v1.Node, typeof utilsObj> = (utils) => ({
   canHandle: (node) => node._v === 1,
@@ -40,10 +46,27 @@ export const _V1Handler: HandlerFactory<BaseNode._v1.Node, typeof utilsObj> = (u
     }
 
     const variablesMap = variables.getState();
-    const type = replaceVariables(node.type, variablesMap);
-    const payload = object.deepMap(node.payload, (value) =>
-      typeof value === 'string' ? replaceVariables(value, variablesMap) : value
-    );
+
+    let type;
+    let payload;
+
+    if (isTraceNode(node)) {
+      type = replaceVariables(node.payload.name, variablesMap);
+      payload = replaceVariables(node.payload.body, variablesMap);
+
+      if (node.payload.bodyType === 'json') {
+        try {
+          payload = JSON.parse(payload);
+        } catch (error) {
+          runtime.trace.debug(`error parsing as JSON: ${error.message}\n\`\`\`${payload}\`\`\``);
+        }
+      }
+    } else {
+      type = replaceVariables(node.type, variablesMap);
+      payload = object.deepMap(node.payload, (value) =>
+        typeof value === 'string' ? replaceVariables(value, variablesMap) : value
+      );
+    }
 
     runtime.trace.addTrace<BaseNode.Utils.BaseTraceFrame<unknown>>({
       type,

--- a/lib/services/runtime/handlers/_v1.ts
+++ b/lib/services/runtime/handlers/_v1.ts
@@ -17,7 +17,7 @@ const utilsObj = {
 const isTraceNode = (
   node: BaseNode._v1.Node
 ): node is BaseNode._v1.Node & { payload: { name: string; body: string; bodyType: string } } =>
-  node.type === BaseNode.NodeType.TRACE;
+  node.type === BaseNode.NodeType.TRACE && (node.payload as any)?.name && (node.payload as any)?.body;
 
 export const _V1Handler: HandlerFactory<BaseNode._v1.Node, typeof utilsObj> = (utils) => ({
   canHandle: (node) => node._v === 1,


### PR DESCRIPTION
Old custom action nodes on the program look like this:
```
{
      "id": "65417846329b6455cb69f2a9",
      "_v": 1,
      "type": "name",
      "stop": false,
      "payload": "body",
      "paths": [
        { "event": { "type": "path 1" }, "nextID": null },
        { "event": { "type": "path 2" }, "nextID": null }
      ],
      "defaultPath": 0
    }
```

Basically new custom action nodes on the program look like this:
```
{
      "id": "65417694125e184893a0b2e3",
      "_v": 1,
      "type": "trace",
      "stop": true,
      "payload": {
        "name": "name",
        "body": "body",
        "bodyType": "json"
      },
      "paths": [
		{ "event": { "type": "path 1" },  "nextID": null },
        { "event": { "type": "path 2" }, "nextID": null }
      ],
      "defaultPath": 0
    }
```

We're moving everything inside `payload`. There's one additional piece of data: `bodyType`.
If `type === 'trace'` we will look at `bodyType`, if it is `json` we will try to parse and return a JSON object with the response. This allows folks to mock a carousel step, and other steps, properly.