### PR TITLE
[Merged by Bors] - fix: default to proj dev version (VF-000)

### DIFF
--- a/lib/controllers/test/index.ts
+++ b/lib/controllers/test/index.ts
@@ -118,7 +118,13 @@ class TestController extends AbstractController {
     const api = await this.services.dataAPI.get();
     // if DM API key infer project from header
     const project = await api.getProject(req.headers.authorization || req.body.projectID!);
-    const version = req.body.versionID ? await api.getVersion(req.body.versionID) : null;
+
+    let version = null;
+    if (req.body.versionID) {
+      version = await api.getVersion(req.body.versionID);
+    } else if (project.devVersion) {
+      version = await api.getVersion(project.devVersion);
+    }
 
     const answer = await this.services.aiSynthesis.knowledgeBaseQuery({
       project,


### PR DESCRIPTION
We have a versioned KB feature flag, it is turned on for this user. The issue was that without passing the `versionID` in the request body, the KB query API was defaulting back to the **project** level settings, but since the feature flag is on, their changes to the KB were modifying the **version** level settings. 

This change makes it so the user doesn't have to pass the **versionID** param in the KB query request, it will default to the project.devVersion, and if version level KB settings exist they'll be used. If no version level KB settings exist (this is true for people without the feature flag turned on) then we just use the project level settings as usual.

<img width="769" alt="Screenshot 2023-11-28 at 12 41 53 PM" src="https://github.com/voiceflow/general-runtime/assets/23105545/cffcf62d-1eec-4b5a-8b3b-8e8f8c34a9a0">
