### PR TITLE
[Merged by Bors] - feat: add listen to the carousel (COR-1928)

### DIFF
--- a/runtime/lib/Handlers/function/lib/execute-function/lib/adapt-trace.ts
+++ b/runtime/lib/Handlers/function/lib/execute-function/lib/adapt-trace.ts
@@ -111,8 +111,8 @@ const adaptButton = (
     // !TODO! - Need to add an empty payload object `{}` because the old button type in
     //          `base-types` requires that `payload` is defined, but the new button type
     //          in `dtos` makes `payload` optional so it's missing when we need it. Need to
-    //          port all code over to the `dtos` package and unify the expectations for this
-    //          property.
+    //          port all code over to the `dtos` package and unify the types across
+    //          `general-runtime` and `creator-app`.
     return {
       ...parsedGeneralButton.data,
       request: {

--- a/runtime/lib/Handlers/function/runtime-command/button/button.dto.ts
+++ b/runtime/lib/Handlers/function/runtime-command/button/button.dto.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+import { SimpleActionButtonDTO } from './action-button.dto';
+import { SimpleGeneralButtonDTO } from './general-button.dto';
+
+export const SimpleButtonDTO = z.union([SimpleActionButtonDTO, SimpleGeneralButtonDTO]);
+
+export type SimpleButton = z.infer<typeof SimpleButtonDTO>;

--- a/runtime/lib/Handlers/function/runtime-command/card/card.dto.ts
+++ b/runtime/lib/Handlers/function/runtime-command/card/card.dto.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { SimpleActionButtonDTO } from '../button/action-button.dto';
+import { SimpleButtonDTO } from '../button/button.dto';
 
 export const SimpleCardDTO = z.object({
   imageUrl: z.string(),
@@ -8,7 +8,7 @@ export const SimpleCardDTO = z.object({
   description: z.object({
     text: z.string(),
   }),
-  buttons: z.array(SimpleActionButtonDTO).optional(),
+  buttons: z.array(SimpleButtonDTO).optional(),
 });
 
 export type SimpleCard = z.infer<typeof SimpleCardDTO>;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements COR-1928**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Add the ability for carousel and card traces to trigger listen functionality. 

Import these functions file for testing:

[Card_with_listen_20240424.json](https://github.com/voiceflow/general-runtime/files/15067717/Card_with_listen_20240424.json)

[Carousel_with_listen_20240424.json](https://github.com/voiceflow/general-runtime/files/15067719/Carousel_with_listen_20240424.json)

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

Added the new `SimpleGeneralButton` type to card and carousel by allowing it through the adapter layer. 

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

N/A

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

N/A

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test