### PR TITLE
[Merged by Bors] - fix: streamline kb answer synthesis calls (PL-875)

### DIFF
--- a/lib/services/aiSynthesis/index.ts
+++ b/lib/services/aiSynthesis/index.ts
@@ -3,13 +3,7 @@ import dedent from 'dedent';
 import _merge from 'lodash/merge';
 
 import { AIModelContext } from '@/lib/clients/ai/ai-model.interface';
-import {
-  AIResponse,
-  EMPTY_AI_RESPONSE,
-  fetchChat,
-  fetchPrompt,
-  getMemoryMessages,
-} from '@/lib/services/runtime/handlers/utils/ai';
+import { AIResponse, EMPTY_AI_RESPONSE, fetchChat, getMemoryMessages } from '@/lib/services/runtime/handlers/utils/ai';
 import { getCurrentTime } from '@/lib/services/runtime/handlers/utils/generativeNoMatch';
 import {
   addFaqTrace,
@@ -73,60 +67,24 @@ class AISynthesis extends AbstractManager {
 
     const options = { model, system: systemWithTime, temperature, maxTokens };
 
-    if (
-      [BaseUtils.ai.GPT_MODEL.GPT_3_5_turbo, BaseUtils.ai.GPT_MODEL.GPT_4, BaseUtils.ai.GPT_MODEL.GPT_4_turbo].includes(
-        model
-      )
-    ) {
-      // for GPT-3.5 and 4.0 chat models
-      const messages = [
-        {
-          role: BaseUtils.ai.Role.USER,
-          content: generateAnswerSynthesisPrompt({ query: question, instruction, data }),
-        },
-      ];
+    // for GPT-3.5 and 4.0 chat models
+    const messages = [
+      {
+        role: BaseUtils.ai.Role.USER,
+        content: generateAnswerSynthesisPrompt({ query: question, instruction, data }),
+      },
+    ];
 
-      response = await fetchChat(
-        { ...options, messages },
-        this.services.mlGateway,
-        {
-          retries: this.DEFAULT_ANSWER_SYNTHESIS_RETRIES,
-          retryDelay: this.DEFAULT_ANSWER_SYNTHESIS_RETRY_DELAY_MS,
-          context,
-        },
-        variables
-      );
-    } else if ([BaseUtils.ai.GPT_MODEL.DaVinci_003].includes(model)) {
-      // for GPT-3 completion model
-      const prompt = dedent`
-        <context>
-          ${stringifyChunks(data)}
-        </context>
-
-        If you don't know the answer say exactly "NOT_FOUND".\n\nQ: ${question}\nA: `;
-
-      response = await fetchPrompt(
-        { ...options, prompt, mode: BaseUtils.ai.PROMPT_MODE.PROMPT },
-        this.services.mlGateway,
-        { context },
-        variables
-      );
-    } else if (
-      [
-        BaseUtils.ai.GPT_MODEL.CLAUDE_INSTANT_V1,
-        BaseUtils.ai.GPT_MODEL.CLAUDE_V1,
-        BaseUtils.ai.GPT_MODEL.CLAUDE_V2,
-      ].includes(model)
-    ) {
-      const prompt = generateAnswerSynthesisPrompt({ query: question, instruction, data });
-
-      response = await fetchPrompt(
-        { ...options, prompt, mode: BaseUtils.ai.PROMPT_MODE.PROMPT },
-        this.services.mlGateway,
-        { context },
-        variables
-      );
-    }
+    response = await fetchChat(
+      { ...options, messages },
+      this.services.mlGateway,
+      {
+        retries: this.DEFAULT_ANSWER_SYNTHESIS_RETRIES,
+        retryDelay: this.DEFAULT_ANSWER_SYNTHESIS_RETRY_DELAY_MS,
+        context,
+      },
+      variables
+    );
 
     response.output = response.output?.trim() || null;
     if (response.output) {

--- a/lib/services/aiSynthesis/index.ts
+++ b/lib/services/aiSynthesis/index.ts
@@ -67,7 +67,6 @@ class AISynthesis extends AbstractManager {
 
     const options = { model, system: systemWithTime, temperature, maxTokens };
 
-    // for GPT-3.5 and 4.0 chat models
     const messages = [
       {
         role: BaseUtils.ai.Role.USER,


### PR DESCRIPTION
What is going on?
Basically we had a if condition with 3 branches:
```
if (model IS OpenAI Chat models) {
  // use ml-gateway chat API
} else if (model IS BaseUtils.ai.GPT_MODEL.DaVinci_003) {
  // use this weird custom prompt
} else if (model IS claude model) {
  // use ml-gateway text completion API
}
```

### DaVinci_003 branch
First off, `BaseUtils.ai.GPT_MODEL.DaVinci_003`, is completely deprecated. OpenAI already killed it.
If you look at `ml-gateway`, you'll see that we actually just remap all the requests to GPT 3.5:
https://github.com/voiceflow/creator-app/blob/master/apps/ml-gateway/src/llm/llm.service.ts#L29-L30

No point in maintaining a constant prompt just for `DaVinci_003`. I acknowledge and know this might potentially change the behavior of the KB for people using it, and we are conciously moving forward with this. Most of our high value and high usage customers don't even use our answer synthesis - they do a API step followed up by a bunch of AI Set Steps.
Basically they will just get the standard, default KB experience with GPT 3.5 now, which I am pretty sure is better than before. 
So we're going to remove that branch from that if condition. 

### Claude Text Completion branch
So there's two types of LLM APIs: 
* Text completion (here's a paragraph with a run a sentence, finish it)
* messages/chat (here's a transcript of a conversation, what does the agent say next?)

Both OpenAI and Anthropic have definitively moved over to the "messages" format. 
We do some hackiness in `ml-gateway` to allow every model to be able to handle both formats (API adapters). But if you carefully look at [claude implementations](https://github.com/voiceflow/creator-app/blob/f48cebe4e1e5888c78e31c75859bf38077d1c8cf/apps/ml-gateway/src/llm/anthropic/anthropic.abstract.ts#L34-L39), you will see that we actually just remap the text completion api to the messages one.

So technically there's 0 difference functionally between calling `fetchChat` or `fetchPrompt` for any of the claude models. 
**I have done logging here and confirm it, the final API request we give to anthropic is the EXACT same.**
<img width="1383" alt="Screenshot 2024-03-14 at 3 39 02 PM" src="https://github.com/voiceflow/general-runtime/assets/5643574/e6aae810-20e4-4250-8fb2-461e70b1ff5e">
So we're going to remove that branch from that if condition. 


Okay, we only have one condition branch now, do we even need that branch? Before we were filtering by model name. The worst case scenerio is that `ml-gateway` gets a model it doesn't accept, it will just fail and `response` will be `null`. No big deal.

So now we can simplify a shitton of messy logic and folks no longer have to go into `general-runtime` to add a new model.

