### PR TITLE
[Merged by Bors] - feat: improve smoke tests visibility (IN-1101)

### DIFF
--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -166,11 +166,12 @@ jobs:
           background: true
           command: |
             function capture_logs() {
-                if [ -f workspace/env_name ] && [ "$(cat workspace/env_name)" != "null" ]; then
-                    DEV_ENV_NAME=$(cat workspace/env_name)
+                if [ -n "$ENV_NAME" ]; then
+                    DEV_ENV_NAME=$ENV_NAME
                 else
                     DEV_ENV_NAME=<< parameters.e2e-env-name >>
                 fi
+                echo "Capturing logs for environment $DEV_ENV_NAME"
                 # Read components into an array directly from the command output
                 components=($(vfcli component list -n "${DEV_ENV_NAME:?}" | awk 'NR>3 {print $1}'))
                 # Iterate over the first n-1 components.Process log collection in parallel as background processes

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:734856f5888c18a230a71b05f5bc9e7355d73c43
+  vfcommon: voiceflow/common@dev:7f2eaf7db693d29def5b705d1a9cd4bd458719b6
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -145,6 +145,9 @@ jobs:
           type: string
           description: Name of the cluster in which the environment exists
           default: "cm4-vf-dev-br-2-0-p1"
+        e2e-env-name:
+          type: string
+          description: Name of the environment to collect logs from
     steps:
       - vfcommon/install-vfcli:
           init-cluster: << parameters.cluster >>

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:cfaeb4b6c4b56a0af104153464c0a0811bc57a23
+  vfcommon: voiceflow/common@dev:f4c0298a581d35550b841ef581bdbdb4e52c2347
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -149,6 +149,8 @@ jobs:
           type: string
           description: Name of the environment to collect logs from
     steps:
+      - attach_workspace:
+          at: ~/voiceflow
       - vfcommon/install-vfcli:
           init-cluster: << parameters.cluster >>
       - run:

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:1c2ade90411e7041214b931e747062ad23c4dc98
+  vfcommon: voiceflow/common@dev:068a24ee36016553dd64e18964d9eec61c5e54d8
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:f4c0298a581d35550b841ef581bdbdb4e52c2347
+  vfcommon: voiceflow/common@dev:734856f5888c18a230a71b05f5bc9e7355d73c43
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -138,6 +138,59 @@ jobs:
           enable_cache_to: true
           extra_build_args: *node_version_arg
 
+  collect-smoke-test-logs:
+    executor: vfcommon/default-executor
+    parameters:
+        cluster:
+          type: string
+          description: Name of the cluster in which the environment exists
+          default: "cm4-vf-dev-br-2-0-p1"
+    steps:
+      - vfcommon/install-vfcli:
+          init-cluster: << parameters.cluster >>
+      - run:
+          name: Install stern
+          command: |
+            curl -sSL https://raw.githubusercontent.com/upciti/wakemeops/main/assets/install_repository | sudo bash
+            sudo apt install stern
+      - run:
+          name: Gather Logs
+          environment:
+            ENV_NAME: {{ .values.e2e_env_name }}
+            LOG_DIR: &log_dir /tmp/pod-logs-{{ .values.e2e_env_name }}
+          background: true
+          command: |
+            function capture_logs() {
+                if [ -f workspace/env_name ] && [ "$(cat workspace/env_name)" != "null" ]; then
+                    DEV_ENV_NAME=$(cat workspace/env_name)
+                else
+                    DEV_ENV_NAME=<< parameters.e2e-env-name >>
+                fi
+                # Read components into an array directly from the command output
+                components=($(vfcli component list -n "${DEV_ENV_NAME:?}" | awk 'NR>3 {print $1}'))
+                # Iterate over the first n-1 components.Process log collection in parallel as background processes
+                for ((i = 0; i < ${#components[@]} - 1; i++)); do
+                    component=${components[$i]}
+                    echo "Capturing logs for component $component"
+                    stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$component" >>"${LOG_DIR:?}/$component.log" &
+                done
+                # Handle the last component separately to introduce blocking.If all components' log collection is done as non blocking tasks,
+                # the circleci step will terminate.So having last component as blocking ensures the collect logs step continues executing
+                last_component=${components[${#components[@]}-1]}
+                echo "Capturing logs for last component $last_component"
+                stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$last_component" >>"${LOG_DIR:?}/$last_component.log"
+            }
+            mkdir "${LOG_DIR:?}"
+            capture_logs
+      - store_artifacts:
+          name: Store Logs
+          path: *log_dir
+          destination: logs
+      - store_artifacts:
+          name: Store Cluster Info
+          path: /tmp/cluster-info
+          destination: cluster-info
+
 
 workflows:
   {{- if has $masterProdBranches .values.branch }}
@@ -205,6 +258,12 @@ workflows:
           requires:
             - vfcommon/provision-env
             - vfcommon/update_track
+      - collect-smoke-test-logs:
+          context: dev-test
+          e2e-env-name: {{ .values.e2e_env_name }}
+          requires:
+            - vfcommon/prepare-env
+          filters: *bors_branches_filters
       - vfcommon/run-smoke-tests:
           context: dev-test
           e2e-env-name: {{ .values.e2e_env_name }}
@@ -217,6 +276,7 @@ workflows:
           env-name: {{ .values.e2e_env_name }}
           requires:
             - vfcommon/run-smoke-tests
+            - collect-smoke-test-logs
           filters: *bors_branches_filters
 
       - vfcommon/sync_branches:

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:e1b0bf84d5ccb556299bde7df17da215692a279b
+  vfcommon: voiceflow/common@dev:dce671ea8efa7fc3693f39782011ee0ac47f4d6f
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@{{ .values.common_orb_version }}
+  vfcommon: voiceflow/common@dev:e1b0bf84d5ccb556299bde7df17da215692a279b
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 
@@ -138,72 +138,6 @@ jobs:
           enable_cache_to: true
           extra_build_args: *node_version_arg
 
-  collect-smoke-test-logs:
-    executor: vfcommon/default-executor
-    parameters:
-        cluster:
-          type: string
-          description: Name of the cluster in which the environment exists
-          default: "cm4-vf-dev-br-2-0-p1"
-        e2e-env-name:
-          type: string
-          description: Name of the environment to collect logs from
-        env-name-path:
-          type: string
-          description: Path to the env_name file
-          default: "/home/circleci/voiceflow/env_name.txt"
-    steps:
-      - restore_cache:
-          key: env_name_cache-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
-      - vfcommon/install-vfcli:
-          init-cluster: << parameters.cluster >>
-      - run:
-          name: Install stern
-          command: |
-            curl -sSL https://raw.githubusercontent.com/upciti/wakemeops/main/assets/install_repository | sudo bash
-            sudo apt install stern
-      - run:
-          name: Gather Logs
-          environment:
-            ENV_NAME: {{ .values.e2e_env_name }}
-            LOG_DIR: &log_dir /tmp/pod-logs-{{ .values.e2e_env_name }}
-          background: true
-          command: |
-            function capture_logs() {
-                echo "Contents of << parameters.env-name-path >>:"
-                 cat << parameters.env-name-path >>
-                if [[ -f << parameters.env-name-path >> ]]; then
-                   DEV_ENV_NAME=$(cat << parameters.env-name-path >>)
-                else
-                    DEV_ENV_NAME=<< parameters.e2e-env-name >>
-                fi
-                echo "Capturing logs for environment $DEV_ENV_NAME"
-                # Read components into an array directly from the command output
-                components=($(vfcli component list -n "${DEV_ENV_NAME:?}" | awk 'NR>3 {print $1}'))
-                # Iterate over the first n-1 components.Process log collection in parallel as background processes
-                for ((i = 0; i < ${#components[@]} - 1; i++)); do
-                    component=${components[$i]}
-                    echo "Capturing logs for component $component"
-                    stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$component" >>"${LOG_DIR:?}/$component.log" &
-                done
-                # Handle the last component separately to introduce blocking.If all components' log collection is done as non blocking tasks,
-                # the circleci step will terminate.So having last component as blocking ensures the collect logs step continues executing
-                last_component=${components[${#components[@]}-1]}
-                echo "Capturing logs for last component $last_component"
-                stern -n "${DEV_ENV_NAME:?}" -l "app.kubernetes.io/name=$last_component" >>"${LOG_DIR:?}/$last_component.log"
-            }
-            mkdir "${LOG_DIR:?}"
-            capture_logs
-      - store_artifacts:
-          name: Store Logs
-          path: *log_dir
-          destination: logs
-      - store_artifacts:
-          name: Store Cluster Info
-          path: /tmp/cluster-info
-          destination: cluster-info
-
-
 workflows:
   {{- if has $masterProdBranches .values.branch }}
   test-and-release:
@@ -270,7 +204,7 @@ workflows:
           requires:
             - vfcommon/provision-env
             - vfcommon/update_track
-      - collect-smoke-test-logs:
+      - vfcommon/collect-e2e-logs:
           context: dev-test
           e2e-env-name: {{ .values.e2e_env_name }}
           requires:
@@ -288,7 +222,7 @@ workflows:
           env-name: {{ .values.e2e_env_name }}
           requires:
             - vfcommon/run-smoke-tests
-            - collect-smoke-test-logs
+            - vfcommon/collect-e2e-logs
           filters: *bors_branches_filters
 
       - vfcommon/sync_branches:

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:3dae4f8c7104b1f628d41501a85c810f3bcd285e
+  vfcommon: voiceflow/common@dev:cfaeb4b6c4b56a0af104153464c0a0811bc57a23
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:075f033ec53d96d9b312d26cebb04c6db38fa8c3
+  vfcommon: voiceflow/common@dev:cb97b44714e1976752343fedd776a1752e712fe3
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -43,14 +43,14 @@ defaults:
 
   executor: &node-executor
     name: vfcommon/node-executor-node-20
-    tag: {{ .values.node_version }}-vf-1
+    tag: {{ .values.node_version }}-vf-2
 
   code-test-executor: &code-test-node-executor
     name: vfcommon/code-test-executor-node-20
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:7f2eaf7db693d29def5b705d1a9cd4bd458719b6
+  vfcommon: voiceflow/common@dev:1c2ade90411e7041214b931e747062ad23c4dc98
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 
@@ -206,6 +206,7 @@ workflows:
             - vfcommon/update_track
       - vfcommon/collect-e2e-logs:
           context: dev-test
+          executor: *node-executor
           e2e-env-name: {{ .values.e2e_env_name }}
           requires:
             - vfcommon/prepare-env

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -153,8 +153,8 @@ jobs:
           description: Path to the env_name file
           default: "/home/circleci/voiceflow/env_name.txt"
     steps:
-      - attach_workspace:
-          at: ~/voiceflow
+      - restore_cache:
+          key: env_name_cache-{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
       - vfcommon/install-vfcli:
           init-cluster: << parameters.cluster >>
       - run:

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:dce671ea8efa7fc3693f39782011ee0ac47f4d6f
+  vfcommon: voiceflow/common@dev:075f033ec53d96d9b312d26cebb04c6db38fa8c3
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:cb97b44714e1976752343fedd776a1752e712fe3
+  vfcommon: voiceflow/common@dev:3dae4f8c7104b1f628d41501a85c810f3bcd285e
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -148,6 +148,10 @@ jobs:
         e2e-env-name:
           type: string
           description: Name of the environment to collect logs from
+        env-name-path:
+          type: string
+          description: Path to the env_name file
+          default: "/home/circleci/voiceflow/env_name.txt"
     steps:
       - attach_workspace:
           at: ~/voiceflow
@@ -166,8 +170,10 @@ jobs:
           background: true
           command: |
             function capture_logs() {
-                if [ -n "$ENV_NAME" ]; then
-                    DEV_ENV_NAME=$ENV_NAME
+                echo "Contents of << parameters.env-name-path >>:"
+                 cat << parameters.env-name-path >>
+                if [[ -f << parameters.env-name-path >> ]]; then
+                   DEV_ENV_NAME=$(cat << parameters.env-name-path >>)
                 else
                     DEV_ENV_NAME=<< parameters.e2e-env-name >>
                 fi

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:068a24ee36016553dd64e18964d9eec61c5e54d8
+  vfcommon: voiceflow/common@{{ .values.common_orb_version }}
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/values.test.json
+++ b/.circleci/values.test.json
@@ -1,5 +1,6 @@
 {
   "e2e_env_name": "e2e-general-runtime-12c262a",
-  "common_orb_version": "0.56.2",
+  "common_orb_version": "0.67.0",
+  "node_version": "12.18.3",
   "branch": "trying"
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* [IN-1101](https://linear.app/voiceflow/issue/IN-1101/improve-logs-in-our-cicd-system)

### Successful run 
* https://app.circleci.com/pipelines/gh/voiceflow/general-runtime/16323/workflows/7dc9898c-138b-4b7e-a71d-b2e206b4c216
### Brief description. What is this change?
* The change allows us to 
  * Capture component logs during a smoke test run 
     * Logs are `tailed` for the duration of the smoke test run allowing us to preserve logs from initial pod instance if a 
     pod restart occurs
   * Capture summary pod state for all pods before smoke test run 
   * Capture summary pod state for all pods after smoke test run 
   * Capture detailed pod state for each pod after smoke test run 

### Related PR's 
* https://github.com/voiceflow/orb-common/pull/250
* https://github.com/voiceflow/infrastructure/pull/685

### Checklist

- [x] Logs collect on a successful run 
- [x] Logs collect on a failed run 
    