### PR TITLE
[Merged by Bors] - feat: move rate limit for public interact route (PL-000)

### DIFF
--- a/backend/api/routers/public.ts
+++ b/backend/api/routers/public.ts
@@ -11,7 +11,10 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
 
   router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
 
-  const interactMiddleware = [middlewares.project.resolvePublicProjectID, middlewares.rateLimit.versionConsume];
+  const interactMiddleware = [
+    middlewares.rateLimit.consumeResource((req) => req.params.projectID),
+    middlewares.project.resolvePublicProjectID,
+  ];
 
   // full route: /public/:projectID/state/user/:userID/interact
   router.post('/:projectID/state/user/:userID/interact', interactMiddleware, controllers.public.interact);


### PR DESCRIPTION
Instead of needing to look up the project to use the version ID for rate limiting, we can use the given project ID for rate limiting instead. This allows the rate limiting to be the first check, before any database lookups.