### PR TITLE
[Merged by Bors] - build(ci): remove the use of COMMON_ORB_VERSION_OVERRIDE (PL-1061)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ workflows:
                 command: jq --raw-output '.volta.node // ""' package.json
             - vfcommon/set-json-string-from-env:
                 field: common_orb_version
-                value-env-var: COMMON_ORB_VERSION_OVERRIDE
+                value-env-var: COMMON_ORB_VERSION
             - run: cat values.json
           contexts: values.json
 


### PR DESCRIPTION
### Brief description. What is this change?
`COMMON_ORB_VERSION_OVERRIDE` shouldn't exist in master branch. This PR starts tracking latest `COMMON_ORB_VERSION` again