### PR TITLE
feat: move runtime to turn handler context (PL-000)

### DIFF
--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -21,7 +21,7 @@ import { Context, ContextHandler, VersionTag } from '@/types';
 import { Predictor } from '../classification';
 import { castToDTO } from '../classification/classification.utils';
 import { getIntentRequest } from '../nlu';
-import { getNoneIntentRequest } from '../nlu/utils';
+import { getNoneIntentRequest, shouldBypassNLU } from '../nlu/utils';
 import { isIntentRequest, StorageType } from '../runtime/types';
 import { addOutputTrace, getOutputTrace } from '../runtime/utils';
 import { AbstractManager, injectServices } from '../utils';
@@ -120,6 +120,8 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
     if (!isIntentRequest(context.request)) {
       return context;
     }
+
+    if (await shouldBypassNLU(context)) return context;
 
     const version = await context.data.api.getVersion(context.versionID);
 

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -13,7 +13,7 @@ import { DebugEvent, Predictor } from '../classification';
 import { castToDTO } from '../classification/classification.utils';
 import { Prediction } from '../classification/interfaces/nlu.interface';
 import { AbstractManager } from '../utils';
-import { getNoneIntentRequest } from './utils';
+import { getNoneIntentRequest, shouldBypassNLU } from './utils';
 
 export const getIntentRequest = (prediction: Prediction | null): BaseRequest.IntentRequest => {
   if (!prediction) {
@@ -46,6 +46,8 @@ class NLU extends AbstractManager implements ContextHandler {
         request: getNoneIntentRequest(),
       };
     }
+
+    if (await shouldBypassNLU(context)) return context;
 
     const version = await context.data.api.getVersion(context.versionID);
     const project = await context.data.api.getProject(version.projectID);

--- a/lib/services/nlu/utils.ts
+++ b/lib/services/nlu/utils.ts
@@ -1,14 +1,10 @@
 import { AlexaConstants } from '@voiceflow/alexa-types';
-import { BaseModels, BaseNode, BaseRequest } from '@voiceflow/base-types';
-import { CommandType, EventType } from '@voiceflow/base-types/build/cjs/node/utils';
-import { VoiceflowConstants, VoiceflowUtils } from '@voiceflow/voiceflow-types';
+import { BaseModels, BaseRequest } from '@voiceflow/base-types';
+import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import { match } from 'ts-pattern';
 
-import { Stack } from '@/runtime';
 import { Context } from '@/types';
 
-import { isIntentInInteraction, isIntentScopeInNode, isInteractionsInNode } from '../dialog/utils';
-import RuntimeManager from '../runtime';
 import { isConfidenceScoreAbove } from '../runtime/utils';
 import { NLUGatewayPredictResponse, PredictProps } from './types';
 
@@ -94,107 +90,18 @@ export const mapChannelData = (data: any, platform?: VoiceflowConstants.Platform
   };
 };
 
