### PR TITLE
fix: payload type is wrong, can be undefined (PL-752) [bugfix]

### DIFF
--- a/lib/services/runtime/index.ts
+++ b/lib/services/runtime/index.ts
@@ -63,7 +63,7 @@ class RuntimeManager extends AbstractManager<{ utils: typeof utils }> implements
       }
     }
 
-    if (isPathRequest(request) && typeof request.payload?.label === 'string') {
+    if (isPathRequest(request)) {
       runtime.variables.set(VoiceflowConstants.BuiltInVariable.LAST_UTTERANCE, request.payload.label);
     }
 

--- a/lib/services/runtime/types.ts
+++ b/lib/services/runtime/types.ts
@@ -38,7 +38,10 @@ export const isActionRequest = (request?: RuntimeRequest | null): request is Bas
   !!request && BaseRequest.isActionRequest(request);
 
 export const isPathRequest = (request?: RuntimeRequest | null): request is BaseRequest.GeneralRequest =>
-  !!request && BaseRequest.isGeneralRequest(request) && request.type.startsWith('path-');
+  !!request &&
+  BaseRequest.isGeneralRequest(request) &&
+  request.type.startsWith('path-') &&
+  typeof request.payload?.label === 'string';
 
 export const isRuntimeRequest = (request: any): request is RuntimeRequest => {
   return request === null || !!(typeof request.type === 'string' && !!request.type);


### PR DESCRIPTION
Caused by: https://github.com/voiceflow/general-runtime/pull/698

The `isPathRequest` guard did not assert a payload label existed, so when using that in the ai memory variable the types indicate that payload will be there.

![image](https://github.com/voiceflow/general-runtime/assets/15315657/b2e59242-c146-4c11-a4d9-148438cadaa4)

So accessing `payload.label` resulted in a "Cannot read payload from undefined" error.

This change adds a `payload.label` check to guard itself, as the typing for `payload` is wrong, and could be null or undefined.

![image](https://github.com/voiceflow/general-runtime/assets/15315657/eac325bf-1b69-4e6b-b7c0-296987f61e47)

See: https://github.com/voiceflow/general-runtime/pull/690

