### PR TITLE
fix: fix settings (PL-844)

### DIFF
--- a/lib/clients/dataAPI.ts
+++ b/lib/clients/dataAPI.ts
@@ -1,4 +1,4 @@
-import { VoiceflowProgram, VoiceflowVersion } from '@voiceflow/voiceflow-types';
+import { VoiceflowProgram, VoiceflowProject, VoiceflowVersion } from '@voiceflow/voiceflow-types';
 
 import { LocalDataApi } from '@/runtime';
 import { Config } from '@/types';
@@ -11,7 +11,7 @@ import Static from './static';
  * Build all clients
  */
 class DataAPI {
-  localDataApi?: LocalDataApi<VoiceflowProgram.Program, VoiceflowVersion.Version>;
+  localDataApi?: LocalDataApi<VoiceflowProgram.Program, VoiceflowVersion.Version, VoiceflowProject.Project>;
 
   prototypeDataApi?: PrototypeDataAPI;
 

--- a/lib/clients/prototypeDataAPI.ts
+++ b/lib/clients/prototypeDataAPI.ts
@@ -1,8 +1,12 @@
-import { VoiceflowProgram, VoiceflowVersion } from '@voiceflow/voiceflow-types';
+import { VoiceflowProgram, VoiceflowProject, VoiceflowVersion } from '@voiceflow/voiceflow-types';
 
 import { MongoDataAPI } from '@/runtime';
 
-class PrototypeDataAPI extends MongoDataAPI<VoiceflowProgram.Program, VoiceflowVersion.Version> {
+class PrototypeDataAPI extends MongoDataAPI<
+  VoiceflowProgram.Program,
+  VoiceflowVersion.Version,
+  VoiceflowProject.Project
+> {
   protected programsCollection = 'prototype-programs';
 }
 

--- a/lib/controllers/nlu.ts
+++ b/lib/controllers/nlu.ts
@@ -75,11 +75,7 @@ class NLUController extends AbstractController {
       throw new VError('Missmatch in projectID/versionID', VError.HTTP_STATUS.BAD_REQUEST);
     }
 
-    const { settings, intents, slots } = castToDTO(version);
-
-    if (!settings?.intentClassification) {
-      throw new Error('');
-    }
+    const { intentClassificationSettings, intents, slots } = castToDTO(version, project);
 
     const predictor = new Predictor(
       {
@@ -96,7 +92,7 @@ class NLUController extends AbstractController {
         intents: intents ?? [],
         slots: slots ?? [],
       },
-      settings.intentClassification,
+      intentClassificationSettings,
       {
         locale: version.prototype?.data.locales[0] as VoiceflowConstants.Locale,
         hasChannelIntents: project?.platformData?.hasChannelIntents,

--- a/lib/services/classification/classification.const.ts
+++ b/lib/services/classification/classification.const.ts
@@ -1,0 +1,24 @@
+import { DEFAULT_INTENT_CLASSIFICATION_PROMPT_WRAPPER_CODE } from '@voiceflow/default-prompt-wrappers';
+import {
+  AIModel,
+  IntentClassificationLLMSettings,
+  IntentClassificationNLUSettings,
+  IntentClassificationType,
+} from '@voiceflow/dtos';
+
+export const DEFAULT_NLU_INTENT_CLASSIFICATION: IntentClassificationNLUSettings = {
+  type: IntentClassificationType.NLU,
+  params: { confidence: 0.6 },
+};
+
+// can be removed after migration PL-846
+export const LEGACY_LLM_INTENT_CLASSIFICATION: IntentClassificationLLMSettings = {
+  type: IntentClassificationType.LLM,
+  params: {
+    model: AIModel.GPT_4_TURBO,
+    temperature: 0.1,
+  },
+  promptWrapper: {
+    content: DEFAULT_INTENT_CLASSIFICATION_PROMPT_WRAPPER_CODE,
+  },
+};

--- a/lib/services/classification/predictor.class.ts
+++ b/lib/services/classification/predictor.class.ts
@@ -28,7 +28,7 @@ const ML_GATEWAY_TIMEOUT = 5000;
 const nonePrediction: Omit<Prediction, 'utterance'> = {
   predictedIntent: VoiceflowConstants.IntentName.NONE,
   predictedSlots: [],
-  confidence: 100,
+  confidence: 1,
 };
 
 const hasValueReducer = (slots?: ISlotFullfilment[]) =>

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -155,11 +155,11 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
 
       try {
         const prefix = dmPrefix(dmStateStore.intentRequest.payload.intent.name);
-        const { settings, intents, slots } = castToDTO(version);
+        const { intentClassificationSettings, intents, slots } = castToDTO(version, project);
 
         let dmPrefixedResult = incomingRequest;
 
-        if (settings && this.isNluGatwayEndpointConfigured()) {
+        if (this.isNluGatwayEndpointConfigured()) {
           const predictor = new Predictor(
             {
               axios: this.services.axios,
@@ -176,7 +176,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
               slots: slots ?? [],
               dmRequest: dmStateStore.intentRequest.payload,
             },
-            settings.intentClassification,
+            intentClassificationSettings,
             {
               locale: version.prototype?.data.locales[0] as VoiceflowConstants.Locale,
               hasChannelIntents: project?.platformData?.hasChannelIntents,

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -49,12 +49,8 @@ class NLU extends AbstractManager implements ContextHandler {
     }
 
     const version = await context.data.api.getVersion(context.versionID);
-    const { settings, intents, slots } = castToDTO(version);
     const project = await context.data.api.getProject(version.projectID);
-
-    if (!settings) {
-      return context;
-    }
+    const { intentClassificationSettings, intents, slots } = castToDTO(version, project);
 
     const predictor = new Predictor(
       {
@@ -71,7 +67,7 @@ class NLU extends AbstractManager implements ContextHandler {
         intents: intents ?? [],
         slots: slots ?? [],
       },
-      settings.intentClassification,
+      intentClassificationSettings,
       {
         locale: version.prototype?.data.locales[0] as VoiceflowConstants.Locale,
         hasChannelIntents: project?.platformData?.hasChannelIntents,


### PR DESCRIPTION
the `version.settings` is strictly optional.
https://github.com/voiceflow/creator-app/blob/cfc893c267d5a9562973fceb01b3f8821668c504/libs/dtos/src/version/version.dto.ts#L33

All existing projects don't have it. 
And the migrations only target projects with existing projects.

The very first test I ran basically failed, so a bit of an oversight there.

I intend to just merge this into [tyler/test-classification-endpoint/PL-844](https://github.com/voiceflow/general-runtime/tree/tyler/test-classification-endpoint/PL-844)