### PR TITLE
[Merged by Bors] - fix: correct shutdown sequence for http server (ENG-87)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -62,16 +62,16 @@ class Server {
 
   /**
    * Stop server
-   * - Stops services first, then server
+   * - stops accepting new connections, wait for all existing ones to drain, then stop services
    */
   async stop() {
-    // Stop services
-    await this.serviceManager.stop();
-
     if (this.server) {
       this.server.close();
       await once(this.server, 'close');
     }
+
+    // Stop services
+    await this.serviceManager.stop();
   }
 }
 


### PR DESCRIPTION
Please read the full report [here](https://www.notion.so/voiceflow/general-runtime-MongoDB-issues-5dcc5295b80a4a39916b6b4a6691cf91).

Put simply, we were seeing this Mongo Error: `'MongoNotConnectedError: Client must be connected before running operations`
However, it was always occurring AFTER a `SIGTERM` event:
![image](https://github.com/voiceflow/general-runtime/assets/5643574/35c030d4-3738-4134-a72c-f978a8e37282)

This is because we were kill all client connections first (Mongo, Redis, etc), THEN we were stopping the server from accepting new connections.

What this means is that it was possible for a existing request to be executed, the mongo client to get closed, then for that request to try and make a call to mongo.

To reproduce the error locally, just checkout this commit/branch:
https://github.com/voiceflow/general-runtime/commit/18f076c070ad6820ce9fa26f952efc7ff654e0a1
mesh the service and try to make a API call that uses mongo to it within 30 seconds.
<img width="1406" alt="Screenshot 2024-06-14 at 7 12 03 PM" src="https://github.com/voiceflow/general-runtime/assets/5643574/9f9ba100-5fc9-4647-89cc-a237ac861529">

