### PR TITLE
fix: leave slot filling to only dialog service using nlu (PL-1109)

### DIFF
--- a/lib/controllers/test/index.ts
+++ b/lib/controllers/test/index.ts
@@ -180,6 +180,7 @@ class TestController extends AbstractController {
         hasChannelIntents: project?.platformData?.hasChannelIntents,
         platform: version?.prototype?.platform as VoiceflowConstants.PlatformType,
         filteredIntents: Array.from(extraIntentNames),
+        excludeFilteredIntents: true,
       }
     );
 

--- a/lib/services/classification/classification.const.ts
+++ b/lib/services/classification/classification.const.ts
@@ -22,3 +22,5 @@ export const LEGACY_LLM_INTENT_CLASSIFICATION: IntentClassificationLLMSettings =
     content: DEFAULT_INTENT_CLASSIFICATION_PROMPT_WRAPPER_CODE,
   },
 };
+
+export const NLU_LIMIT = 10;

--- a/lib/services/classification/interfaces/nlu.interface.ts
+++ b/lib/services/classification/interfaces/nlu.interface.ts
@@ -87,4 +87,5 @@ export interface NLUPredictOptions {
   filteredEntities?: string[];
   excludeFilteredIntents?: boolean;
   excludeFilteredEntities?: boolean;
+  limit?: number;
 }

