### PR TITLE
[Merged by Bors] - fix: reduce entitlement lookup failure log level (PL-000)

### DIFF
--- a/lib/services/state/index.ts
+++ b/lib/services/state/index.ts
@@ -29,7 +29,7 @@ const getSubscriptionEntitlements = async (billingClientFactory: BillingClient, 
     const subscriptionResponse = await billingClient.resourcesPrivate
       .getResourceSubscription('workspace', workspaceID)
       .catch((error) => {
-        logger.error(`Failed to get subscription entitlements for workspace ${workspaceID}: ${logger.vars({ error })}`);
+        logger.debug(`Failed to get subscription entitlements for workspace ${workspaceID}: ${logger.vars({ error })}`);
         return undefined;
       });
 


### PR DESCRIPTION
This log isn't very helpful right now, since most workspaces will fail. We can change it back to `error` once our billing migration is complete.