### PR TITLE
refactor: predictor as event emitter for debug tracing (PL-844)

### DIFF
--- a/lib/services/classification/predictor.class.ts
+++ b/lib/services/classification/predictor.class.ts
@@ -1,6 +1,6 @@
 import { Utils } from '@voiceflow/common';
 import { DEFAULT_INTENT_CLASSIFICATION_PROMPT_WRAPPER_CODE } from '@voiceflow/default-prompt-wrappers';
-import { DebugTraceDTO, IntentClassificationSettings } from '@voiceflow/dtos';
+import { IntentClassificationSettings } from '@voiceflow/dtos';
 import { ISlotFullfilment } from '@voiceflow/natural-language-commander';
 import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import type { AxiosStatic } from 'axios';

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -11,7 +11,7 @@ import { Context, ContextHandler, VersionTag } from '@/types';
 
 import { DebugEvent, Predictor } from '../classification';
 import { castToDTO } from '../classification/classification.utils';
-import { ClassificationResult, PredictError, Prediction } from '../classification/interfaces/nlu.interface';
+import { Prediction } from '../classification/interfaces/nlu.interface';
 import { AbstractManager } from '../utils';
 import { getNoneIntentRequest } from './utils';
 

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -9,7 +9,7 @@ import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import { isTextRequest } from '@/lib/services/runtime/types';
 import { Context, ContextHandler, VersionTag } from '@/types';
 
-import { Predictor } from '../classification';
+import { DebugEvent, Predictor } from '../classification';
 import { castToDTO } from '../classification/classification.utils';
 import { ClassificationResult, PredictError, Prediction } from '../classification/interfaces/nlu.interface';
 import { AbstractManager } from '../utils';
@@ -78,9 +78,9 @@ class NLU extends AbstractManager implements ContextHandler {
       }
     );
 
-    const addDebug = (error: PredictError, type?: ClassificationResult['result']) => {
-      const prefix = type && `${type.toUpperCase()}: `;
-      return context.trace?.push(debugTrace(`${prefix}${error.message}`));
+    const addDebug = (event: DebugEvent) => {
+      const prefix = `${event.type.toUpperCase()}: `;
+      return context.trace?.push(debugTrace(`${prefix}${event.message}`));
     };
 
     if (context.trace) {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-844**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Debug tracing is best left within the `Predictor` class as it has all the context and ordering of events.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

`Predictor extends EventEmitter` and emits debug information. The caller can choose to listen and map to traces, or ignore all together