--- a/lib/services/classification/interfaces/nlu.interface.ts
+++ b/lib/services/classification/interfaces/nlu.interface.ts
@@ -76,6 +76,8 @@ export interface PredictRequest {
 export interface PredictOptions {
   filteredIntents?: string[];
   filteredEntities?: string[];
+  excludeFilteredIntents?: boolean;
+  excludeFilteredEntities?: boolean;
   // Legacy options for NLC
   hasChannelIntents?: boolean;
   locale: VoiceflowConstants.Locale;

--- a/lib/services/classification/interfaces/nlu.interface.ts
+++ b/lib/services/classification/interfaces/nlu.interface.ts
@@ -73,16 +73,7 @@ export interface PredictRequest {
   dmRequest?: BaseRequest.IntentRequestPayload;
 }
 
-export interface PredictOptions {
-  filteredIntents?: string[];
-  filteredEntities?: string[];
-  excludeFilteredIntents?: boolean;
-  excludeFilteredEntities?: boolean;
-  // Legacy options for NLC
-  hasChannelIntents?: boolean;
-  locale: VoiceflowConstants.Locale;
-  platform: VoiceflowConstants.PlatformType;
-}
+export type PredictOptions = NLUPredictOptions & NLCPredictOptions;
 
 export interface NLUPredictOptions {
   filteredIntents?: string[];
@@ -90,4 +81,11 @@ export interface NLUPredictOptions {
   excludeFilteredIntents?: boolean;
   excludeFilteredEntities?: boolean;
   limit?: number;
+}
+
+/** @deprecated */
+export interface NLCPredictOptions {
+  hasChannelIntents?: boolean;
+  locale: VoiceflowConstants.Locale;
+  platform: VoiceflowConstants.PlatformType;
 }

--- a/lib/services/classification/predictor.class.ts
+++ b/lib/services/classification/predictor.class.ts
@@ -149,16 +149,14 @@ export class Predictor extends EventEmitter {
   }
 
   private async nluGatewayPrediction(utterance: string, options: Partial<NLUPredictOptions>) {
-    const { filteredIntents = [], excludeFilteredIntents = true } = options;
+    const { limit } = options;
 
     const { data: prediction } = await this.config.axios
       .post<NLUIntentPrediction | null>(`${this.nluGatewayURL}/v1/predict/${this.props.versionID}`, {
         utterance,
         tag: this.props.tag,
         workspaceID: this.props.workspaceID,
-        filteredIntents,
-        excludeFilteredIntents,
-        limit: 10,
+        ...(limit ? { limit } : {}),
       })
       .catch((err: Error) => {
         logger.error(err, 'Something went wrong with NLU prediction');
@@ -315,7 +313,7 @@ export class Predictor extends EventEmitter {
       return nlcPrediction;
     }
 
-    const nluPrediction = this.props.isTrained && (await this.nlu(utterance, this.options));
+    const nluPrediction = this.props.isTrained && (await this.nlu(utterance, { limit: 10 }));
 
     if (!nluPrediction) {
       if (isIntentClassificationLLMSettings(this.settings)) {

--- a/lib/services/classification/predictor.class.ts
+++ b/lib/services/classification/predictor.class.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/cognitive-complexity */
 import { Utils } from '@voiceflow/common';
 import { DEFAULT_INTENT_CLASSIFICATION_PROMPT_WRAPPER_CODE } from '@voiceflow/default-prompt-wrappers';
 import { IntentClassificationSettings } from '@voiceflow/dtos';
@@ -6,7 +5,6 @@ import { ISlotFullfilment } from '@voiceflow/natural-language-commander';
 import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import type { AxiosStatic } from 'axios';
 import { EventEmitter } from 'node:events';
-import { match } from 'ts-pattern';
 
 import MLGateway from '@/lib/clients/ml-gateway';
 import logger from '@/logger';
@@ -360,31 +358,9 @@ export class Predictor extends EventEmitter {
 
       this.predictions.result = 'llm';
 
-      if (!(llmPrediction.predictedIntent in this.intentNameMap)) {
-        return {
-          ...llmPrediction,
-          predictedSlots: [],
-        };
-      }
-
-      // STEP 4: retrieve intent from intent map
-      const intent = this.intentNameMap[llmPrediction.predictedIntent];
-
-      // slot filling
-      const slots = await match({
-        predicted: llmPrediction.predictedIntent === nluPrediction.predictedIntent,
-        hasSlots: !!intent.slots?.length,
-      })
-        .with({ hasSlots: true }, () =>
-          this.fillSlots(utterance, {
-            filteredIntents: [llmPrediction.predictedIntent],
-          })
-        )
-        .otherwise(() => []);
-
       return {
         ...llmPrediction,
-        predictedSlots: slots ?? [],
+        predictedSlots: [],
       };
     }
 

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -154,7 +154,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
 
       try {
         const prefix = dmPrefix(dmStateStore.intentRequest.payload.intent.name);
-        const { intentClassificationSettings, intents, isTrained, slots } = castToDTO(version, project);
+        const { intents, isTrained, slots } = castToDTO(version, project);
 
         let dmPrefixedResult = incomingRequest;
 
@@ -176,7 +176,10 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
               dmRequest: dmStateStore.intentRequest.payload,
               isTrained,
             },
-            intentClassificationSettings,
+            {
+              type: 'nlu',
+              params: { confidence: 0.6 },
+            },
             {
               locale: version.prototype?.data.locales[0] as VoiceflowConstants.Locale,
               hasChannelIntents: project?.platformData?.hasChannelIntents,

--- a/lib/services/nlu/types.ts
+++ b/lib/services/nlu/types.ts
@@ -27,10 +27,6 @@ export interface PredictProps {
   dmRequest?: BaseRequest.IntentRequestPayload;
   workspaceID: string;
   intentConfidence?: number;
-  filteredIntents?: Set<string>;
-  filteredEntities?: Set<string>;
-  excludeFilteredIntents?: boolean;
-  excludeFilteredEntities?: boolean;
   nluSettings?: BaseModels.Project.NLUSettings;
   trace?: BaseTrace.AnyTrace[];
 }

--- a/tests/lib/services/classification/predictor.class.unit.ts
+++ b/tests/lib/services/classification/predictor.class.unit.ts
@@ -81,17 +81,6 @@ describe('predictor unit tests', () => {
     },
   };
 
-  const noneIntent: BaseRequest.IntentRequest = {
-    type: BaseRequest.RequestType.INTENT,
-    payload: {
-      intent: {
-        name: VoiceflowConstants.IntentName.NONE,
-      },
-      query,
-      entities: [],
-    },
-  };
-
   const nlcPrediction: IIntentFullfilment & { confidence: number } = {
     intent: 'abcedfg',
     slots: [],
@@ -311,37 +300,6 @@ describe('predictor unit tests', () => {
       expect(result).to.eql('llm');
       expect(config.axios.post.callCount).to.eql(1);
       expect(prediction?.predictedIntent).to.eql(mlGatewayPrediction.output);
-    });
-
-    it('fills slots if prediction different than NLU', async () => {
-      const utterance = 'query-val';
-      const predictionWithSlots = {
-        ...mlGatewayPrediction,
-        output: orderPizzaIntentWithSlots.name,
-      };
-      const { config, props, settings, options } = setup({
-        props: {
-          intents: [orderPizzaIntent, orderPizzaIntentWithSlots],
-          slots: [pizzaAmountSlot],
-        },
-        axios: { data: { ...nluGatewayPrediction, predictionIntent: 'womp' } },
-        mlGateway: predictionWithSlots,
-        settings: {
-          type: 'llm',
-          params: { model: 'gpt-4-turbo', temperature: 0.7 },
-        },
-      });
-
-      const predictor = new Predictor(config, props, settings.intentClassification, options);
-      const handleNLCCommandStub = sinon.stub(NLC, 'handleNLCCommand');
-      handleNLCCommandStub.returns(null);
-
-      const prediction = await predictor.predict(utterance);
-      const { result } = predictor.predictions;
-
-      expect(result).to.eql('llm');
-      expect(config.axios.post.callCount).to.eql(2);
-      expect(prediction?.predictedIntent).to.eql(predictionWithSlots.output);
     });
 
     it('skips NLC', async () => {

--- a/tests/lib/services/nlu/index.unit.ts
+++ b/tests/lib/services/nlu/index.unit.ts
@@ -180,8 +180,6 @@ describe('nlu manager unit tests', () => {
 
       expect(result).to.eql({ ...context, request: intentResponse });
       expect(services.axios.post.args[0][1]).to.eql({
-        filteredIntents: [],
-        excludeFilteredIntents: true,
         utterance: query,
         tag: VersionTag.PRODUCTION,
         limit: 10,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Remove slot filling from nlu service and leave solely to dialog service

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

there are 2 places we do slot filling:
first in the nlu service
the in the dialog manager if needed
They both do the same fillSlots call (now, in my test). but the main difference is that the dialog manager adds a prefix to the utterance.
I'm unsure why the NLU performs poorly on the number match (only takes the first 3?) given the same intent and utterance (without prefix). but the solution i'll be pushing is to remove slot filling from the nlu service and leave all slot filling to be done in the dialog manager until a proper investigation can be done to tweak/optimize/etc

### Checklist

- [x] Appropriate tests have been written
- [x] bors try
- [ ] manual