### PR TITLE
[Merged by Bors] - fix: empty kb aggregator crashing (PL-925)

### DIFF
--- a/runtime/lib/DataAPI/mongoDataAPI.ts
+++ b/runtime/lib/DataAPI/mongoDataAPI.ts
@@ -114,7 +114,16 @@ class MongoDataAPI<
         {
           $project: {
             hasDocuments: {
-              $gt: [{ $size: { $objectToArray: '$knowledgeBase.documents' } }, 0],
+              $gt: [
+                {
+                  $size: {
+                    $objectToArray: {
+                      $ifNull: ['$knowledgeBase.documents', {}], // Provide an empty object as default
+                    },
+                  },
+                },
+                0,
+              ],
             },
           },
         },


### PR DESCRIPTION
This query fails:
```
$project: {
  hasDocuments: {
    $gt: [{ $size: { $objectToArray: '$knowledgeBase.documents' } }, 0],
  },
},
```

if `knowledgeBase.documents` DNE.
![image](https://github.com/voiceflow/general-runtime/assets/5643574/98fd0c61-ebb6-4845-8e68-9ca9df80b594)

Easy way to update it is to add more mongo query syntax. 
We implemented this functionality in a massive hurry for the sake of a memory leak. This is going to get redone as part of the KB refactor.

https://www.mongodb.com/docs/manual/reference/operator/aggregation/ifNull/