### PR TITLE
[Merged by Bors] - feat: pass intent & entity scopes (VF-000)

### DIFF
--- a/lib/services/dialog/utils.ts
+++ b/lib/services/dialog/utils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 import { BaseModels, BaseNode, BaseRequest } from '@voiceflow/base-types';
+import { EventType } from '@voiceflow/base-types/build/cjs/node/utils';
 import { SLOT_REGEXP, VF_DM_PREFIX } from '@voiceflow/common';
 import * as crypto from 'crypto';
 
@@ -72,6 +73,15 @@ export const isInteractionsInNode = (
   node: BaseModels.BaseNode & { interactions?: BaseNode.Interaction.NodeInteraction[] }
 ): node is BaseModels.BaseNode & { interactions: BaseNode.Interaction.NodeInteraction[] } =>
   Array.isArray(node.interactions);
+
+export const isIntentInInteraction = (
+  interaction: BaseNode.Interaction.NodeInteraction
+): interaction is BaseNode.Interaction.NodeInteraction<BaseNode.Utils.IntentEvent> =>
+  interaction.event.type === EventType.INTENT;
+
+export const isIntentScopeInNode = (
+  node: BaseModels.BaseNode & { intentScope?: BaseNode.Utils.IntentScope }
+): node is BaseModels.BaseNode & { intentScope?: BaseNode.Utils.IntentScope } => !!node.intentScope;
 
 export const isIntentInNode = (
   node: BaseModels.BaseNode & { intent?: { name?: string } }

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -13,7 +13,7 @@ import { Context, ContextHandler, VersionTag } from '@/types';
 import { isConfidenceScoreAbove } from '../runtime/utils';
 import { AbstractManager, injectServices } from '../utils';
 import { handleNLCCommand } from './nlc';
-import { getNoneIntentRequest, mapChannelData } from './utils';
+import { getNLUScope, getNoneIntentRequest, mapChannelData } from './utils';
 
 export const utils = {};
 
@@ -61,6 +61,8 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     dmRequest,
     workspaceID,
     intentConfidence = 0.6,
+    availableIntents,
+    availableEntities,
   }: {
     query: string;
     model?: BaseModels.PrototypeModel;
@@ -73,6 +75,8 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     dmRequest?: BaseRequest.IntentRequestPayload;
     workspaceID: string;
     intentConfidence?: number;
+    availableIntents?: string[];
+    availableEntities?: string[];
   }): Promise<BaseRequest.IntentRequest> {
     // 1. first try restricted regex (no open slots) - exact string match
     if (model && locale) {
@@ -89,6 +93,8 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
           utterance: query,
           tag,
           workspaceID,
+          availableIntents,
+          availableEntities,
         })
         .catch(() => ({ data: null }));
 
@@ -129,6 +135,19 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
       };
     }
 
+    const client = this.services.runtime.createClient(context.data.api);
+
+    const runtime = client.createRuntime({
+      versionID: context.versionID,
+      state: context.state,
+      request: context.request,
+      version: context.version,
+      project: context.project,
+      timeout: 0,
+    });
+
+    const { availableIntents, availableEntities } = await getNLUScope(runtime);
+
     const version = await context.data.api.getVersion(context.versionID);
 
     const project = await context.data.api.getProject(version.projectID);
@@ -144,6 +163,8 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
       platform: version?.prototype?.platform as VoiceflowConstants.PlatformType,
       workspaceID: project.teamID,
       intentConfidence: version?.platformData?.settings?.intentConfidence,
+      availableIntents,
+      availableEntities,
     });
 
     return { ...context, request };

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -61,8 +61,10 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     dmRequest,
     workspaceID,
     intentConfidence = 0.6,
