### PR TITLE
fix: dm request logic (PL-844)

### DIFF
--- a/lib/services/classification/interfaces/nlu.interface.ts
+++ b/lib/services/classification/interfaces/nlu.interface.ts
@@ -1,3 +1,4 @@
+import { BaseRequest } from '@voiceflow/base-types';
 import { PrototypeIntent, PrototypeSlot } from '@voiceflow/dtos';
 import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 
@@ -66,6 +67,9 @@ export interface PredictRequest {
   tag: string;
   versionID: string;
   workspaceID: string;
+
+  // legacy
+  dmRequest?: BaseRequest.IntentRequestPayload;
 }
 
 export interface PredictOptions {

--- a/lib/services/classification/predictor.class.ts
+++ b/lib/services/classification/predictor.class.ts
@@ -84,6 +84,7 @@ export class Predictor {
       },
       locale: this.options.locale,
       openSlot,
+      dmRequest: this.props.dmRequest,
     });
 
     if (!data) {
@@ -308,7 +309,7 @@ export class Predictor {
       return nluPrediction;
     }
 
-    if (isIntentClassificationLLMSettings(this.settings)) {
+    if (isIntentClassificationLLMSettings(this.settings) && !this.props.dmRequest?.intent) {
       const llmPrediction = await this.llm(nluPrediction, {
         mlGateway: this.config.mlGateway,
       });

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -174,6 +174,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
               tag: project.liveVersion === context.versionID ? VersionTag.PRODUCTION : VersionTag.DEVELOPMENT,
               intents: intents ?? [],
               slots: slots ?? [],
+              dmRequest: dmStateStore.intentRequest.payload,
             },
             settings.intentClassification,
             {


### PR DESCRIPTION
We were fully missing the logic for dialog service from the old flow, a bit of an oversight.

![Screenshot 2024-04-04 at 12.19.34 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/uwUPDItslwtohkuZjc43/159f1f88-fb42-4fd2-85c6-2e33f0036bdf.png)

this was causing issues during my tests with entity filling, and it was unable to get the entities.

In the old code, this is where it was being passed through:
https://github.com/voiceflow/general-runtime/blob/ca5c4833113610dbca3fce240c933f92bb6d8050/lib/services/dialog/index.ts#L154