### PR TITLE
[Merged by Bors] - fix: debug message too large for transcript [bugfix] (BUG-667)

### DIFF
--- a/runtime/lib/Handlers/code/index.ts
+++ b/runtime/lib/Handlers/code/index.ts
@@ -69,10 +69,9 @@ const CodeHandler: HandlerFactory<BaseNode.Code.Node, CodeOptions | void> = ({
       const changesSummary = Object.entries(changes)
         .map(
           ([variable, change]) =>
-            `\`{${variable}}\`: \`${_.truncate(JSON.stringify(change.before), { length: 100 })}\` => \`${_.truncate(
-              JSON.stringify(change.after),
-              { length: 100 }
-            )}\``
+            `\`{${variable}}\`: \`${_.truncate(String(JSON.stringify(change.before)), {
+              length: 100,
+            })}\` => \`${_.truncate(String(JSON.stringify(change.after)), { length: 100 })}\``
         )
         .join('\n');
 

--- a/runtime/lib/Handlers/code/index.ts
+++ b/runtime/lib/Handlers/code/index.ts
@@ -69,7 +69,10 @@ const CodeHandler: HandlerFactory<BaseNode.Code.Node, CodeOptions | void> = ({
       const changesSummary = Object.entries(changes)
         .map(
           ([variable, change]) =>
-            `\`{${variable}}\`: \`${JSON.stringify(change.before)}\` => \`${JSON.stringify(change.after)}\``
+            `\`{${variable}}\`: \`${_.truncate(JSON.stringify(change.before), { length: 100 })}\` => \`${_.truncate(
+              JSON.stringify(change.after),
+              { length: 100 }
+            )}\``
         )
         .join('\n');
 

--- a/runtime/lib/Runtime/Trace/index.ts
+++ b/runtime/lib/Runtime/Trace/index.ts
@@ -1,4 +1,5 @@
 import { BaseNode } from '@voiceflow/base-types';
+import _truncate from 'lodash/truncate';
 
 import { EventType } from '@/runtime/lib/Lifecycle';
 
@@ -29,6 +30,9 @@ export default class Trace {
   }
 
   debug(message: string, type?: BaseNode.NodeType): void {
-    this.addTrace({ type: BaseNode.Utils.TraceType.DEBUG, payload: { type, message } });
+    this.addTrace({
+      type: BaseNode.Utils.TraceType.DEBUG,
+      payload: { type, message: _truncate(message, { length: 500 }) },
+    });
   }
 }


### PR DESCRIPTION
Basically if a message is too large, the `event-ingestion-service` ignores it. It has a hard cut off.

this should make it a lot better.