-    availableIntents,
-    availableEntities,
+    filteredIntents,
+    filteredEntities,
+    excludeFilteredIntents,
+    excludeFilteredEntities,
   }: {
     query: string;
     model?: BaseModels.PrototypeModel;
@@ -75,8 +77,10 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
     dmRequest?: BaseRequest.IntentRequestPayload;
     workspaceID: string;
     intentConfidence?: number;
-    availableIntents?: string[];
-    availableEntities?: string[];
+    filteredIntents?: string[];
+    filteredEntities?: string[];
+    excludeFilteredIntents?: boolean;
+    excludeFilteredEntities?: boolean;
   }): Promise<BaseRequest.IntentRequest> {
     // 1. first try restricted regex (no open slots) - exact string match
     if (model && locale) {
@@ -93,8 +97,10 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
           utterance: query,
           tag,
           workspaceID,
-          availableIntents,
-          availableEntities,
+          filteredIntents,
+          filteredEntities,
+          excludeFilteredIntents,
+          excludeFilteredEntities,
         })
         .catch(() => ({ data: null }));
 
@@ -163,8 +169,10 @@ class NLU extends AbstractManager<{ utils: typeof utils }> implements ContextHan
       platform: version?.prototype?.platform as VoiceflowConstants.PlatformType,
       workspaceID: project.teamID,
       intentConfidence: version?.platformData?.settings?.intentConfidence,
-      availableIntents,
-      availableEntities,
+      filteredIntents: availableIntents,
+      filteredEntities: availableEntities,
+      excludeFilteredIntents: false,
+      excludeFilteredEntities: false,
     });
 
     return { ...context, request };

--- a/lib/services/nlu/utils.ts
+++ b/lib/services/nlu/utils.ts
@@ -1,8 +1,13 @@
 import { AlexaConstants } from '@voiceflow/alexa-types';
-import { BaseRequest } from '@voiceflow/base-types';
+import { BaseNode, BaseRequest } from '@voiceflow/base-types';
+import { CommandType, EventType } from '@voiceflow/base-types/build/cjs/node/utils';
 import { GoogleConstants } from '@voiceflow/google-types';
 import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import { match } from 'ts-pattern';
+
+import Runtime from '@/runtime/lib/Runtime';
+
+import { isIntentInInteraction, isIntentScopeInNode, isInteractionsInNode } from '../dialog/utils';
 
 export const getNoneIntentRequest = ({
   query = '',
@@ -51,4 +56,52 @@ export const mapChannelData = (data: any, platform?: VoiceflowConstants.Platform
       },
     },
   };
+};
+
+export const setIntersect = (set1: Set<any>, set2: Set<any>) => new Set([...set1].filter((i) => set2.has(i)));
+
+export const getNLUScope = async (
+  runtime: Runtime
+): Promise<{ availableIntents: string[]; availableEntities: string[] }> => {
+  // get command-level scope
+  const intentCommands = runtime.stack
+    .getFrames()
+    .flatMap((frame) => frame.getCommands<BaseNode.Utils.AnyCommand<BaseNode.Utils.IntentEvent>>())
+    .filter((command) => command.type === CommandType.JUMP && command.event.type === EventType.INTENT);
+
+  const commandIntentNames = new Set(intentCommands.map((command) => command.event.intent));
+
+  const commandEntityNames = new Set(
+    intentCommands.flatMap((command) => command.event?.mappings).flatMap((mapping) => mapping?.slot || [])
+  );
+
+  // get node-level scope
+  const currentFrame = runtime.stack.top();
+  const program = await runtime.getProgram(runtime.getVersionID(), currentFrame.getDiagramID());
+  const node = program.getNode(currentFrame.getNodeID());
+
+  let nodeInteractionIntentNames: Set<string> = new Set();
+  let nodeInteractionEntityNames: Set<string> = new Set();
+  if (node && isInteractionsInNode(node)) {
+    const intentInteractions = node.interactions.filter(isIntentInInteraction);
+
+    nodeInteractionIntentNames = new Set(intentInteractions.flatMap((interaction) => interaction.event.intent));
+
+    nodeInteractionEntityNames = new Set(
+      intentInteractions.flatMap((interaction) => interaction.event.mappings).flatMap((mapping) => mapping?.slot || [])
+    );
+  }
+
+  // intersect scopes if necessary
+  let availableIntentsSet = commandIntentNames;
+  let availableEntitiesSet = commandEntityNames;
+  if (node && isIntentScopeInNode(node) && node.intentScope === BaseNode.Utils.IntentScope.NODE) {
+    availableIntentsSet = setIntersect(commandIntentNames, nodeInteractionIntentNames);
+    availableEntitiesSet = setIntersect(commandEntityNames, nodeInteractionEntityNames);
+  }
+
+  const availableIntents = Array.from(availableIntentsSet);
+  const availableEntities = Array.from(availableEntitiesSet);
+
+  return { availableIntents, availableEntities };
 };

