### PR TITLE
fix: use prediction to get fallback in preview (PL-926)

### DIFF
--- a/lib/controllers/test/index.ts
+++ b/lib/controllers/test/index.ts
@@ -180,7 +180,8 @@ class TestController extends AbstractController {
         filteredIntents: Array.from(extraIntentNames),
       }
     );
-    await predictor.predict(data.utterance);
+
+    const prediction = await predictor.predict(data.utterance);
 
     const { predictions } = predictor;
 
@@ -198,7 +199,7 @@ class TestController extends AbstractController {
         ];
       }
 
-      return [];
+      return [{ name: prediction?.predictedIntent, confidence: prediction?.confidence }];
     })();
 
     return {

--- a/lib/controllers/test/index.ts
+++ b/lib/controllers/test/index.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 
 import { Predictor } from '@/lib/services/classification';
 import { castToDTO } from '@/lib/services/classification/classification.utils';
+import { PredictedIntent } from '@/lib/services/classification/interfaces/nlu.interface';
 import { getAPIBlockHandlerOptions } from '@/lib/services/runtime/handlers/api';
 import { callAPI } from '@/runtime/lib/Handlers/api/utils';
 import { ivmExecute } from '@/runtime/lib/Handlers/code/utils';
@@ -185,7 +186,7 @@ class TestController extends AbstractController {
 
     const { predictions } = predictor;
 
-    const nluIntents = (() => {
+    const nluIntents = ((): PredictedIntent[] => {
       if (predictions.nlu?.intents) {
         return predictions.nlu.intents;
       }
@@ -199,7 +200,16 @@ class TestController extends AbstractController {
         ];
       }
 
-      return [{ name: prediction?.predictedIntent, confidence: prediction?.confidence }];
+      if (!prediction) {
+        throw new VError('No predictions', VError.HTTP_STATUS.NOT_FOUND);
+      }
+
+      return [
+        {
+          name: prediction.predictedIntent,
+          confidence: prediction.confidence,
+        },
+      ];
     })();
 
     return {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Use the returned prediction that would contain the fallback in the preview/test endpoint