### PR TITLE
[Merged by Bors] - fix: truncate assistant memory [bugfix] (PL-1010)

### DIFF
--- a/lib/services/aiAssist.ts
+++ b/lib/services/aiAssist.ts
@@ -45,6 +45,9 @@ class AIAssist extends AbstractManager implements ContextHandler {
 
     if (lastTranscript?.role === BaseUtils.ai.Role.ASSISTANT) {
       lastTranscript.content += `\n${content}`;
+
+      // truncate the content if it's too long, consecutive assistant messages can accumulate
+      lastTranscript.content = lastTranscript.content.substring(0, 10000);
     } else {
       transcript.push({ role: BaseUtils.ai.Role.ASSISTANT, content });
       if (transcript.length > MAX_TURNS) transcript.shift();


### PR DESCRIPTION
Reference linear ticket for more information.

Potential "memory leak" if the assistant keeps speaking consecutive messages.