### PR TITLE
[Merged by Bors] - ci: local api startup check (PL-916)

### DIFF
--- a/runtime/lib/DataAPI/localDataAPI.ts
+++ b/runtime/lib/DataAPI/localDataAPI.ts
@@ -21,6 +21,14 @@ class LocalDataAPI<
 
     const content = JSON.parse(fs.readFileSync(path.join('projects', projectSource), 'utf8'));
 
+    if (!content.programs || !Object.keys(content.programs).length) {
+      throw new Error('[invalid VFR] no programs included');
+    }
+
+    if (!Object.keys(content.programs).includes(content.version._id)) {
+      throw new Error('[invalid VFR] missing base program');
+    }
+
     this.version = content.version;
     this.project = content.project;
     this.programs = content.programs;


### PR DESCRIPTION
For more details please reference ticket:
https://linear.app/voiceflow/issue/PL-916/throw-error-if-programs-not-initialized-for-vfr-on-general-runtime

Added a check on `localDataAPI` to crash on initialization if VFR file is invalid.

This is the expected output:
<img width="831" alt="Screenshot 2024-04-08 at 1 34 48 PM" src="https://github.com/voiceflow/general-runtime/assets/5643574/1208ece9-1514-43b4-a29b-a76cd9be259c">
<img width="847" alt="Screenshot 2024-04-08 at 1 39 11 PM" src="https://github.com/voiceflow/general-runtime/assets/5643574/236843ed-09a9-4bfa-91c5-5dc4f209e8ed">


