### PR TITLE
fix: extend nodeJS keepalive (IN-1085)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -47,6 +47,9 @@ class Server {
       this.server = http.createServer(this.app);
     }
 
+    // nodeJS keepAliveTimeout has to be higher than downstream nginx keepAliveTimeout (default 75s)
+    this.server.keepAliveTimeout = 76 * 1000;
+
     const { middlewares, controllers } = this.serviceManager;
 
     ExpressMiddleware.attach(this.app, middlewares, controllers);


### PR DESCRIPTION
So the default nodeJS value is 5 seconds.
I just did `console.log(this.server.keepAliveTimeout)` -> `5000`

Reference all the following posts:
https://github.com/nodejs/node/issues/27363#issuecomment-603489130
https://www.notion.so/Mysterious-Connection-reset-by-NodeJS-logged-by-Nginx-0fae2213c195404c80c89b1c0cbfbf0c
If you look at this stackoverflow answer:
https://stackoverflow.com/a/68922692
It mentions that we don't need to set `headersTimeout` for newer node versions.

Our production `nginx.conf` (checked on a prod ingress pod) is either 75s or 60s (not sure which, just going to go with the higher one). 
It's 75 for `http.keepalive_timeout`
It's 60s for `upstream upstream_balancer.keepalive_timeout` which is probably what we want.
