### PR TITLE
[Merged by Bors] - fix: output variables command (CV3-813) [bugfix]

### DIFF
--- a/runtime/lib/Handlers/function/index.ts
+++ b/runtime/lib/Handlers/function/index.ts
@@ -22,8 +22,6 @@ const utilsObj = {
   replaceVariables,
 };
 
-const DIAGRAM_VARIABLE_REGEX = /^{(\w)\w*}$/g;
-
 function applyOutputCommand(
   command: OutputVarsCommand,
   runtime: Runtime,
@@ -32,19 +30,8 @@ function applyOutputCommand(
   outputVarAssignments: FunctionCompiledInvocation['outputVars']
 ): void {
   Object.keys(outputVarDeclarations).forEach((functionVarName) => {
-    const diagramVariableToken = outputVarAssignments[functionVarName];
-
-    if (!diagramVariableToken) return;
-
-    const diagramVariableNameMatches = diagramVariableToken.match(DIAGRAM_VARIABLE_REGEX);
-
-    if (diagramVariableNameMatches === null) {
-      throw new Error('Assignment target of output variable command has invalid format');
-    }
-
-    const firstMatch = diagramVariableNameMatches[0];
-    const diagramVariableName = firstMatch.substring(1, firstMatch.length - 1);
-
+    const diagramVariableName = outputVarAssignments[functionVarName];
+    if (!diagramVariableName) return;
     variables.set(diagramVariableName, command[functionVarName]);
     runtime.variables.set(diagramVariableName, command[functionVarName]);
   });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CV3-813**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

The frontend's format for the `variableName` has changed from `{variableName}` to `variableName`. The `general-runtime` needs to be updated to account for this, so the output variables command doesn't break.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test