### PR TITLE
[Merged by Bors] - feat: implement text variant handler (PL-1043)

### DIFF
--- a/lib/services/runtime/handlers/index.ts
+++ b/lib/services/runtime/handlers/index.ts
@@ -27,6 +27,7 @@ import CarouselHandler from './carousel';
 import ChannelActionHandler from './channelAction';
 import GoToHandler from './goTo';
 import InteractionHandler from './interaction';
+import ResponseHandler from './response';
 import SpeakHandler from './speak';
 import StateHandlers from './state';
 import StreamHandler from './stream';
@@ -48,6 +49,7 @@ export default (config: Config) => [
   EndHandler(),
   FlowHandler(),
   FunctionHandler(),
+  ResponseHandler(),
   IfHandler(),
   IfV2Handler({ _v1: _v1Handler }),
   APIHandler(config),

--- a/lib/services/runtime/handlers/response/index.ts
+++ b/lib/services/runtime/handlers/response/index.ts
@@ -10,9 +10,7 @@ const handlerUtils = {
 };
 
 export const ResponseHandler: HandlerFactory<CompiledResponseNode, typeof handlerUtils> = (utils) => ({
-  canHandle: (node) => {
-    return node.type === NodeType.RESPONSE;
-  },
+  canHandle: (node) => node.type === NodeType.RESPONSE,
 
   handle: async (node, runtime, variables): Promise<string | null> => {
     const { programResources } = runtime.version as any;

--- a/lib/services/runtime/handlers/response/index.ts
+++ b/lib/services/runtime/handlers/response/index.ts
@@ -1,4 +1,4 @@
-import { CompiledResponseNode, NodeType, ResponseVariantType, VersionProgramResources } from '@voiceflow/dtos';
+import { CompiledResponseNode, NodeType, ResponseVariantType, Version } from '@voiceflow/dtos';
 
 import { HandlerFactory } from '@/runtime';
 
@@ -9,21 +9,43 @@ const handlerUtils = {
   textOutputTrace,
 };
 
+const RESPONSE_HANDLER_ERROR_TAG = 'response-handler';
+
+const DEFAULT_DISCRIMINATOR = 'default:en-us';
+
 export const ResponseHandler: HandlerFactory<CompiledResponseNode, typeof handlerUtils> = (utils) => ({
   canHandle: (node) => node.type === NodeType.RESPONSE,
 
   handle: async (node, runtime, variables): Promise<string | null> => {
-    const { programResources } = runtime.version as any;
-    const { responses } = programResources as VersionProgramResources;
-    const responseData = responses[node.data.responseID];
-    const defaultDiscriminator = 'default:en-us';
-    const variants = responseData.variants[defaultDiscriminator];
+    if (!runtime.version) {
+      throw new Error(`[${RESPONSE_HANDLER_ERROR_TAG}]: Runtime was not loaded with a version`);
+    }
+    /**
+     * !TODO! - Need to replace this `as Version` cast by refactoring `general-runtime` to use the
+     *          `Version` from the DTOs.
+     */
+    const version = runtime.version as Version;
 
-    variants?.forEach((val) => {
+    if (!version.programResources) {
+      throw new Error(`[${RESPONSE_HANDLER_ERROR_TAG}]: Version was not compiled`);
+    }
+    const { responses } = version.programResources;
+
+    const responseData = responses[node.data.responseID];
+
+    const variants = responseData.variants[DEFAULT_DISCRIMINATOR];
+
+    if (!variants) {
+      throw new Error(
+        `[${RESPONSE_HANDLER_ERROR_TAG}]: could not resolve response step, missing variants list for '${DEFAULT_DISCRIMINATOR}'`
+      );
+    }
+
+    variants.forEach((val) => {
       if (val.type === ResponseVariantType.TEXT) {
         const trace = utils.textOutputTrace({
           output: val.data.text,
-          delay: val.data.speed ?? 50,
+          ...(val.data.speed && { delay: val.data.speed }),
           variables,
           version: runtime.version,
         });
@@ -31,10 +53,6 @@ export const ResponseHandler: HandlerFactory<CompiledResponseNode, typeof handle
         utils.addOutputTrace(runtime, trace, { node, variables });
       }
     });
-
-    if (!variants) {
-      throw new Error(`[response-handler]: could not resolve response step, missing variants fors 'default:en-us'`);
-    }
 
     return node.ports.default;
   },

--- a/lib/services/runtime/handlers/response/index.ts
+++ b/lib/services/runtime/handlers/response/index.ts
@@ -1,7 +1,8 @@
 import { CompiledResponseNode, NodeType, ResponseVariantType, VersionProgramResources } from '@voiceflow/dtos';
 
-import { addOutputTrace, textOutputTrace } from '@/lib/services/runtime/utils';
-import { HandlerFactory } from '@/runtime/lib/Handler';
+import { HandlerFactory } from '@/runtime';
+
+import { addOutputTrace, textOutputTrace } from '../../utils';
 
 const handlerUtils = {
   addOutputTrace,
@@ -9,7 +10,9 @@ const handlerUtils = {
 };
 
 export const ResponseHandler: HandlerFactory<CompiledResponseNode, typeof handlerUtils> = (utils) => ({
-  canHandle: (node) => node.type === NodeType.RESPONSE,
+  canHandle: (node) => {
+    return node.type === NodeType.RESPONSE;
+  },
 
   handle: async (node, runtime, variables): Promise<string | null> => {
     const { programResources } = runtime.version as any;

--- a/lib/services/runtime/handlers/response/index.ts
+++ b/lib/services/runtime/handlers/response/index.ts
@@ -29,11 +29,8 @@ export const ResponseHandler: HandlerFactory<CompiledResponseNode, typeof handle
     if (!version.programResources) {
       throw new Error(`[${RESPONSE_HANDLER_ERROR_TAG}]: Version was not compiled`);
     }
-    const { responses } = version.programResources;
-
-    const responseData = responses[node.data.responseID];
-
-    const variants = responseData.variants[DEFAULT_DISCRIMINATOR];
+    const responses = version.programResources.responses[node.data.responseID];
+    const variants = responses.variants[DEFAULT_DISCRIMINATOR];
 
     if (!variants) {
       throw new Error(

--- a/lib/services/runtime/handlers/response/index.ts
+++ b/lib/services/runtime/handlers/response/index.ts
@@ -1,4 +1,4 @@
-import { CompiledResponseNode, NodeType, ResponseVariantType, Version } from '@voiceflow/dtos';
+import { CompiledResponseNode, CompiledResponseNodeDTO, ResponseVariantType, Version } from '@voiceflow/dtos';
 
 import { HandlerFactory } from '@/runtime';
 
@@ -14,7 +14,7 @@ const RESPONSE_HANDLER_ERROR_TAG = 'response-handler';
 const DEFAULT_DISCRIMINATOR = 'default:en-us';
 
 export const ResponseHandler: HandlerFactory<CompiledResponseNode, typeof handlerUtils> = (utils) => ({
-  canHandle: (node) => node.type === NodeType.RESPONSE,
+  canHandle: (node) => CompiledResponseNodeDTO.safeParse(node).success,
 
   handle: async (node, runtime, variables): Promise<string | null> => {
     if (!runtime.version) {

--- a/lib/services/runtime/handlers/response/index.ts
+++ b/lib/services/runtime/handlers/response/index.ts
@@ -23,6 +23,9 @@ export const ResponseHandler: HandlerFactory<CompiledResponseNode, typeof handle
       if (val.type === ResponseVariantType.TEXT) {
         const trace = utils.textOutputTrace({
           output: val.data.text,
+          delay: val.data.speed ?? 50,
+          variables,
+          version: runtime.version,
         });
 
         utils.addOutputTrace(runtime, trace, { node, variables });

--- a/lib/services/runtime/handlers/response/index.ts
+++ b/lib/services/runtime/handlers/response/index.ts
@@ -24,7 +24,7 @@ export const ResponseHandler: HandlerFactory<CompiledResponseNode, typeof handle
      * !TODO! - Need to replace this `as Version` cast by refactoring `general-runtime` to use the
      *          `Version` from the DTOs.
      */
-    const version = runtime.version as Version;
+    const version = runtime.version as unknown as Version;
 
     if (!version.programResources) {
       throw new Error(`[${RESPONSE_HANDLER_ERROR_TAG}]: Version was not compiled`);

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "slate": "0.72.3",
     "talisman": "^1.1.3",
     "ts-pattern": "^4.0.5",
+    "type-fest": "4.18.2",
     "undici": "^6.13.0",
     "unleash-client": "5.0.0",
     "validator": "^13.7.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@voiceflow/chat-types": "2.14.1",
     "@voiceflow/common": "8.2.8",
     "@voiceflow/default-prompt-wrappers": "^1.1.1",
-    "@voiceflow/dtos": "1.75.0",
+    "@voiceflow/dtos": "1.76.1",
     "@voiceflow/event-ingestion-service": "1.5.1",
     "@voiceflow/exception": "^1.5.1",
     "@voiceflow/internal": "3.2.3",

--- a/runtime/lib/Handlers/response/index.ts
+++ b/runtime/lib/Handlers/response/index.ts
@@ -1,0 +1,39 @@
+import { CompiledResponseNode, NodeType, ResponseVariantType, VersionProgramResources } from '@voiceflow/dtos';
+
+import { addOutputTrace, textOutputTrace } from '@/lib/services/runtime/utils';
+import { HandlerFactory } from '@/runtime/lib/Handler';
+
+const handlerUtils = {
+  addOutputTrace,
+  textOutputTrace,
+};
+
+export const ResponseHandler: HandlerFactory<CompiledResponseNode, typeof handlerUtils> = (utils) => ({
+  canHandle: (node) => node.type === NodeType.RESPONSE,
+
+  handle: async (node, runtime, variables): Promise<string | null> => {
+    const { programResources } = runtime.version as any;
+    const { responses } = programResources;
+    const responseData = responses[node.data.responseID];
+    const defaultDiscriminator = 'default:en-us';
+    const variants = responseData.variants[defaultDiscriminator];
+
+    variants?.forEach((val) => {
+      if (val.type === ResponseVariantType.TEXT) {
+        const trace = utils.textOutputTrace({
+          output: val.data.text,
+        });
+
+        utils.addOutputTrace(runtime, trace, { node, variables });
+      }
+    });
+
+    if (!variants) {
+      throw new Error(`[response-handler]: could not resolve response step, missing variants fors 'default:en-us'`);
+    }
+
+    return node.ports.default;
+  },
+});
+
+export default () => ResponseHandler(handlerUtils);

--- a/runtime/lib/Handlers/response/index.ts
+++ b/runtime/lib/Handlers/response/index.ts
@@ -13,7 +13,7 @@ export const ResponseHandler: HandlerFactory<CompiledResponseNode, typeof handle
 
   handle: async (node, runtime, variables): Promise<string | null> => {
     const { programResources } = runtime.version as any;
-    const { responses } = programResources;
+    const { responses } = programResources as VersionProgramResources;
     const responseData = responses[node.data.responseID];
     const defaultDiscriminator = 'default:en-us';
     const variants = responseData.variants[defaultDiscriminator];

--- a/tests/lib/services/runtime/handlers/response/index.unit.ts
+++ b/tests/lib/services/runtime/handlers/response/index.unit.ts
@@ -1,0 +1,123 @@
+import { CompiledResponseNode, TraceType, Version } from '@voiceflow/dtos';
+import { expect } from 'chai';
+import { NodeEventHandler } from 'rxjs/internal/observable/fromEvent';
+import sinon from 'sinon';
+
+import ResponseHandler from '@/lib/services/runtime/handlers/response/index';
+import { Program, Runtime, Store } from '@/runtime';
+import { mockResponseNode } from '@/tests/mocks/node/response.node.mock';
+import { ID, mockVersion } from '@/tests/mocks/version/version.mock';
+
+describe('Response handler', () => {
+  const handler = ResponseHandler();
+
+  let version: Version;
+  let runtime: Runtime;
+  let variables: Store;
+  let program: Program;
+  let responseNode: CompiledResponseNode;
+  let eventHandler: NodeEventHandler;
+
+  beforeEach(() => {
+    version = mockVersion();
+    runtime = {
+      version,
+      trace: {
+        addTrace: sinon.stub(),
+      },
+      debugLogging: {
+        recordStepLog: sinon.stub(),
+      },
+    } as unknown as Runtime;
+
+    variables = new Store({});
+    program = null as unknown as Program;
+
+    responseNode = mockResponseNode();
+
+    eventHandler = null as unknown as NodeEventHandler;
+  });
+
+  describe('can handle', () => {
+    it('does not handle - non-response node', () => {
+      const data1 = mockResponseNode({
+        type: 'wrong-type',
+      } as any);
+      const data2 = mockResponseNode({
+        data: 1,
+      } as any);
+      const data3 = mockResponseNode({
+        ports: 1,
+      } as any);
+
+      const result1 = handler.canHandle(data1, runtime, variables, program);
+      const result2 = handler.canHandle(data2, runtime, variables, program);
+      const result3 = handler.canHandle(data3, runtime, variables, program);
+
+      expect(result1).to.eql(false);
+      expect(result2).to.eql(false);
+      expect(result3).to.eql(false);
+    });
+
+    it('handles - response node', () => {
+      const responseNode = mockResponseNode();
+
+      const result = handler.canHandle(responseNode, runtime, variables, program);
+
+      expect(result).to.eql(true);
+    });
+  });
+
+  describe('handle', () => {
+    it('throws an error if version does not exist', async () => {
+      delete runtime.version;
+
+      const promise = handler.handle(responseNode, runtime, variables, program, eventHandler);
+
+      await expect(promise).to.eventually.rejectedWith(`[response-handler]: Runtime was not loaded with a version`);
+    });
+
+    it('throws an error if programResources does not exist', async () => {
+      delete version.programResources;
+
+      const promise = handler.handle(responseNode, runtime, variables, program, eventHandler);
+
+      await expect(promise).to.eventually.rejectedWith(`[response-handler]: Version was not compiled`);
+    });
+
+    it('throws an error if variants does not exist', async () => {
+      delete version.programResources!.responses[ID.responseID].variants['default:en-us'];
+
+      const promise = handler.handle(responseNode, runtime, variables, program, eventHandler);
+
+      await expect(promise).to.eventually.rejectedWith(
+        `[response-handler]: could not resolve response step, missing variants list for 'default:en-us'`
+      );
+    });
+
+    it('outputs text trace for each text variant', async () => {
+      const result = await handler.handle(responseNode, runtime, variables, program, eventHandler);
+
+      await expect(result).to.eql(responseNode.ports.default);
+      await expect((runtime.trace.addTrace as sinon.SinonStub).callCount).to.eql(1);
+
+      const addTraceArgs = (runtime.trace.addTrace as sinon.SinonStub).args[0][0];
+      delete addTraceArgs.payload.slate.id;
+      await expect(addTraceArgs).to.eql({
+        type: TraceType.TEXT,
+        payload: {
+          delay: 100,
+          message: 'Hello, world!',
+          slate: {
+            content: [
+              {
+                text: 'Hello, world!',
+              },
+            ],
+            messageDelayMilliseconds: 100,
+          },
+        },
+      });
+    });
+  });
+});

--- a/tests/mocks/cms-resource/response.mock.ts
+++ b/tests/mocks/cms-resource/response.mock.ts
@@ -1,0 +1,25 @@
+import { CardLayout, CompiledResponse, ResponseVariantType } from '@voiceflow/dtos';
+
+import { mockCreatorFactory } from '@/tests/utils/createMock';
+
+const defaultResponse: CompiledResponse = {
+  variants: {
+    'default:en-us': [
+      {
+        id: '643872531e80120007759e05',
+        type: ResponseVariantType.TEXT,
+        data: {
+          text: [
+            {
+              text: 'Hello, world!',
+            },
+          ],
+          speed: 100,
+          cardLayout: CardLayout.LIST,
+        },
+      },
+    ],
+  },
+};
+
+export const mockResponseResource = mockCreatorFactory(defaultResponse);

--- a/tests/mocks/node/response.node.mock.ts
+++ b/tests/mocks/node/response.node.mock.ts
@@ -1,0 +1,18 @@
+import { CompiledResponseNode, NodeType } from '@voiceflow/dtos';
+
+import { mockCreatorFactory } from '@/tests/utils/createMock';
+
+import { ID } from '../version/version.mock';
+
+const defaultNode: CompiledResponseNode = {
+  id: '664cc26e33c3a959f67ca54e',
+  type: NodeType.RESPONSE,
+  data: {
+    responseID: ID.responseID,
+  },
+  ports: {
+    default: '664cc26e33c3a959f67ca54a',
+  },
+};
+
+export const mockResponseNode = mockCreatorFactory(defaultNode);

--- a/tests/mocks/version/version.mock.ts
+++ b/tests/mocks/version/version.mock.ts
@@ -1,0 +1,33 @@
+import { Version } from '@voiceflow/dtos';
+
+import { mockCreatorFactory } from '@/tests/utils/createMock';
+
+import { mockResponseResource } from '../cms-resource/response.mock';
+
+export const ID = {
+  versionID: '664cc26e33c3a959f67ca54e',
+  responseID: '664cc26e33c3a959f67ca549',
+};
+
+const defaultVersion: Version = {
+  _id: ID.versionID,
+  name: 'Version name',
+  creatorID: 1,
+  projectID: '643872531e80120007759e05',
+  rootDiagramID: '664cc26e33c3a959f67ca550',
+  variables: ['variable-1', 'variable-2', 'variable-3'],
+  platformData: {
+    slots: [],
+    intents: [],
+    settings: {},
+    publishing: {},
+  },
+  programResources: {
+    responses: {
+      [ID.responseID]: mockResponseResource(),
+    },
+    attachments: {},
+  },
+};
+
+export const mockVersion = mockCreatorFactory(defaultVersion);

--- a/tests/utils/createMock.ts
+++ b/tests/utils/createMock.ts
@@ -1,0 +1,26 @@
+import cloneDeep from 'lodash/cloneDeep.js';
+import isPlainObject from 'lodash/isPlainObject.js';
+import { PartialDeep } from 'type-fest';
+
+const isObject = (value: unknown): value is Record<string, any> => {
+  return isPlainObject(value);
+};
+
+const deepOverwrite = (value: any, overwrite: PartialDeep<typeof value>): typeof value => {
+  if (!isObject(overwrite) || !isObject(value)) return overwrite;
+
+  return Object.keys(overwrite).reduce((acc, key) => {
+    return {
+      ...acc,
+      [key]: deepOverwrite(acc[key], overwrite[key]),
+    };
+  }, value);
+};
+
+export const mockCreatorFactory =
+  <T extends Record<string, any>>(defaultValue: T) =>
+  (overwrite?: PartialDeep<T>): T => {
+    if (!isObject(defaultValue)) return overwrite as T;
+    const clonedValue = cloneDeep(defaultValue);
+    return deepOverwrite(clonedValue, overwrite ?? {});
+  };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4808,6 +4808,7 @@ __metadata:
     ts-pattern: ^4.0.5
     tsc-alias: ^1.8.8
     tsconfig-paths: ^4.0.0
+    type-fest: 4.18.2
     typedoc: ^0.20.16
     typedoc-plugin-sourcefile-url: ^1.0.6
     typescript: 4.9.3
@@ -17978,6 +17979,13 @@ __metadata:
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 62b5628bff67c0eb0b66afa371bd73e230399a8d2ad30d852716efcc4656a7516904570cd8631a49a3ce57c10225adf5d0cbdcb47f6b0255fe6557c453925a15
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:4.18.2":
+  version: 4.18.2
+  resolution: "type-fest@npm:4.18.2"
+  checksum: 2e9272b2b97b2f4ea2bbffda43cfce9ca89c474ad7c9565e39b80fee2ce609ea60385faffbbef98994b38feb3fa5fa38feb33acf175f4f85ee21d1773e87bf44
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4594,15 +4594,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@voiceflow/dtos@npm:1.75.0":
-  version: 1.75.0
-  resolution: "@voiceflow/dtos@npm:1.75.0"
+"@voiceflow/dtos@npm:1.76.1":
+  version: 1.76.1
+  resolution: "@voiceflow/dtos@npm:1.76.1"
   dependencies:
     "@voiceflow/default-prompt-wrappers": 1.3.2
     "@voiceflow/internal": 3.2.3
   peerDependencies:
     zod: ^3
-  checksum: 3e37116deae6f2ade02f6a2b82c0246e85be20d0dc1fb3153b58ae0d6e1732773a47eabee4cb0eaf27ab302736b860c69455df5d6220c9c76b9f568f95eeb6f6
+  checksum: 78b3be01e7c49254215c4a2505c603ebf6aaee92ba22167acd3443a0c5e27c9853b00c12112eeeda16ba20924702c9fb6b3aebccb03a7970088a1bb0a10aea27
   languageName: node
   linkType: hard
 
@@ -4724,7 +4724,7 @@ __metadata:
     "@voiceflow/commitlint-config": 2.0.0
     "@voiceflow/common": 8.2.8
     "@voiceflow/default-prompt-wrappers": ^1.1.1
-    "@voiceflow/dtos": 1.75.0
+    "@voiceflow/dtos": 1.76.1
     "@voiceflow/eslint-config": 6.1.0
     "@voiceflow/event-ingestion-service": 1.5.1
     "@voiceflow/exception": ^1.5.1


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-1043**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Adds the skeleton code for the Response node handler. This PR only enables the ability to send a text variant, which should unblock the initial demo for the CORE team.

The remainder of the Response step will be implemented in subsequent PRs.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

Implemented a new `ResponseHandler` in `general-runtime`. This handler has been placed under `libs/services/runtime` rather than `runtime/lib/Handlers`. I _think_ the latter is supposed to be purely logic and control node handlers, while the former dictates specific content like text, video, and image node handlers.

At a high-level, this is how to execute a response node
1. Read a `responseID` from the compiled response node.
2. Read the Response entity corresponding to `responseID` from `version.programResources`, which is a new data structure that contains compiled version-scoped data like function definitions, NLU data, or CMS responses.
3. In the response entity, select the discriminator corresponding to the current channel + language configuration. For this project, the handler always selects the `default:en-us` discriminator. 
4. In the discriminator entity, output each text variant as a text trace.
5. Leave the response node from the default port.

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

N/A

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

N/A

### Related PRs

<!-- List related PRs against other branches -->

N/A

### Checklist

- [x] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [x] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test