### PR TITLE
[Merged by Bors] - fix: use immer 10 (PL-000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "form-data": "3.0.0",
     "helmet": "^4.6.0",
     "html-parse-stringify": "3.0.1",
-    "immer": "^9.0.6",
+    "immer": "10.0.4",
     "ioredis": "^4.22.0",
     "ip-range-check": "^0.2.0",
     "isolated-vm": "^4.5.0",

--- a/runtime/lib/Runtime/Stack/index.ts
+++ b/runtime/lib/Runtime/Stack/index.ts
@@ -1,4 +1,4 @@
-import produce from 'immer';
+import { produce } from 'immer';
 
 import { Event, EventType } from '@/runtime/lib/Lifecycle';
 

--- a/runtime/lib/Runtime/Store/index.ts
+++ b/runtime/lib/Runtime/Store/index.ts
@@ -1,5 +1,6 @@
 import { AnyRecord } from '@voiceflow/base-types';
-import produce, { Draft } from 'immer';
+import type { Draft } from 'immer';
+import { produce } from 'immer';
 
 export type State = Readonly<AnyRecord>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4511,7 +4511,7 @@ __metadata:
     html-parse-stringify: 3.0.1
     http-status: ^1.4.2
     husky: ^4.3.8
-    immer: ^9.0.6
+    immer: 10.0.4
     ioredis: ^4.22.0
     ip-range-check: ^0.2.0
     isolated-vm: ^4.5.0
@@ -10211,6 +10211,13 @@ __metadata:
   version: 3.0.6
   resolution: "immediate@npm:3.0.6"
   checksum: f9b3486477555997657f70318cc8d3416159f208bec4cca3ff3442fd266bc23f50f0c9bd8547e1371a6b5e82b821ec9a7044a4f7b944798b25aa3cc6d5e63e62
+  languageName: node
+  linkType: hard
+
+"immer@npm:10.0.4":
+  version: 10.0.4
+  resolution: "immer@npm:10.0.4"
+  checksum: 8c69cad9adde7296b6857aadc0837b792840d46d5b5759002cfc168abe58815bd5b944a9533a03df4738d6ce3dc918cc0a88437324fd71e1fcbd2e77273c39f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We don't actually use immer much, but immer 10 has a 33% peformance upgrade and is generally nice.
https://github.com/immerjs/immer/releases/tag/v10.0.0

The only place in the code I could functionally trace us using it is to pop frames off the stack:
https://github.com/voiceflow/general-runtime/blob/7369f5037d7f083490a91501650f461813d4cdb5/runtime/lib/Runtime/Stack/index.ts#L48-L58

So pretty low risk, low blast radius. Just a side effect of some of my investigations.