### PR TITLE
[Merged by Bors] - fix: remove required-from-url (PL-754)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "nestjs-zod": "2.3.3",
     "node-fetch": "^2.7.0",
     "regenerator-runtime": "^0.13.3",
-    "require-from-url": "^3.1.3",
     "slate": "0.72.3",
     "talisman": "^1.1.3",
     "ts-pattern": "^4.0.5",

--- a/runtime/lib/Handlers/code/index.ts
+++ b/runtime/lib/Handlers/code/index.ts
@@ -49,7 +49,7 @@ const CodeHandler: HandlerFactory<BaseNode.Code.Node, CodeOptions> = ({
         //  so the remote executor can be removed, leaving only isolated-vm
         const [endpointResult, ivmResult] = await Promise.allSettled([
           utils.remoteVMExecute(endpoint, reqData),
-          utils.ivmExecute(reqData, callbacks, { legacyRequireFromUrl: true }),
+          utils.ivmExecute(reqData, callbacks),
         ]);
 
         const logExecutionResult = utils.createExecutionResultLogger(log, {

--- a/runtime/lib/Handlers/code/utils.ts
+++ b/runtime/lib/Handlers/code/utils.ts
@@ -4,7 +4,6 @@ import type { Logger } from '@voiceflow/logger';
 import axios from 'axios';
 import ivm from 'isolated-vm';
 import { isDeepStrictEqual } from 'node:util';
-import requireFromUrl from 'require-from-url/sync';
 
 import Store from '@/runtime/lib/Runtime/Store';
 
@@ -14,14 +13,9 @@ const ISOLATED_VM_LIMITS = {
   maxExecutionTimeMs: 1 * 1000,
 };
 
-export interface IvmExecuteOptions {
-  legacyRequireFromUrl?: boolean;
-}
-
 export const ivmExecute = async (
   data: { code: string; variables: Record<string, any> },
-  callbacks?: Record<string, (...args: any) => any>,
-  options: IvmExecuteOptions = {}
+  callbacks?: Record<string, (...args: any) => any>
 ) => {
   // Create isolate with 8mb max memory
   const isolate = new ivm.Isolate({ memoryLimit: ISOLATED_VM_LIMITS.maxMemoryMB });
@@ -38,11 +32,6 @@ export const ivmExecute = async (
       // set Promise to not do anything in code because it has complex functionality inside the vm
       jail.set('Promise', null),
     ]);
-
-    if (options.legacyRequireFromUrl) {
-      // support legacy `requireFromUrl` functionality
-      await jail.set('requireFromUrl', (url: string) => requireFromUrl(url));
-    }
 
     // add callbacks if exists
     if (callbacks) {

--- a/runtime/typings/require-from-url.d.ts
+++ b/runtime/typings/require-from-url.d.ts
@@ -1,3 +1,0 @@
-declare module 'require-from-url/sync' {
-  export default function sync(urlString: string): any;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4708,7 +4708,6 @@ __metadata:
     prettier-eslint-cli: ^5.0.0
     redoc-cli: ^0.12.3
     regenerator-runtime: ^0.13.3
-    require-from-url: ^3.1.3
     sinon: ^7.5.0
     slate: 0.72.3
     source-map-support: ^0.5.19
@@ -15184,13 +15183,6 @@ __metadata:
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
   checksum: a03ef6895445f33a4015300c426699bc66b2b044ba7b670aa238610381b56d3f07c686251740d575e22f4c87531ba662d06937508f0f3c0f1ddc04db3130560b
-  languageName: node
-  linkType: hard
-
-"require-from-url@npm:^3.1.3":
-  version: 3.1.3
-  resolution: "require-from-url@npm:3.1.3"
-  checksum: 9897f054a888346dbfb2609e69615cb97cb8c7ae5245cdf2376db613ef2060e28e318e4b8f3e83657fdb862df31d86c0116b12d6c86dcee14a2d22cb723a4f42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This will never work:
`await jail.set('requireFromUrl', (url: string) => requireFromUrl(url));`

It will simply crash whenever, you can not clone anything that is not a primative object between the runtime and the v8 isolate.
![Screenshot 2024-03-23 at 5 55 17 PM](https://github.com/voiceflow/general-runtime/assets/5643574/dd318cea-5d26-4095-b882-5b4c9961eb9d)

I think it is better to get into the motion of deprecating this.