### PR TITLE
fix: move launch request remapping downstream (CT-000)

### DIFF
--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -3,7 +3,7 @@
  * @packageDocumentation
  */
 
-import { BaseNode } from '@voiceflow/base-types';
+import { BaseNode, BaseRequest } from '@voiceflow/base-types';
 import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 
 import Client, { Action as RuntimeAction, Runtime } from '@/runtime';
@@ -97,6 +97,10 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
   }
 
   private getRuntimeForContext(context: Context): Runtime {
+    if (context.request && BaseRequest.isLaunchRequest(context.request)) {
+      context.request = null;
+    }
+
     const runtime = this.createClient(context.data.api).createRuntime({
       versionID: context.versionID,
       state: context.state,

--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -77,7 +77,6 @@ class StateManager extends AbstractManager<{ utils: typeof utils }> implements I
     if (context.request && BaseRequest.isLaunchRequest(context.request) && context.state) {
       context.state.stack = [];
       context.state.storage = {};
-      context.request = null;
     }
 
     // sanitize incoming intents


### PR DESCRIPTION
I apologize for this piece of somewhat convoluted logic. We need to set the request to the builtin `last_event`, so we don't want to set it to `null` at the `state` stage of the pipeline.

The center of the issue is here:
https://github.com/voiceflow/general-runtime/blob/78a10d27ad3d0d2e34f7e939779d35ec242c2bba/runtime/lib/Runtime/index.ts#L224-L229

Only the actual runtime cares about this, so we are setting it right before it gets fed into the runtime, all the other logic is the same. I know the mutation is kind icky, the `context` is a newly generated object for this call so it doesn't matter too much:
https://github.com/voiceflow/general-runtime/blob/5be4e4be8b706b60194c9242e516c3b691074f6f/lib/services/runtime/index.ts#L49

There is another alternative to this: https://github.com/voiceflow/general-runtime/pull/623 but it is higher risk, so I would rather do this.