### PR TITLE
feat: use nlc in place of nlu for test result (PL-844)

### DIFF
--- a/lib/controllers/test/index.ts
+++ b/lib/controllers/test/index.ts
@@ -180,9 +180,21 @@ class TestController extends AbstractController {
 
     const { predictions } = predictor;
 
+    const nluIntents = (() => {
+      if (predictions.nlu?.intents) {
+        return predictions.nlu.intents;
+      }
+
+      if (predictions.nlc?.predictedIntent) {
+        return [{ name: predictions.nlc.predictedIntent, confidence: predictions.nlc.confidence ?? 1 }];
+      }
+
+      return [];
+    })();
+
     return {
       utterance: predictions.utterance ?? data.utterance,
-      nlu: { intents: predictions.nlu?.intents ?? [] },
+      nlu: { intents: nluIntents },
       llm: {
         intents:
           predictions.llm && predictions.llm.predictedIntent && predictions.llm.confidence


### PR DESCRIPTION
If NLU isn't used, use the NLC result as the NLU result.