### PR TITLE
[Merged by Bors] - fix: simplified buttons are action requests (PL-839)

### DIFF
--- a/runtime/lib/Handlers/function/lib/execute-function/lib/adapt-trace.ts
+++ b/runtime/lib/Handlers/function/lib/execute-function/lib/adapt-trace.ts
@@ -90,7 +90,7 @@ const adaptButton = (button: SimpleButton): BaseRequest.GeneralRequestButton => 
   return {
     name: button.name,
     request: {
-      type: `function-request-${button.name}`,
+      type: 'action',
       payload: {
         label: button.name,
         actions: button.payload.actions.map((act) => adaptAction(act)),

--- a/runtime/lib/Handlers/function/lib/execute-function/lib/adapt-trace.ts
+++ b/runtime/lib/Handlers/function/lib/execute-function/lib/adapt-trace.ts
@@ -86,11 +86,11 @@ const adaptAction = (action: SimpleAction): BaseRequest.Action.BaseAction => {
   };
 };
 
-const adaptButton = (button: SimpleButton): BaseRequest.GeneralRequestButton => {
+const adaptButton = (button: SimpleButton): BaseRequest.ActionRequestButton => {
   return {
     name: button.name,
     request: {
-      type: 'action',
+      type: BaseRequest.RequestType.ACTION,
       payload: {
         label: button.name,
         actions: button.payload.actions.map((act) => adaptAction(act)),


### PR DESCRIPTION
Carousel/card buttons created from a function can only open URLs, and should not send a request to the runtime. If a request is sent, we ensure it is of type `action`, so we do not execute the runtime.

See: https://github.com/voiceflow/general-runtime/pull/678