### PR TITLE
[Merged by Bors] - feat: move rate limit before project lookup (PL-000) [bugfix]

### DIFF
--- a/backend/api/routers/interact.ts
+++ b/backend/api/routers/interact.ts
@@ -11,7 +11,7 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
   router.use(middlewares.rateLimit.verify);
 
-  const interactMiddleware = [middlewares.project.resolveVersionAlias, middlewares.rateLimit.versionConsume];
+  const interactMiddleware = [middlewares.rateLimit.versionConsume, middlewares.project.resolveVersionAlias];
 
   const legacyMiddleware = [middlewares.project.unifyVersionID, ...interactMiddleware];
 

--- a/backend/api/routers/state.ts
+++ b/backend/api/routers/state.ts
@@ -12,9 +12,9 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   router.use(middlewares.rateLimit.verify);
 
   const statefulAPIMiddleware = [
+    middlewares.rateLimit.versionConsume,
     middlewares.project.resolveVersionAlias,
     middlewares.project.attachProjectID,
-    middlewares.rateLimit.versionConsume,
   ];
 
   const legacyAPIMiddleware = [middlewares.project.unifyVersionID, ...statefulAPIMiddleware];


### PR DESCRIPTION
The [rate limit `versionConsume` method](https://github.com/voiceflow/general-runtime/blob/master/lib/middlewares/rateLimit.ts#L32) uses the authorization header for these routes, so we don't need to look up the project and version first.