### PR TITLE
[Merged by Bors] - fix: dev flag for ivm (PL-000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "build": "rm -rf build && tsc -p ./tsconfig.build.json && tsc-alias -p ./tsconfig.build.json && cpy app.config.js yarn.lock build/",
     "commit": "cz",
     "connect:cli": "vfcli mesh connect general-runtime -c \"/bin/bash\"",
-    "dev": "ts-node-dev --files --respawn --exit-child --transpile-only -r tsconfig-paths/register --inspect -- start.ts",
+    "dev": "ts-node-dev --files --respawn --exit-child --transpile-only -r tsconfig-paths/register --inspect --no-node-snapshot -- start.ts",
     "docs:gen": "typedoc ./lib ./config.ts",
     "e2e": "yarn kill:e2e && NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_ENV=e2e yarn start:base",
     "e2e:check-deps": "npx wait-on https://localhost:8011/health",


### PR DESCRIPTION
We forgot to add the `--no-node-snapshot` for the meshing/dev flow.
It is mandated by isolated-vim:
<img width="834" alt="Screenshot 2024-03-21 at 4 06 14 PM" src="https://github.com/voiceflow/general-runtime/assets/5643574/acf31a36-59e9-4127-a7d6-5100c18ade1f">
