### PR TITLE
[Merged by Bors] - fix: ensure env var and config names are the same (PL-000)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -39,7 +39,7 @@ const CONFIG: Config = {
   INTEGRATIONS_HANDLER_ENDPOINT: getOptionalProcessEnv('INTEGRATIONS_HANDLER_ENDPOINT') || 'none',
 
   // api node
-  API_REQUEST_TIMEOUT_MS: Number(getOptionalProcessEnv('API_MAX_TIMEOUT_MS')) || null,
+  API_REQUEST_TIMEOUT_MS: Number(getOptionalProcessEnv('API_REQUEST_TIMEOUT_MS')) || null,
   API_MAX_CONTENT_LENGTH_BYTES: Number(getOptionalProcessEnv('API_MAX_CONTENT_LENGTH_BYTES')) || null,
   API_MAX_BODY_LENGTH_BYTES: Number(getOptionalProcessEnv('API_MAX_BODY_LENGTH_BYTES')) || null,
 


### PR DESCRIPTION
The config value `API_REQUEST_TIMEOUT_MS` was actually being set by `API_MAX_TIMEOUT_MS`. This ensures they are the same value.
I added `API_REQUEST_TIMEOUT_MS` to doppler.