### PR TITLE
fix: allow start step to process launch request (CT-000)

### DIFF
--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -77,7 +77,6 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
     if (context.request && BaseRequest.isLaunchRequest(context.request) && context.state) {
       context.state.stack = [];
       context.state.storage = {};
-      context.request = null;
     }
 
     // sanitize incoming intents

--- a/tests/lib/services/runtime/handlers/state/preliminary.unit.ts
+++ b/tests/lib/services/runtime/handlers/state/preliminary.unit.ts
@@ -102,8 +102,10 @@ describe('preliminary handler unit tests', () => {
 
     it('command cant handle', () => {
       const commandHandler = { canHandle: sinon.stub().returns(false) };
+      const startHandler = { canHandle: sinon.stub().returns(false) };
       const utils = {
         commandHandler,
+        startHandler,
       };
       const handler = PreliminaryHandlerFactory(utils as any);
 
@@ -113,6 +115,22 @@ describe('preliminary handler unit tests', () => {
       expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(node.id);
 
       expect(commandHandler.canHandle.args).to.eql([[runtime]]);
+    });
+
+    it('start handler', () => {
+      const nextID = 'next-id';
+      const commandHandler = { canHandle: sinon.stub().returns(false) };
+      const startHandler = { canHandle: sinon.stub().returns(true), handle: sinon.stub().returns(nextID) };
+      const utils = {
+        commandHandler,
+        startHandler,
+      };
+      const handler = PreliminaryHandlerFactory(utils as any);
+
+      const node = { id: 'id' };
+      const runtime = { setAction: sinon.stub() };
+      const variables = { var1: 'val1', var2: 'val2' };
+      expect(handler.handle(node as any, runtime as any, variables as any, null as any)).to.eql(nextID);
     });
   });
 });


### PR DESCRIPTION
I apologize for this piece of somewhat convoluted logic. We need to set the request to the builtin `last_event`, so we don't want to set it to `null`.

The center of the issue is here:
https://github.com/voiceflow/general-runtime/blob/78a10d27ad3d0d2e34f7e939779d35ec242c2bba/runtime/lib/Runtime/index.ts#L224-L229

We used to manually transform any launch requests into `null` requests. But this preliminary handler would basically swallow all events and stop on the same node, so it looks like nothing happens.

What this does is allow the start step to handle events and continue, if there are no global commands. 

The side effect of this behavior, is the on the DMAPI the user could literally send ANY event (that has no global command match) and it would trigger the start.  The previous behavior would've been absolutely nothing happens, and it keeps listening.