### PR TITLE
[Merged by Bors] - fix: test removing dd trace [bugfix] (BUG-1172)

### DIFF
--- a/start.ts
+++ b/start.ts
@@ -1,7 +1,8 @@
 import 'core-js';
 import 'regenerator-runtime/runtime';
-import './tracer';
 
+// temporarily remove tracer to test memory leak
+// import './tracer';
 import { ServiceManager } from './backend';
 import config from './config';
 import log from './logger';


### PR DESCRIPTION
In my heap dump I notice that the dd trace often takes a substantial portion of the memory (100MB)

I'm not sure if it is the underlying issue, but just going through hypothesises and testing right now.

Turning it off temporarily and monitoring production.
<img width="1726" alt="Screenshot 2024-03-09 at 6 38 37 PM" src="https://github.com/voiceflow/general-runtime/assets/5643574/2cab0f32-0f85-4580-98b6-790876fe99c2">
