### PR TITLE
[Merged by Bors] - fix: max node memory threshold [bugfix] (PL-000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "mesh:pre": "exit 0",
     "redoc": "redoc-cli serve backend/docs/openapi.yaml --ssr --watch",
     "start": "cross-env NODE_ENV=production yarn start:base",
-    "start:base": "node --no-node-snapshot --max-old-space-size=8192 build/start.js",
+    "start:base": "node --no-node-snapshot --max-old-space-size=4096 build/start.js",
     "start:local": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 IS_MESHED=true NODE_ENV=local yarn dev",
     "start:meshed": "yarn start:local",
     "test": "yarn test:run",


### PR DESCRIPTION
So our production instances are only at 1.5GB.

Under any regular circumstance, the node memory threshold should be higher than the pod's memory threshold, because this gives us visibility when something goes OOM.

Setting it to 4GB allows me to set the pod to just 4.5 GB for doing a heap dump. Otherwise I'd have to set it to 8.5GB or something for the 8GB configuration.