### PR TITLE
[Merged by Bors] - edison/datadog apm not working (in-921)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -141,3 +141,4 @@ const CONFIG: Config = {
 };
 
 export default CONFIG;
+export const APP_NAME = 'general-runtime';

--- a/start.ts
+++ b/start.ts
@@ -1,7 +1,7 @@
 import 'core-js';
 import 'regenerator-runtime/runtime';
+import './tracer';
 
-// import './tracer';
 import { ServiceManager } from './backend';
 import config from './config';
 import log from './logger';

--- a/tracer.ts
+++ b/tracer.ts
@@ -1,7 +1,10 @@
 // tracer.ts
 import tracer from 'dd-trace';
 
+import { APP_NAME } from './config';
+
 tracer.init({
+  service: APP_NAME,
   runtimeMetrics: true,
   profiling: true,
   logInjection: true,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* Linear [ticket](https://linear.app/voiceflow/issue/IN-921/datadog-apm-not-working-on-general-runtime) 

### Brief description. What is this change?
* After related PR was merged, general-runtime no longer showed on APM list 
* This is because it was disabled during mongo memory leak debugging 
* The related PR was a seperate PR to add profiling capabilities, so when it was merged, we missed the line of code to enable dd-trace back, i.e when the nodejs server is starting 

### What this change does 
* Re-enable datadog 
* Add application name so that metric collection and attribution can work correctly for `nodejs` runtime profiling  

### Related PRs

* https://github.com/voiceflow/general-runtime/pull/730

<!-- List related PRs against other branches -->

### Checklist

- [x] Tested on vftest-89