### PR TITLE
[Merged by Bors] - feat: added logging for edge case where lambda response is null (BUG-741) [bugfix]

### DIFF
--- a/runtime/lib/HTTPClient/function-lambda/function-lambda-client.ts
+++ b/runtime/lib/HTTPClient/function-lambda/function-lambda-client.ts
@@ -18,6 +18,7 @@ import {
   FunctionLambdaSuccessResponse,
   FunctionLambdaSuccessResponseDTO,
 } from './function-lambda-client.interface';
+import { AWSResponsePayload } from './function-lambda-client.types';
 import { LambdaErrorCode } from './lambda-error-code.enum';
 
 export class FunctionLambdaClient {
@@ -159,7 +160,16 @@ export class FunctionLambdaClient {
 
           reject(new Error('Lambda did not send back a response'));
         } else {
-          const parsedPayload = JSON.parse(data.Payload as string);
+          const parsedPayload: null | AWSResponsePayload = JSON.parse(data.Payload as string);
+
+          if (parsedPayload === null) {
+            log.error(`Received null payload from function lambda, data.Payload=${data.Payload.toString()}`);
+
+            reject(new Error('Unknown error, `function-lambda` sent back `data.Payload === null`'));
+
+            return;
+          }
+
           const responseBody = parsedPayload.body;
 
           if (parsedPayload.statusCode !== HTTP_STATUS.OK) {

--- a/runtime/lib/HTTPClient/function-lambda/function-lambda-client.ts
+++ b/runtime/lib/HTTPClient/function-lambda/function-lambda-client.ts
@@ -163,7 +163,7 @@ export class FunctionLambdaClient {
 
           reject(new Error('Lambda did not send back a response'));
         } else {
-          const rawPayload = null;
+          const rawPayload = JSON.parse(data.Payload.toString());
           const zodParseResult = AWSSuccessResponsePayloadDTO.safeParse(rawPayload);
 
           if (!zodParseResult.success) {

--- a/runtime/lib/HTTPClient/function-lambda/function-lambda-client.ts
+++ b/runtime/lib/HTTPClient/function-lambda/function-lambda-client.ts
@@ -1,5 +1,4 @@
 import { InternalServerErrorException } from '@voiceflow/exception';
-import { HTTP_STATUS } from '@voiceflow/verror';
 import AWS from 'aws-sdk';
 import { performance } from 'perf_hooks';
 import { z } from 'zod';
@@ -18,7 +17,7 @@ import {
   FunctionLambdaSuccessResponse,
   FunctionLambdaSuccessResponseDTO,
 } from './function-lambda-client.interface';
-import { AWSResponsePayload } from './function-lambda-client.types';
+import { AWSSuccessResponsePayloadDTO } from './function-lambda-client.types';
 import { LambdaErrorCode } from './lambda-error-code.enum';
 
 export class FunctionLambdaClient {
@@ -129,6 +128,10 @@ export class FunctionLambdaClient {
     );
   }
 
+  private isLambdaErrorResponse(data: unknown): data is FunctionLambdaErrorResponse {
+    return FunctionLambdaErrorResponseDTO.safeParse(data).success;
+  }
+
   private invokeLambda(request: FunctionLambdaRequest): Promise<FunctionLambdaSuccessResponse> {
     const params: AWS.Lambda.InvocationRequest = {
       FunctionName: this.functionLambdaARN,
@@ -160,34 +163,37 @@ export class FunctionLambdaClient {
 
           reject(new Error('Lambda did not send back a response'));
         } else {
-          const parsedPayload: null | AWSResponsePayload = JSON.parse(data.Payload as string);
+          const rawPayload = null;
+          const zodParseResult = AWSSuccessResponsePayloadDTO.safeParse(rawPayload);
 
-          if (parsedPayload === null) {
-            log.error(`Received null payload from function lambda, data.Payload=${data.Payload.toString()}`);
+          if (!zodParseResult.success) {
+            log.error(`Received unexpected payload from function lambda, data.Payload=${data.Payload.toString()}`);
 
-            reject(new Error('Unknown error, `function-lambda` sent back `data.Payload === null`'));
+            reject(
+              new Error(`\`function-lambda\` sent back unexpected data, data.Payload= ${data.Payload.toString()}`)
+            );
 
             return;
           }
 
-          const responseBody = parsedPayload.body;
+          const parsedPayload = zodParseResult.data;
 
-          if (parsedPayload.statusCode !== HTTP_STATUS.OK) {
+          if (this.isLambdaErrorResponse(parsedPayload.body)) {
             log.error(
-              `[${
-                this.errorLabel
-              }]: Received non-200 status from \`function-lambda\`, latency=${timeElapsed} ms, responseBody=${JSON.stringify(
-                responseBody,
+              `[${this.errorLabel}]: Received ${
+                parsedPayload.statusCode
+              } status from \`function-lambda\`, latency=${timeElapsed} ms, responseBody=${JSON.stringify(
+                parsedPayload.body,
                 null,
                 2
               )}`
             );
 
-            reject(responseBody);
+            reject(parsedPayload.body);
           } else {
             log.info(`Function lambda invocation was resolved, latency=${timeElapsed} ms`);
 
-            resolve(responseBody);
+            resolve(parsedPayload.body);
           }
         }
       });
@@ -212,7 +218,7 @@ export class FunctionLambdaClient {
         throw this.createLambdaException(lambdaError.data);
       }
 
-      const errorBody = (err.message ?? JSON.stringify(err, null, 2)).slice(0, 100);
+      const errorBody = (err.message ?? JSON.stringify(err, null, 2)).slice(0, 2048);
 
       log.error(`[${this.errorLabel}]: An unknown internal server error occurred, errorBody=${errorBody}`);
 

--- a/runtime/lib/HTTPClient/function-lambda/function-lambda-client.types.ts
+++ b/runtime/lib/HTTPClient/function-lambda/function-lambda-client.types.ts
@@ -1,6 +1,10 @@
-import { FunctionLambdaSuccessResponse } from './function-lambda-client.interface';
+import { z } from 'zod';
 
-export interface AWSResponsePayload {
-  statusCode: number;
-  body: FunctionLambdaSuccessResponse;
-}
+import { FunctionLambdaResponseDTO } from './function-lambda-client.interface';
+
+export const AWSSuccessResponsePayloadDTO = z.object({
+  statusCode: z.number(),
+  body: FunctionLambdaResponseDTO,
+});
+
+export type AWSSuccessResponsePayload = z.infer<typeof AWSSuccessResponsePayloadDTO>;

--- a/runtime/lib/HTTPClient/function-lambda/function-lambda-client.types.ts
+++ b/runtime/lib/HTTPClient/function-lambda/function-lambda-client.types.ts
@@ -1,0 +1,6 @@
+import { FunctionLambdaSuccessResponse } from './function-lambda-client.interface';
+
+export interface AWSResponsePayload {
+  statusCode: number;
+  body: FunctionLambdaSuccessResponse;
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements BUG-741**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Adding logging to catch a strange edge-case where the AWS Lambda `function-lambda` returns `null` in one of its response data, which is throwing an uncaught exception that shuts down the `general-runtime`.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test