-const setIntersect = (set1: Set<any>, set2: Set<any>) => new Set([...set1].filter((i) => set2.has(i)));
-
-const getCommandLevelIntentsAndEntities = (
-  stack: Stack
-): { commandIntentNames: Set<string>; commandEntityNames: Set<string> } => {
-  const intentCommands = stack
-    .getFrames()
-    .flatMap((frame) => frame.getCommands<BaseNode.Utils.AnyCommand<BaseNode.Utils.IntentEvent>>())
-    .filter((command) => command.type === CommandType.JUMP && command.event.type === EventType.INTENT);
-
-  const commandIntentNames = new Set(intentCommands.map((command) => command.event.intent));
-
-  const commandEntityNames = new Set(
-    intentCommands.flatMap((command) => command.event?.mappings ?? []).flatMap((mapping) => mapping.slot ?? [])
-  );
-
-  return { commandIntentNames, commandEntityNames };
-};
-
-const getNodeLevelIntentsAndEntities = (
-  node: BaseNode.Utils.BaseNode | null
-): {
-  nodeInteractionIntentNames: Set<string>;
-  nodeInteractionEntityNames: Set<string>;
-} => {
-  const nodeInteractionIntentNames: Set<string> = new Set();
-  const nodeInteractionEntityNames: Set<string> = new Set();
-  if (node && isInteractionsInNode(node)) {
-    const intentInteractions = node.interactions.filter(isIntentInInteraction);
-
-    intentInteractions
-      .flatMap((interaction) => interaction.event.intent)
-      .forEach((intent) => nodeInteractionIntentNames.add(intent));
-
-    intentInteractions
-      .flatMap((interaction) => interaction.event.mappings)
-      .flatMap((mapping) => mapping?.slot || [])
-      .forEach((entity) => nodeInteractionEntityNames.add(entity));
-  }
-
-  return { nodeInteractionIntentNames, nodeInteractionEntityNames };
-};
-
-export const getAvailableIntentsAndEntities = async (
-  runtimeManager: RuntimeManager,
-  context: Context
-): Promise<{
-  availableIntents: Set<string>;
-  availableEntities: Set<string>;
-  bypass?: boolean;
-}> => {
-  const runtime = runtimeManager
-    .createClient(context.data.api, () => undefined)
-    .createRuntime({
-      versionID: context.versionID,
-      state: context.state,
-      request: context.request,
-      version: context.version,
-      project: context.project,
-      timeout: 0,
-    });
-
-  // get command-level scope
-  const { commandIntentNames, commandEntityNames } = getCommandLevelIntentsAndEntities(runtime.stack);
-
-  const currentFrame = runtime.stack.top();
-  const program = await runtime.getProgram(runtime.getVersionID(), currentFrame.getDiagramID());
-  const node = program.getNode(currentFrame.getNodeID());
-
-  // TODO: temporary bypass for locally scoped capture step
-  // please remove this and properly fix the getAvailableIntentsAndEntities function/intent scoping
-  if (
-    node &&
-    VoiceflowUtils.node.isCaptureV2(node) &&
-    !node.intent?.name &&
-    node.variable &&
-    node.intentScope === BaseNode.Utils.IntentScope.NODE
-  ) {
-    return {
-      availableIntents: new Set(),
-      availableEntities: new Set(),
-      bypass: true,
-    };
-  }
-
-  // get node-level scope
-  const { nodeInteractionIntentNames, nodeInteractionEntityNames } = getNodeLevelIntentsAndEntities(node);
-
-  // intersect scopes if necessary
-  if (node && isIntentScopeInNode(node) && node.intentScope === BaseNode.Utils.IntentScope.NODE) {
-    return {
-      availableIntents: setIntersect(commandIntentNames, nodeInteractionIntentNames),
-      availableEntities: setIntersect(commandEntityNames, nodeInteractionEntityNames),
-    };
-  }
-
-  return {
-    availableIntents: commandIntentNames,
-    availableEntities: commandEntityNames,
-  };
-};
-
 export const isHybridLLMStrategy = (nluSettings?: BaseModels.Project.NLUSettings) =>
   nluSettings?.classifyStrategy === BaseModels.Project.ClassifyStrategy.VF_NLU_LLM_HYBRID;
+
+/**
+ * The newer listen steps have their own classification logic,
+ * so we shouldn't run the NLU or DialogManagement turn handlers.
+ */
+export const shouldBypassNLU = async (context: Context) => {
+  const currentFrame = context.runtime.stack.top();
+  const program = await context.runtime.getProgram(context.runtime.getVersionID(), currentFrame.getDiagramID());
+  const node = program.getNode(currentFrame.getNodeID());
+
+  // TODO: update with actual node type checks, probably via DTOs
+  return node?.type === 'interaction';
+};

--- a/lib/services/runtime/init.ts
+++ b/lib/services/runtime/init.ts
@@ -72,6 +72,8 @@ const init = (client: Client, eventHandler: HandleContextEventHandler) => {
       trace: frame,
     });
   });
+
+  return client;
 };
 
 export default init;

--- a/runtime/lib/Context/types.ts
+++ b/runtime/lib/Context/types.ts
@@ -1,6 +1,7 @@
 import { BaseNode, BaseProject, BaseVersion, RuntimeLogs } from '@voiceflow/base-types';
 
-import { State, SubscriptionEntitlements } from '@/runtime/lib/Runtime';
+import { GeneralRuntime } from '@/lib/services/runtime/types';
+import Client, { State, SubscriptionEntitlements } from '@/runtime';
 
 export interface Context<
   Request = Record<string, unknown>,
@@ -23,6 +24,8 @@ export interface Context<
   subscriptionEntitlements?: SubscriptionEntitlements;
   /** The most verbose logs to receive in runtime logging. */
   maxLogLevel: RuntimeLogs.LogLevel;
