### PR TITLE
[Merged by Bors] - feat: don't call NLU if project.prototype.nlp not set (PL-949)

### DIFF
--- a/lib/controllers/nlu.ts
+++ b/lib/controllers/nlu.ts
@@ -75,7 +75,7 @@ class NLUController extends AbstractController {
       throw new VError('Missmatch in projectID/versionID', VError.HTTP_STATUS.BAD_REQUEST);
     }
 
-    const { intentClassificationSettings, intents, slots } = castToDTO(version, project);
+    const { intentClassificationSettings, intents, isTrained, slots } = castToDTO(version, project);
 
     const predictor = new Predictor(
       {
@@ -91,6 +91,7 @@ class NLUController extends AbstractController {
         tag: project.liveVersion === versionID ? VersionTag.PRODUCTION : VersionTag.DEVELOPMENT,
         intents: intents ?? [],
         slots: slots ?? [],
+        isTrained,
       },
       intentClassificationSettings,
       {

--- a/lib/controllers/test/index.ts
+++ b/lib/controllers/test/index.ts
@@ -153,7 +153,7 @@ class TestController extends AbstractController {
 
     const version = await api.getVersion(data.versionID);
     const project = await api.getProject(version.projectID);
-    const { intents, slots } = castToDTO(version, project);
+    const { intents, isTrained, slots } = castToDTO(version, project);
 
     // extra intents has the set of capture intents we want to exclude
     const extraIntentNames = new Set(version.prototype?.surveyorContext.extraIntents.map(({ name }) => name));
@@ -172,6 +172,7 @@ class TestController extends AbstractController {
         tag: project.liveVersion === data.versionID ? VersionTag.PRODUCTION : VersionTag.DEVELOPMENT,
         intents: intents ?? [],
         slots,
+        isTrained,
       },
       data.intentClassificationSettings,
       {

--- a/lib/services/classification/classification.utils.ts
+++ b/lib/services/classification/classification.utils.ts
@@ -36,6 +36,7 @@ export const castToDTO = (
   intentClassificationSettings: IntentClassificationSettings;
   intents?: PrototypeModel['intents'];
   slots?: PrototypeModel['slots'];
+  isTrained: boolean;
 } => {
   const { settings, prototype } = version as unknown as Version;
   const { intents, slots } = prototype?.model ?? {};
@@ -61,5 +62,6 @@ export const castToDTO = (
     intentClassificationSettings,
     intents,
     slots,
+    isTrained: !!project.prototype?.nlp,
   };
 };

--- a/lib/services/classification/interfaces/nlu.interface.ts
+++ b/lib/services/classification/interfaces/nlu.interface.ts
@@ -67,6 +67,7 @@ export interface PredictRequest {
   tag: string;
   versionID: string;
   workspaceID: string;
+  isTrained: boolean;
 
   // legacy
   dmRequest?: BaseRequest.IntentRequestPayload;

--- a/lib/services/classification/predictor.class.ts
+++ b/lib/services/classification/predictor.class.ts
@@ -317,7 +317,7 @@ export class Predictor extends EventEmitter {
       return nlcPrediction;
     }
 
-    const nluPrediction = await this.nlu(utterance, this.options);
+    const nluPrediction = this.props.isTrained && (await this.nlu(utterance, this.options));
 
     if (!nluPrediction) {
       // try open regex slot matching

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -155,7 +155,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
 
       try {
         const prefix = dmPrefix(dmStateStore.intentRequest.payload.intent.name);
-        const { intentClassificationSettings, intents, slots } = castToDTO(version, project);
+        const { intentClassificationSettings, intents, isTrained, slots } = castToDTO(version, project);
 
         let dmPrefixedResult = incomingRequest;
 
@@ -175,6 +175,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
               intents: intents ?? [],
               slots: slots ?? [],
               dmRequest: dmStateStore.intentRequest.payload,
+              isTrained,
             },
             intentClassificationSettings,
             {

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -49,7 +49,7 @@ class NLU extends AbstractManager implements ContextHandler {
 
     const version = await context.data.api.getVersion(context.versionID);
     const project = await context.data.api.getProject(version.projectID);
-    const { intentClassificationSettings, intents, slots } = castToDTO(version, project);
+    const { intentClassificationSettings, intents, isTrained, slots } = castToDTO(version, project);
 
     const predictor = new Predictor(
       {
@@ -65,6 +65,7 @@ class NLU extends AbstractManager implements ContextHandler {
         tag: project.liveVersion === context.versionID ? VersionTag.PRODUCTION : VersionTag.DEVELOPMENT,
         intents: intents ?? [],
         slots: slots ?? [],
+        isTrained,
       },
       intentClassificationSettings,
       {

--- a/tests/lib/services/classification/predictor.class.unit.ts
+++ b/tests/lib/services/classification/predictor.class.unit.ts
@@ -76,6 +76,9 @@ describe('predictor unit tests', () => {
     liveVersion: '1',
     devVersion: '2',
     teamID,
+    prototype: {
+      nlp: true,
+    },
   };
 
   const noneIntent: BaseRequest.IntentRequest = {
@@ -108,6 +111,7 @@ describe('predictor unit tests', () => {
     versionID: version._id,
     workspaceID: String(project.teamID),
     tag: VersionTag.DEVELOPMENT,
+    isTrained: true,
   };
   const defaultSettings: IntentClassificationSettings = {
     type: 'nlu',
@@ -221,6 +225,25 @@ describe('predictor unit tests', () => {
 
       sinon.assert.called(config.axios.post);
       expect(handleNLCCommandStub.callCount).to.eql(2);
+      expect(prediction?.predictedIntent).to.eql(nlcPrediction.intent);
+      expect(result).to.eql('nlc');
+    });
+
+    it('not called when nlp false', async () => {
+      const utterance = 'query-val';
+      const { config, props, settings, options } = setup({
+        axios: { data: null },
+        props: { isTrained: false },
+      });
+      const predictor = new Predictor(config, props, settings.intentClassification, options);
+      const handleNLCCommandStub = sinon.stub(NLC, 'handleNLCCommand');
+      handleNLCCommandStub.returns(nlcPrediction as any);
+
+      const prediction = await predictor.predict(utterance);
+      const { result } = predictor.predictions;
+
+      sinon.assert.notCalled(config.axios.post);
+      expect(handleNLCCommandStub.callCount).to.eql(1);
       expect(prediction?.predictedIntent).to.eql(nlcPrediction.intent);
       expect(result).to.eql('nlc');
     });

--- a/tests/lib/services/nlu/index.unit.ts
+++ b/tests/lib/services/nlu/index.unit.ts
@@ -54,6 +54,9 @@ describe('nlu manager unit tests', () => {
     liveVersion: '1',
     devVersion: '2',
     teamID,
+    prototype: {
+      nlp: true,
+    },
   };
   const liveVersion = 'some-live-version';
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->
We allow publishing without training, so a model may not exist. Check `project.prototype.nlp` for existence of a model.

This is a temporary solution that needs a more robust check because it does not actually indicate that the current version is the one that is trained and available. But will lessen the log noise and unnecessary NLU calls