### PR TITLE
[Merged by Bors] - feat: add speak trace, audio trace, URL buttons to carousel and card (CV3-794)

### DIFF
--- a/runtime/lib/Handlers/function/lib/execute-function/lib/adapt-trace.ts
+++ b/runtime/lib/Handlers/function/lib/execute-function/lib/adapt-trace.ts
@@ -1,19 +1,29 @@
-import { BaseNode, BaseTrace } from '@voiceflow/base-types';
-import cuid from 'cuid';
+import { BaseNode, BaseRequest, BaseTrace } from '@voiceflow/base-types';
+import { Utils } from '@voiceflow/common';
 
 import {
+  SimpleAction,
+  SimpleAudioTrace,
+  SimpleButton,
+  SimpleCard,
   SimpleCardV2Trace,
   SimpleCarouselTrace,
+  SimpleSpeakTrace,
   SimpleTextTrace,
   SimpleTrace,
   SimpleTraceDTO,
+  SimpleTraceType,
   SimpleVisualTrace,
   Trace,
 } from '../../../runtime-command/trace-command.dto';
 
+const { cuid } = Utils.id;
+const { TraceType } = BaseTrace;
+
 const adaptTextTrace = (trace: SimpleTextTrace): Trace => {
   return {
     ...trace,
+    type: TraceType.TEXT,
     payload: {
       slate: {
         id: 'dummy',
@@ -24,9 +34,33 @@ const adaptTextTrace = (trace: SimpleTextTrace): Trace => {
   } satisfies BaseTrace.TextTrace;
 };
 
+const adaptSpeakTrace = (trace: SimpleSpeakTrace): Trace => {
+  return {
+    ...trace,
+    type: TraceType.SPEAK,
+    payload: {
+      ...trace.payload,
+      type: BaseNode.Speak.TraceSpeakType.MESSAGE,
+    },
+  } satisfies BaseTrace.SpeakTrace;
+};
+
+const adaptAudioTrace = (trace: SimpleAudioTrace): Trace => {
+  return {
+    ...trace,
+    type: TraceType.SPEAK,
+    payload: {
+      ...trace.payload,
+      type: BaseNode.Speak.TraceSpeakType.AUDIO,
+      message: '',
+    },
+  } satisfies BaseTrace.SpeakTrace;
+};
+
 const adaptVisualTrace = (trace: SimpleVisualTrace): Trace => {
   return {
     ...trace,
+    type: TraceType.VISUAL,
     payload: {
       visualType: BaseNode.Visual.VisualType.IMAGE,
       device: BaseNode.Visual.DeviceType.DESKTOP,
@@ -40,17 +74,48 @@ const adaptVisualTrace = (trace: SimpleVisualTrace): Trace => {
   } satisfies BaseTrace.VisualTrace;
 };
 
+const adaptAction = (action: SimpleAction): BaseRequest.Action.BaseAction => {
+  if (action.type !== BaseRequest.Action.ActionType.OPEN_URL) {
+    throw new Error(`received unexpected action type`);
+  }
+
+  const { type, ...payload } = action;
+
+  return {
+    type,
+    payload,
+  };
+};
+
+const adaptButton = (button: SimpleButton): BaseRequest.GeneralRequestButton => {
+  return {
+    name: button.name,
+    request: {
+      type: `function-request-${button.name}`,
+      payload: {
+        label: button.name,
+        actions: button.payload.actions.map((act) => adaptAction(act)),
+      },
+    },
+  };
+};
+
+const adaptCard = (card: SimpleCard): BaseNode.Carousel.TraceCarouselCard => {
+  return {
+    ...card,
+    id: cuid.slug(),
+    buttons: (card.buttons ?? []).map((but) => adaptButton(but)),
+  };
+};
+
 const adaptCarouselTrace = (trace: SimpleCarouselTrace): Trace => {
   return {
     ...trace,
+    type: TraceType.CAROUSEL,
     payload: {
       layout: BaseNode.Carousel.CarouselLayout.CAROUSEL,
       ...trace.payload,
-      cards: trace.payload.cards.map((item) => ({
-        id: cuid.slug(),
-        buttons: [],
-        ...item,
-      })),
+      cards: trace.payload.cards.map((item) => adaptCard(item)),
     },
   } satisfies BaseTrace.CarouselTrace;
 };
@@ -58,6 +123,7 @@ const adaptCarouselTrace = (trace: SimpleCarouselTrace): Trace => {
 const adaptCardV2Trace = (trace: SimpleCardV2Trace): Trace => {
   return {
     ...trace,
+    type: TraceType.CARD_V2,
     payload: {
       ...trace.payload,
       buttons: [],
@@ -71,13 +137,17 @@ export function adaptTrace(trace: Trace): Trace {
   if (!isSimpleTrace(trace)) return trace;
 
   switch (trace.type) {
-    case BaseTrace.TraceType.TEXT:
+    case SimpleTraceType.Text:
       return adaptTextTrace(trace);
-    case BaseTrace.TraceType.VISUAL:
+    case SimpleTraceType.Speak:
+      return adaptSpeakTrace(trace);
+    case SimpleTraceType.Audio:
+      return adaptAudioTrace(trace);
+    case SimpleTraceType.Visual:
       return adaptVisualTrace(trace);
-    case BaseTrace.TraceType.CAROUSEL:
+    case SimpleTraceType.Carousel:
       return adaptCarouselTrace(trace);
-    case BaseTrace.TraceType.CARD_V2:
+    case SimpleTraceType.CardV2:
       return adaptCardV2Trace(trace);
     default:
       return trace;

--- a/runtime/lib/Handlers/function/lib/execute-function/lib/adapt-trace.ts
+++ b/runtime/lib/Handlers/function/lib/execute-function/lib/adapt-trace.ts
@@ -50,9 +50,8 @@ const adaptAudioTrace = (trace: SimpleAudioTrace): Trace => {
     ...trace,
     type: TraceType.SPEAK,
     payload: {
-      ...trace.payload,
       type: BaseNode.Speak.TraceSpeakType.AUDIO,
-      message: '',
+      message: `<audio src='${trace.payload.src ?? ''}'/>`,
     },
   } satisfies BaseTrace.SpeakTrace;
 };

--- a/runtime/lib/Handlers/function/lib/execute-function/lib/adapt-trace.ts
+++ b/runtime/lib/Handlers/function/lib/execute-function/lib/adapt-trace.ts
@@ -125,7 +125,7 @@ const adaptCardV2Trace = (trace: SimpleCardV2Trace): Trace => {
     type: TraceType.CARD_V2,
     payload: {
       ...trace.payload,
-      buttons: [],
+      buttons: (trace.payload.buttons ?? []).map((but) => adaptButton(but)),
     },
   } satisfies BaseTrace.CardV2;
 };

--- a/runtime/lib/Handlers/function/runtime-command/trace-command.dto.ts
+++ b/runtime/lib/Handlers/function/runtime-command/trace-command.dto.ts
@@ -1,5 +1,15 @@
-import { BaseNode, BaseTrace } from '@voiceflow/base-types';
+import { BaseNode, BaseRequest } from '@voiceflow/base-types';
 import { z } from 'zod';
+
+export enum SimpleTraceType {
+  Text = 'text',
+  Speak = 'speak',
+  Audio = 'audio',
+  Debug = 'debug',
+  Visual = 'visual',
+  CardV2 = 'cardV2',
+  Carousel = 'carousel',
+}
 
 export const TraceDTO = z
   .object({
@@ -20,7 +30,7 @@ export const TraceCommandDTO = z.array(TraceDTO, {
 export type TraceCommand = z.infer<typeof TraceCommandDTO>;
 
 export const SimpleTextTraceDTO = TraceDTO.extend({
-  type: z.literal(BaseTrace.TraceType.TEXT),
+  type: z.literal(SimpleTraceType.Text),
   payload: z.object({
     message: z.string(),
   }),
@@ -28,8 +38,28 @@ export const SimpleTextTraceDTO = TraceDTO.extend({
 
 export type SimpleTextTrace = z.infer<typeof SimpleTextTraceDTO>;
 
+export const SimpleSpeakTraceDTO = TraceDTO.extend({
+  type: z.literal(SimpleTraceType.Speak),
+  payload: z.object({
+    message: z.string(),
+    voice: z.string().optional(),
+    src: z.string().optional(),
+  }),
+});
+
+export type SimpleSpeakTrace = z.infer<typeof SimpleSpeakTraceDTO>;
+
+export const SimpleAudioTraceDTO = TraceDTO.extend({
+  type: z.literal(SimpleTraceType.Audio),
+  payload: z.object({
+    src: z.string().optional(),
+  }),
+});
+
+export type SimpleAudioTrace = z.infer<typeof SimpleAudioTraceDTO>;
+
 export const SimpleDebugTraceDTO = TraceDTO.extend({
-  type: z.literal(BaseTrace.TraceType.DEBUG),
+  type: z.literal(SimpleTraceType.Debug),
   payload: z.object({
     message: z.string(),
   }),
@@ -38,7 +68,7 @@ export const SimpleDebugTraceDTO = TraceDTO.extend({
 export type SimpleDebugTrace = z.infer<typeof SimpleDebugTraceDTO>;
 
 export const SimpleVisualTraceDTO = TraceDTO.extend({
-  type: z.literal(BaseTrace.TraceType.VISUAL),
+  type: z.literal(SimpleTraceType.Visual),
   payload: z.object({
     image: z.string(),
   }),
@@ -46,25 +76,46 @@ export const SimpleVisualTraceDTO = TraceDTO.extend({
 
 export type SimpleVisualTrace = z.infer<typeof SimpleVisualTraceDTO>;
 
+export const SimpleURLActionDTO = z.object({
+  type: z.literal(BaseRequest.Action.ActionType.OPEN_URL),
+  url: z.string(),
+});
+
+export type SimpleURLAction = z.infer<typeof SimpleURLActionDTO>;
+
+export const SimpleActionDTO = z.discriminatedUnion('type', [SimpleURLActionDTO]);
+
+export type SimpleAction = z.infer<typeof SimpleActionDTO>;
+
+export const SimpleButtonDTO = z.object({
+  name: z.string(),
+  payload: z.object({
+    actions: z.array(SimpleActionDTO),
+  }),
+});
+
+export type SimpleButton = z.infer<typeof SimpleButtonDTO>;
+
 export const SimpleCardDTO = z.object({
   imageUrl: z.string(),
   title: z.string(),
   description: z.object({
     text: z.string(),
   }),
+  buttons: z.array(SimpleButtonDTO).optional(),
 });
 
 export type SimpleCard = z.infer<typeof SimpleCardDTO>;
 
 export const SimpleCardV2TraceDTO = TraceDTO.extend({
-  type: z.literal(BaseTrace.TraceType.CARD_V2),
+  type: z.literal(SimpleTraceType.CardV2),
   payload: SimpleCardDTO,
 });
 
 export type SimpleCardV2Trace = z.infer<typeof SimpleCardV2TraceDTO>;
 
 export const SimpleCarouselTraceDTO = TraceDTO.extend({
-  type: z.literal(BaseTrace.TraceType.CAROUSEL),
+  type: z.literal(SimpleTraceType.Carousel),
   payload: z.object({
     layout: z.nativeEnum(BaseNode.Carousel.CarouselLayout).optional(),
     cards: z.array(SimpleCardDTO),
@@ -75,6 +126,8 @@ export type SimpleCarouselTrace = z.infer<typeof SimpleCarouselTraceDTO>;
 
 export const SimpleTraceDTO = z.discriminatedUnion('type', [
   SimpleTextTraceDTO,
+  SimpleSpeakTraceDTO,
+  SimpleAudioTraceDTO,
   SimpleDebugTraceDTO,
   SimpleVisualTraceDTO,
   SimpleCardV2TraceDTO,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CV3-794**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Adding adapters to support simplified speak trace, audio trace, and adding URL buttons to the carousel & card. 

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

Add adapters to convert simplified speak traces, audio traces, and URL buttons to their correct format that is expected by the rest of our codebase.

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

N/A

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

N/A

### Related PRs

<!-- List related PRs against other branches -->

N/A

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test