+  client: Client;
+  runtime: GeneralRuntime;
 }
 
 export type ContextHandle<C extends Context<any, any, any, any, any>> = (

--- a/tests/lib/services/nlu/utils.unit.ts
+++ b/tests/lib/services/nlu/utils.unit.ts
@@ -1,13 +1,9 @@
 import { AlexaConstants } from '@voiceflow/alexa-types';
-import { BaseNode } from '@voiceflow/base-types';
-import { CommandType, EventType } from '@voiceflow/base-types/build/cjs/node/utils';
 import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import chai from 'chai';
 import sinon from 'sinon';
 
-import { getAvailableIntentsAndEntities, mapChannelData } from '@/lib/services/nlu/utils';
-
-import { getMockRuntime } from './fixture';
+import { mapChannelData } from '@/lib/services/nlu/utils';
 
 const { expect } = chai;
 
@@ -40,103 +36,6 @@ describe('nlu manager utils unit tests', () => {
 
       const expectData = { payload: { intent: { name: AlexaConstants.AmazonIntent.YES } } };
       expect(outputData).to.eql(expectData);
-    });
-  });
-
-  describe('getAvailableIntentsAndEntities', () => {
-    const mockContext = { data: { api: sinon.stub() } };
-    const mockPizzaIntent = { type: EventType.INTENT, intent: 'Pizza', mappings: [{ slot: 'foo' }, { slot: 'bar' }] };
-    const mockYesIntent = { type: EventType.INTENT, intent: 'VF.YES', mappings: [{ slot: 'baz' }] };
-    const mockNoIntent = { type: EventType.INTENT, intent: 'VF.NO', mappings: [{ slot: 'qux' }] };
-
-    it('takes intersection when node is scoped', async () => {
-      const mockNodeInteractions = [{ event: mockPizzaIntent }, { event: mockYesIntent }, { event: mockNoIntent }];
-
-      const mockNode = {
-        interactions: mockNodeInteractions,
-        intentScope: BaseNode.Utils.IntentScope.NODE,
-      };
-
-      const mockCommands = [
-        {
-          type: CommandType.JUMP,
-          event: mockYesIntent,
-        },
-        {
-          type: CommandType.JUMP,
-          event: mockPizzaIntent,
-        },
-      ];
-
-      const runtimeClient = {
-        createRuntime: sinon.stub().returns(getMockRuntime(mockCommands, mockNode)),
-      };
-
-      const mockRuntimeManager = {
-        createClient: sinon.stub().returns(runtimeClient),
-      };
-
-      const { availableIntents, availableEntities } = await getAvailableIntentsAndEntities(
-        mockRuntimeManager as any,
-        mockContext as any
-      );
-
-      expect(availableIntents).to.eql(new Set(['VF.YES', 'Pizza']));
-      expect(availableEntities).to.eql(new Set(['baz', 'foo', 'bar']));
-    });
-
-    it('ignores node level when intentScope is global', async () => {
-      const mockNodeInteractions = [
-        {
-          event: mockYesIntent,
-        },
-      ];
-
-      const mockNode = {
-        interactions: mockNodeInteractions,
-        intentScope: BaseNode.Utils.IntentScope.GLOBAL,
-      };
-
-      const mockCommands = [
-        {
-          type: CommandType.JUMP,
-          event: mockNoIntent,
-        },
-      ];
-
-      const runtimeClient = {
-        createRuntime: sinon.stub().returns(getMockRuntime(mockCommands, mockNode)),
-      };
-
-      const mockRuntimeManager = {
-        createClient: sinon.stub().returns(runtimeClient),
-      };
-
-      const { availableIntents, availableEntities } = await getAvailableIntentsAndEntities(
-        mockRuntimeManager as any,
-        mockContext as any
-      );
-
-      expect(availableIntents).to.eql(new Set(['VF.NO']));
-      expect(availableEntities).to.eql(new Set(['qux']));
-    });
-
-    it('works with empty params', async () => {
-      const runtimeClient = {
-        createRuntime: sinon.stub().returns(getMockRuntime()),
-      };
-
-      const mockRuntimeManager = {
-        createClient: sinon.stub().returns(runtimeClient),
-      };
-
-      const { availableIntents, availableEntities } = await getAvailableIntentsAndEntities(
-        mockRuntimeManager as any,
-        mockContext as any
-      );
-
-      expect(availableIntents).to.eql(new Set([]));
-      expect(availableEntities).to.eql(new Set([]));
     });
   });
 });


### PR DESCRIPTION
Currently, we don't have context to your diagram/current node until we reach the runtime turn handler. This change moves the loading of the "runtime" component (not turn handler), to the turn "context" instead. This lets us check the runtime during any turn handler. This is then used to determine if we should skip the NLU/dialog management turn handlers if we're on a new listen step.
The goal here being to reduce the scope of changes needed, as well as reducing the risk of changing old behaviour.