### PR TITLE
feat: enable python kb retriever for vodafone (VF-000)

### DIFF
--- a/lib/services/runtime/handlers/utils/knowledgeBase/index.ts
+++ b/lib/services/runtime/handlers/utils/knowledgeBase/index.ts
@@ -56,6 +56,7 @@ const FLAGGED_WORKSPACES_MAP = new Map<string, string[]>([
   [CloudEnv.VFTESTBR, []],
   [CloudEnv.VFTEST82, []],
   [CloudEnv.GM, []],
+  [CloudEnv.VODAFONE, []],
 ]);
 
 const { KL_RETRIEVER_SERVICE_HOST: host, KL_RETRIEVER_SERVICE_PORT: port } = Config;

--- a/lib/services/runtime/handlers/utils/knowledgeBase/types.ts
+++ b/lib/services/runtime/handlers/utils/knowledgeBase/types.ts
@@ -7,4 +7,5 @@ export enum CloudEnv {
   VFTESTBR = 'vf-dev-br-2',
   VFTEST82 = 'vftest-82',
   GM = 'gm',
+  VODAFONE = 'vodafone',
 }


### PR DESCRIPTION


### Brief description. What is this change?

Minor change to add new cloud env values to invoke python KB retrieval end point

### Implementation details. How do you make this change?
Added the cloud env values for the staging environments to workspace map in knowledgebase/index.ts

