### PR TITLE
[Merged by Bors] - ci: run smoke tests instead of e2e (DX-993)

### DIFF
--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -140,22 +140,31 @@ workflows:
           requires:
             - vfcommon/provision-env
             - vfcommon/update_track
-      - vfcommon/build-e2e-tests:
-          context: dev-test
-          filters: *bors_branches_filters
+      # - vfcommon/build-e2e-tests:
+      #     context: dev-test
+      #     filters: *bors_branches_filters
 
-      - vfcommon/run-e2e-tests:
+      # - vfcommon/run-e2e-tests:
+      #     context: dev-test
+      #     env-name: {{ .values.e2e_env_name }}
+      #     requires:
+      #       - vfcommon/build-e2e-tests
+      #       - vfcommon/prepare-env
+      #     filters: *bors_branches_filters
+      - vfcommon/run-smoke-tests:
           context: dev-test
-          env-name: {{ .values.e2e_env_name }}
+          e2e-env-name: {{ .values.e2e_env_name }}
+          branch-or-commit: ci
           requires:
-            - vfcommon/build-e2e-tests
+            # - vfcommon/build-e2e-tests
             - vfcommon/prepare-env
           filters: *bors_branches_filters
       - vfcommon/release-env:
           context: dev-test
           env-name: {{ .values.e2e_env_name }}
           requires:
-            - vfcommon/run-e2e-tests
+            # - vfcommon/run-e2e-tests
+            - vfcommon/run-smoke-tests
           filters: *bors_branches_filters
 
       - vfcommon/sync_branches:

--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,8 @@ status = [
   "ci/circleci: update_track",
   "ci/circleci: install_and_build",
   "ci/circleci: test",
-  "ci/circleci: run-e2e-tests",
+  # "ci/circleci: run-e2e-tests",
+  "ci/circleci: run-smoke-tests",
   "ci/circleci: provision-env",
   "ci/circleci: prepare-env",
 ]


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements DX-993**

### Brief description. What is this change?

Run smoke test suite instead of E2E tests

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test