### PR TITLE
fix: resolve why k8 logs are missing:IN-1219

### DIFF
--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:e01ae1035cc2580656507cbbe9a315c3b7212cde
+  vfcommon: voiceflow/common@dev:27a092c7c2b7d607aa41e76c278624938eee5684
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@{{ .values.common_orb_version }}
+  vfcommon: voiceflow/common@dev:e01ae1035cc2580656507cbbe9a315c3b7212cde
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* https://linear.app/voiceflow/issue/IN-1219/investigate-why-e2e-k8s-logs-are-missing-for-some-pods

### Brief description. What is this change?
* Some component logs are not showing  

### Checklist

- [ ] Tested