--- a/tests/lib/services/nlu/fixture.ts
+++ b/tests/lib/services/nlu/fixture.ts
@@ -1,3 +1,5 @@
+import sinon from 'sinon';
+
 export const regexMatcherSlots = [
   {
     key: 'slot1',
@@ -53,3 +55,26 @@ export const customTypeSlots = [
     color: 'custom-color3',
   },
 ];
+
+export const getMockRuntime = (mockCommands: Array<any> = [], mockNode: any = {}) => {
+  const mockProgram = {
+    getNode: sinon.stub().returns(mockNode),
+  };
+
+  const mockFrames = [
+    {
+      getCommands: sinon.stub().returns(mockCommands),
+      getDiagramID: sinon.stub(),
+      getNodeID: sinon.stub(),
+    },
+  ];
+
+  return {
+    getProgram: sinon.stub().resolves(mockProgram),
+    getVersionID: sinon.stub(),
+    stack: {
+      getFrames: sinon.stub().returns(mockFrames),
+      top: sinon.stub().returns(mockFrames[0]),
+    },
+  };
+};

--- a/tests/lib/services/nlu/index.unit.ts
+++ b/tests/lib/services/nlu/index.unit.ts
@@ -8,6 +8,8 @@ import NLUManager, { NLUGatewayPredictResponse, utils as defaultUtils } from '@/
 import * as NLC from '@/lib/services/nlu/nlc';
 import { VersionTag } from '@/types';
 
+import { getMockRuntime } from './fixture';
+
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
@@ -95,9 +97,15 @@ describe('nlu manager unit tests', () => {
         type: BaseRequest.RequestType.TEXT,
         payload: 'query',
       };
+      const runtimeClient = {
+        createRuntime: sinon.stub().returns(getMockRuntime()),
+      };
       const services = {
         axios: {
           post: sinon.stub().resolves({ data: nluGatewayPrediction }),
+        },
+        runtime: {
+          createClient: sinon.stub().returns(runtimeClient),
         },
       };
       const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
@@ -123,9 +131,15 @@ describe('nlu manager unit tests', () => {
         type: BaseRequest.RequestType.TEXT,
         payload: query,
       };
+      const runtimeClient = {
+        createRuntime: sinon.stub().returns(getMockRuntime()),
+      };
       const services = {
         axios: {
           post: sinon.stub().resolves({ data: nluGatewayPrediction }),
+        },
+        runtime: {
+          createClient: sinon.stub().returns(runtimeClient),
         },
       };
       const nlu = new NLUManager({ ...services, utils: { ...defaultUtils } } as any, config as any);
@@ -149,6 +163,8 @@ describe('nlu manager unit tests', () => {
 
       expect(result).to.eql({ ...context, request: intentResponse });
       expect(services.axios.post.args[0][1]).to.eql({
+        availableEntities: [],
+        availableIntents: [],
         utterance: query,
         tag: VersionTag.PRODUCTION,
         workspaceID: teamID,

--- a/tests/lib/services/nlu/index.unit.ts
+++ b/tests/lib/services/nlu/index.unit.ts
@@ -163,8 +163,10 @@ describe('nlu manager unit tests', () => {
 
       expect(result).to.eql({ ...context, request: intentResponse });
       expect(services.axios.post.args[0][1]).to.eql({
-        availableEntities: [],
-        availableIntents: [],
+        filteredEntities: [],
+        filteredIntents: [],
+        excludeFilteredEntities: false,
+        excludeFilteredIntents: false,
         utterance: query,
         tag: VersionTag.PRODUCTION,
         workspaceID: teamID,

--- a/tests/lib/services/nlu/utils.unit.ts
+++ b/tests/lib/services/nlu/utils.unit.ts
@@ -1,10 +1,14 @@
 import { AlexaConstants } from '@voiceflow/alexa-types';
+import { BaseNode } from '@voiceflow/base-types';
+import { CommandType, EventType } from '@voiceflow/base-types/build/cjs/node/utils';
 import { GoogleConstants } from '@voiceflow/google-types';
 import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import chai from 'chai';
 import sinon from 'sinon';
 
-import { mapChannelData } from '@/lib/services/nlu/utils';
+import { getNLUScope, mapChannelData } from '@/lib/services/nlu/utils';
+
+import { getMockRuntime } from './fixture';
 
 const { expect } = chai;
 
@@ -45,6 +49,75 @@ describe('nlu manager utils unit tests', () => {
 
       const expectData = { payload: { intent: { name: AlexaConstants.AmazonIntent.YES } } };
       expect(outputData).to.eql(expectData);
+    });
+  });
+
+  describe('getNLUScope', () => {
+    const mockPizzaIntent = { type: EventType.INTENT, intent: 'Pizza', mappings: [{ slot: 'foo' }, { slot: 'bar' }] };
+    const mockYesIntent = { type: EventType.INTENT, intent: 'VF.YES', mappings: [{ slot: 'baz' }] };
+    const mockNoIntent = { type: EventType.INTENT, intent: 'VF.NO', mappings: [{ slot: 'qux' }] };
+
+    it('takes intersection when node is scoped', async () => {
+      const mockNodeInteractions = [{ event: mockPizzaIntent }, { event: mockYesIntent }, { event: mockNoIntent }];
+
+      const mockNode = {
+        interactions: mockNodeInteractions,
+        intentScope: BaseNode.Utils.IntentScope.NODE,
+      };
+
+      const mockCommands = [
+        {
+          type: CommandType.JUMP,
+          event: mockYesIntent,
+        },
+        {
+          type: CommandType.JUMP,
+          event: mockPizzaIntent,
+        },
+      ];
+
+      const mockRuntime = getMockRuntime(mockCommands, mockNode);
+
+      const { availableIntents, availableEntities } = await getNLUScope(mockRuntime as any);
+
+      expect(availableIntents).to.eql(['VF.YES', 'Pizza']);
+      expect(availableEntities).to.eql(['baz', 'foo', 'bar']);
+    });
+
+    it('ignores node level when intentScope is global', async () => {
+      const mockNodeInteractions = [
+        {
+          event: mockYesIntent,
+        },
+      ];
+
+      const mockNode = {
+        interactions: mockNodeInteractions,
+        intentScope: BaseNode.Utils.IntentScope.GLOBAL,
+      };
+
+      const mockCommands = [
+        {
+          type: CommandType.JUMP,
+          event: mockNoIntent,
+        },
+      ];
+
+      const mockRuntime = getMockRuntime(mockCommands, mockNode);
+
+      const { availableIntents, availableEntities } = await getNLUScope(mockRuntime as any);
+
+      expect(availableIntents).to.eql(['VF.NO']);
+      expect(availableEntities).to.eql(['qux']);
+    });
+
+    it('works with empty params', async () => {
+      const mockRuntime = getMockRuntime();
+
+      const { availableIntents, availableEntities } = await getNLUScope(mockRuntime as any);
+
+      expect(availableIntents).to.eql([]);
+      expect(availableEntities).to.eql([]);
     });
   });
 });


### PR DESCRIPTION
Determine intent/entity scope and pass it to nlu-gateway via:
- `filteredIntents: string[]`
- `filteredEntities: string[]`
- `excludeFilteredIntents: boolean`
- `excludeFilteredEntities: boolean`

The scope is defined by the intersection of:
- "intent scoping" at the `Listen` step level (`Buttons`, `Choice`, `Capture`) of the current node
- reachable intents determined by all commands in all frames on the runtime stack. ("Available from other topics" toggle on intent block)

Changes are backwards compatible and have no impact on functionality at this point. 

For context, these parameters will be passed to NLU user inference in order to better calculate accuracies based on a refined intent/entity scope rather than the full set of intents/entities.