### PR TITLE
[Merged by Bors] - fix: bypass NLU for local scoped captureV2 [bugfix] (CT-000)

### DIFF
--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -113,10 +113,14 @@ class NLU extends AbstractManager implements ContextHandler {
       };
     }
 
-    const { availableIntents, availableEntities } = await getAvailableIntentsAndEntities(
+    const { availableIntents, availableEntities, bypass } = await getAvailableIntentsAndEntities(
       this.services.runtime,
       context
     );
+
+    if (bypass) {
+      return { ...context, request: getNoneIntentRequest({ query: context.request.payload }) };
+    }
 
     const version = await context.data.api.getVersion(context.versionID);
 


### PR DESCRIPTION
Yoyo and I disabled the intents/entities scoping feature by @e-vandenberg, but this has resurfaced some new issues withe scoping.

Bypass NLU for captureV2 with local scoping. There is 0 reason to use the NLU in this configuration:
<img width="470" alt="Screenshot 2023-12-28 at 2 25 18 PM" src="https://github.com/voiceflow/general-runtime/assets/5643574/33664de2-6ce6-45e4-b270-9307efb8c464">

The problem right now is it might trigger entity filling if you match an intent. What this PR does is if there is a capture step that is capture entire user utterance AND scoped to just the node, then just pass a none intent