### PR TITLE
fix: check button label before setting last utterance (PL-000) [bug-fix]

### DIFF
--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -63,7 +63,7 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
       }
     }
 
-    if (isPathRequest(request) && request.payload.label) {
+    if (isPathRequest(request) && typeof request.payload?.label === 'string') {
       runtime.variables.set(VoiceflowConstants.BuiltInVariable.LAST_UTTERANCE, request.payload.label);
     }
 


### PR DESCRIPTION
It seems that `payload` can be undefined, which the types do not indicate.

![image](https://github.com/voiceflow/general-runtime/assets/15315657/1d3ffddc-3693-4868-bab3-bd2628d52ca1)
