### PR TITLE
feat: add kubernetes events to logs (IN-1271)

### DIFF
--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@{{ .values.common_orb_version }}
+  vfcommon: voiceflow/common@dev:7afe0804ca9c365446002ff65bda9befc21473d9
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -49,7 +49,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:72887b5fc8fdef489e6b5633e111a7621660be62
+  vfcommon: voiceflow/common@{{ .values.common_orb_version }}
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -43,14 +43,13 @@ defaults:
 
   executor: &node-executor
     name: vfcommon/node-executor-node-20
-    tag: {{ .values.node_version }}-vf-4
 
   code-test-executor: &code-test-node-executor
     name: vfcommon/code-test-executor-node-20
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:c7cff05384bb1aefe2213040686d0e7e2117eddd
+  vfcommon: voiceflow/common@dev:72887b5fc8fdef489e6b5633e111a7621660be62
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:c68055f91ade7a95d6365d0aad555d1a60864079
+  vfcommon: voiceflow/common@dev:c7cff05384bb1aefe2213040686d0e7e2117eddd
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -43,7 +43,7 @@ defaults:
 
   executor: &node-executor
     name: vfcommon/node-executor-node-20
-    tag: {{ .values.node_version }}-vf-2
+    tag: {{ .values.node_version }}-vf-4
 
   code-test-executor: &code-test-node-executor
     name: vfcommon/code-test-executor-node-20

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -50,7 +50,7 @@ defaults:
     tag: {{ .values.node_version }}-vf-1
 
 orbs:
-  vfcommon: voiceflow/common@dev:7afe0804ca9c365446002ff65bda9befc21473d9
+  vfcommon: voiceflow/common@dev:c68055f91ade7a95d6365d0aad555d1a60864079
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* Linear [ticket](https://linear.app/voiceflow/issue/IN-1271/add-events-to-e2e-logs) 


### Brief description. What is this change?
* Include kubernetes events in the e2e gathered logs 

### Related PRs
* https://github.com/voiceflow/orb-common/pull/264
* https://github.com/voiceflow/infrastructure/pull/704

- [ ] Tested in a PR 
