### PR TITLE
[Merged by Bors] - feat: add trace time property (ENG-172)

### DIFF
--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -273,6 +273,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
             entityToFill: unfulfilledEntity.name,
             intent: dmStateStore.intentRequest,
           },
+          time: Date.now(),
         });
 
         debugLogging.recordGlobalLog(RuntimeLogs.Kinds.GlobalLogKind.NLU_INTENT_RESOLVED, {

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -99,6 +99,7 @@ const debugTrace = (message: string): BaseTrace.DebugTrace => ({
   payload: {
     message,
   },
+  time: Date.now(),
 });
 
 export default NLU;

--- a/lib/services/runtime/handlers/aiResponse/traces.ts
+++ b/lib/services/runtime/handlers/aiResponse/traces.ts
@@ -26,6 +26,7 @@ export const completionToStartTrace = (
       total: completion.tokens,
     },
   },
+  time: Date.now(),
 });
 
 export const completionToContinueTrace = (
@@ -40,9 +41,11 @@ export const completionToContinueTrace = (
       total: completion.tokens,
     },
   },
+  time: Date.now(),
 });
 
 export const endTrace = (): BaseTrace.CompletionEndTrace => ({
   type: BaseTrace.TraceType.COMPLETION_END,
   payload: {},
+  time: Date.now(),
 });

--- a/lib/services/runtime/utils.ts
+++ b/lib/services/runtime/utils.ts
@@ -289,6 +289,7 @@ export function textOutputTrace({
       ...(ai && { ai }),
       ...(isPrompt && { isPrompt }),
     },
+    time: Date.now(),
   };
 
   variables?.set(VoiceflowConstants.BuiltInVariable.LAST_RESPONSE, plainContent);
@@ -309,6 +310,7 @@ export function speakOutputTrace({ variables, output, isPrompt, ai }: OutputPara
       ...(ai && { ai }),
       ...(isPrompt && { isPrompt }),
     },
+    time: Date.now(),
   };
 
   variables?.set(VoiceflowConstants.BuiltInVariable.LAST_RESPONSE, message);

--- a/lib/services/tts/index.ts
+++ b/lib/services/tts/index.ts
@@ -15,12 +15,12 @@ export const utils = {};
 
 @injectServices({ utils })
 class TTS extends AbstractManager<{ utils: typeof utils }> implements ContextHandler {
-  fetchTTS = async (node: BaseNode.Speak.TraceFrame, locale?: string): Promise<BaseTrace.SpeakTrace[]> => {
+  fetchTTS = async (trace: BaseNode.Speak.TraceFrame, locale?: string): Promise<BaseTrace.SpeakTrace[]> => {
     try {
       const { data } = await this.services.axios.post<BaseTrace.SpeakTrace['payload'][]>(
         `${this.config.GENERAL_SERVICE_ENDPOINT}/tts/convert`,
         {
-          ssml: node.payload.message,
+          ssml: trace.payload.message,
         },
         {
           params: { ...(locale && { locale }) },
@@ -28,15 +28,17 @@ class TTS extends AbstractManager<{ utils: typeof utils }> implements ContextHan
       );
 
       return data.map((payload) => ({
+        ...trace,
         type: BaseNode.Utils.TraceType.SPEAK,
-        payload: { ...node.payload, ...payload },
+        payload: { ...trace.payload, ...payload },
       }));
     } catch (error) {
       log.error(`[app] [runtime] [${TTS.name}] failed to fetch TTS ${log.vars({ error })}`);
       return [
         {
+          ...trace,
           type: BaseNode.Utils.TraceType.SPEAK,
-          payload: { message: node.payload.message, type: BaseNode.Speak.TraceSpeakType.AUDIO },
+          payload: { message: trace.payload.message, type: BaseNode.Speak.TraceSpeakType.AUDIO },
         },
       ];
     }

--- a/runtime/lib/Handlers/function/index.ts
+++ b/runtime/lib/Handlers/function/index.ts
@@ -52,7 +52,7 @@ function applyTraceCommand(command: TraceCommand, runtime: Runtime): void {
   command.forEach((trace) => {
     // !TODO! - Revamp `general-runtime` types to allow users to modify the built-in
     //          trace types and avoid this `as` cast.
-    runtime.trace.addTrace(trace as BaseTraceFrame);
+    runtime.trace.addTrace(trace as Omit<BaseTraceFrame, 'time'>);
   });
 }
 
@@ -265,7 +265,7 @@ export const FunctionHandler: HandlerFactory<CompiledFunctionNode, typeof utilsO
     } catch (err) {
       // !TODO! - Revamp `general-runtime` types to allow users to modify the built-in
       //          trace types and avoid this `as` cast.
-      runtime.trace.addTrace(createFunctionExceptionDebugTrace(err) as BaseTrace.DebugTrace);
+      runtime.trace.addTrace(createFunctionExceptionDebugTrace(err) as Omit<BaseTrace.DebugTrace, 'time'>);
 
       return null;
     }

--- a/runtime/lib/Handlers/function/lib/execute-function/lib/validate-trace.ts
+++ b/runtime/lib/Handlers/function/lib/execute-function/lib/validate-trace.ts
@@ -5,6 +5,10 @@ import { SimpleTraceDTO } from '../../../runtime-command/trace-command.dto';
 import { isSimpleTraceType } from './is-simple-trace';
 
 export function parseTrace(trace: UnknownTrace): UnknownTrace {
+  // force all function declared traces to have a timestamp
+  // eslint-disable-next-line no-param-reassign
+  if (!trace.time) trace.time = Date.now();
+
   if (isSimpleTraceType(trace.type)) {
     try {
       return SimpleTraceDTO.parse(trace);

--- a/runtime/lib/Runtime/DebugLogging/utils.ts
+++ b/runtime/lib/Runtime/DebugLogging/utils.ts
@@ -4,6 +4,7 @@ import { Environment } from '@voiceflow/common';
 export const createLogTrace = (log: RuntimeLogs.Log): Trace.LogTrace => ({
   type: Trace.TraceType.LOG,
   payload: log,
+  time: Date.now(),
 });
 
 export const getISO8601Timestamp: () => RuntimeLogs.Iso8601Timestamp =

--- a/runtime/lib/Runtime/Trace/index.ts
+++ b/runtime/lib/Runtime/Trace/index.ts
@@ -1,4 +1,5 @@
 import { BaseNode } from '@voiceflow/base-types';
+import type { WithOptional } from '@voiceflow/common';
 import _truncate from 'lodash/truncate';
 
 import { EventType } from '@/runtime/lib/Lifecycle';
@@ -10,8 +11,13 @@ export default class Trace {
 
   constructor(private runtime: Runtime) {}
 
-  addTrace<TF extends BaseNode.Utils.BaseTraceFrame>(frame: TF) {
+  addTrace<TF extends BaseNode.Utils.BaseTraceFrame>(frameWithOptionalTime: WithOptional<TF, 'time'>): void {
     let stop = false;
+
+    const frame = {
+      time: Date.now(),
+      ...frameWithOptionalTime,
+    };
 
     this.runtime.callEvent(EventType.traceWillAdd, {
       frame,

--- a/tests/lib/services/dialog/fixture.ts
+++ b/tests/lib/services/dialog/fixture.ts
@@ -4,6 +4,8 @@ import sinon from 'sinon';
 import CacheDataAPI from '@/lib/services/state/cacheDataAPI';
 import { Context } from '@/types';
 
+export const mockTime = new Date('2020-01-01T00:00:00Z').getTime();
+
 export const mockUnfulfilledIntentRequest: BaseRequest.IntentRequest = {
   type: BaseRequest.RequestType.INTENT,
   payload: {
@@ -533,6 +535,7 @@ export const mockEntityFillingTrace: BaseTrace.EntityFillingTrace = {
     entityToFill: 'flavor',
     intent: mockUnfulfilledIntentRequest,
   },
+  time: mockTime,
 };
 
 export const mockEntityFillingTraceWithElicit: BaseTrace.EntityFillingTrace = {
@@ -541,4 +544,5 @@ export const mockEntityFillingTraceWithElicit: BaseTrace.EntityFillingTrace = {
     entityToFill: 'flavor',
     intent: { ...mockUnfulfilledIntentRequest, ELICIT: true } as any,
   },
+  time: mockTime,
 };

--- a/tests/lib/services/dialog/index.unit.ts
+++ b/tests/lib/services/dialog/index.unit.ts
@@ -21,6 +21,7 @@ import {
   mockRegularNoEntityResult,
   mockRegularSingleEntityResult,
   mockRegularUnrelatedResult,
+  mockTime,
   mockUnfulfilledIntentRequest,
 } from './fixture';
 
@@ -33,9 +34,9 @@ const createDM = () => {
 };
 
 describe('dialog manager unit tests', () => {
-  afterEach(() => {
-    sinon.restore();
-  });
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
 
   describe('general handler', () => {
     it('fails if version is not found', async () => {
@@ -172,6 +173,7 @@ describe('dialog manager unit tests', () => {
               type: 'message',
               isPrompt: true,
             },
+            time: mockTime,
           },
           mockEntityFillingTrace,
         ];

--- a/tests/lib/services/runtime/handlers/capture.unit.ts
+++ b/tests/lib/services/runtime/handlers/capture.unit.ts
@@ -4,13 +4,19 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { CaptureHandler } from '@/lib/services/runtime/handlers/capture';
-import runtime, { Action, Store } from '@/runtime';
+import { Action, Store } from '@/runtime';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
+
+import { mockTime } from '../../dialog/fixture';
 
 const CapturePathTrace = { type: 'path', payload: { path: 'capture' } };
 
 describe('Capture handler', () => {
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
+
   describe('canHandle', () => {
     it('false', () => {
       expect(CaptureHandler(null as any).canHandle({} as any, null as any, null as any, null as any)).to.eql(false);
@@ -279,6 +285,7 @@ describe('Capture handler', () => {
                       },
                       timestamp: getISO8601Timestamp(),
                     },
+                    time: mockTime,
                   },
                 ],
                 [CapturePathTrace],
@@ -340,6 +347,7 @@ describe('Capture handler', () => {
                       },
                       timestamp: getISO8601Timestamp(),
                     },
+                    time: mockTime,
                   },
                 ],
                 [CapturePathTrace],
@@ -404,6 +412,7 @@ describe('Capture handler', () => {
                       },
                       timestamp: getISO8601Timestamp(),
                     },
+                    time: mockTime,
                   },
                 ],
                 [CapturePathTrace],

--- a/tests/lib/services/runtime/handlers/message/index.unit.ts
+++ b/tests/lib/services/runtime/handlers/message/index.unit.ts
@@ -9,6 +9,8 @@ import { Program, Runtime, Store } from '@/runtime';
 import { mockMessageNode } from '@/tests/mocks/node/message.node.mock';
 import { ID, mockVersion } from '@/tests/mocks/version/version.mock';
 
+import { mockTime } from '../../../dialog/fixture';
+
 describe('Message handler', () => {
   const handler = MessageHandler();
 
@@ -32,6 +34,8 @@ describe('Message handler', () => {
   });
 
   beforeEach(() => {
+    sinon.useFakeTimers(mockTime);
+
     version = mockVersion();
     runtime = {
       version,
@@ -51,6 +55,10 @@ describe('Message handler', () => {
     messageNode = mockMessageNode();
 
     eventHandler = null as unknown as NodeEventHandler;
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   describe('can handle', () => {
@@ -136,6 +144,7 @@ describe('Message handler', () => {
             messageDelayMilliseconds: 100,
           },
         },
+        time: mockTime,
       });
     });
   });

--- a/tests/lib/services/runtime/handlers/message/lib/conditions/condition.unit.ts
+++ b/tests/lib/services/runtime/handlers/message/lib/conditions/condition.unit.ts
@@ -1,8 +1,6 @@
 import {
-  AIModel,
   AnyCompiledCondition,
   CompiledExpressionCondition,
-  CompiledPromptCondition,
   CompiledScriptCondition,
   ConditionType,
 } from '@voiceflow/dtos';
@@ -10,7 +8,6 @@ import { expect } from 'chai';
 
 import { createCondition } from '@/lib/services/runtime/handlers/message/lib/conditions/condition';
 import { ExpressionCondition } from '@/lib/services/runtime/handlers/message/lib/conditions/expression.condition';
-import { PromptCondition } from '@/lib/services/runtime/handlers/message/lib/conditions/prompt.condition';
 import { ScriptCondition } from '@/lib/services/runtime/handlers/message/lib/conditions/script.condition';
 
 describe('createCondition', () => {
@@ -46,38 +43,6 @@ describe('createCondition', () => {
       const result = createCondition(scriptCondition, variables);
 
       expect(result).to.instanceOf(ScriptCondition);
-    });
-
-    it('creates prompt condition', () => {
-      const promptCondition: CompiledPromptCondition = {
-        type: ConditionType.PROMPT,
-        data: {
-          turns: 37,
-          prompt: {
-            text: 'list the 10 presidents of all time',
-            settings: {
-              model: AIModel.CLAUDE_3_HAIKU,
-              maxLength: 137,
-              temperature: 237,
-              systemPrompt: 'You are a noble knight of the realm',
-            },
-          },
-          assertions: [
-            {
-              rhs: '1 + 3',
-              operation: 'is',
-            },
-            {
-              rhs: 'hello',
-              operation: 'is',
-            },
-          ],
-        },
-      };
-
-      const result = createCondition(promptCondition, variables);
-
-      expect(result).to.instanceOf(PromptCondition);
     });
 
     it('fails if unrecognized condition type received', () => {

--- a/tests/lib/services/runtime/handlers/noMatch.unit.ts
+++ b/tests/lib/services/runtime/handlers/noMatch.unit.ts
@@ -9,6 +9,8 @@ import { addOutputTrace, EMPTY_AUDIO_STRING, getOutputTrace } from '@/lib/servic
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
+import { mockTime } from '../../dialog/fixture';
+
 const RepromptPathTrace = { type: 'path', payload: { path: 'reprompt' } };
 const NoMatchPathTrace = { type: 'path', payload: { path: 'choice:else' } };
 
@@ -17,6 +19,10 @@ const GlobalNoMatch = { prompt: { content: 'Sorry, could not understand what you
 // force rebuild
 
 describe('noMatch handler unit tests', async () => {
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
+
   describe('handle', async () => {
     it('with noMatch', async () => {
       const node = {
@@ -58,6 +64,7 @@ describe('noMatch handler unit tests', async () => {
               message: 'the counter is 5.23',
               type: 'message',
             },
+            time: mockTime,
           },
         ],
         [
@@ -73,6 +80,7 @@ describe('noMatch handler unit tests', async () => {
               },
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);
@@ -195,6 +203,7 @@ describe('noMatch handler unit tests', async () => {
               message: 'the counter is {counter}',
               type: 'message',
             },
+            time: mockTime,
           },
         ],
         [
@@ -210,6 +219,7 @@ describe('noMatch handler unit tests', async () => {
               },
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);
@@ -260,6 +270,7 @@ describe('noMatch handler unit tests', async () => {
               message: 'the counter is {counter}',
               type: 'message',
             },
+            time: mockTime,
           },
         ],
         [
@@ -275,6 +286,7 @@ describe('noMatch handler unit tests', async () => {
               },
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);
@@ -521,6 +533,7 @@ describe('noMatch handler unit tests', async () => {
               message: 'the counter is 5.23',
               type: 'message',
             },
+            time: mockTime,
           },
         ],
         [
@@ -536,6 +549,7 @@ describe('noMatch handler unit tests', async () => {
               },
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);

--- a/tests/lib/services/runtime/handlers/noReply.unit.ts
+++ b/tests/lib/services/runtime/handlers/noReply.unit.ts
@@ -7,11 +7,17 @@ import { addOutputTrace, EMPTY_AUDIO_STRING, getOutputTrace } from '@/lib/servic
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
+import { mockTime } from '../../dialog/fixture';
+
 const RepromptPathTrace = { type: 'path', payload: { path: 'reprompt' } };
 const NoReplyPathTrace = { type: 'path', payload: { path: 'choice:noReply' } };
 const GlobalNoReply = { prompt: { content: 'Still there?' } };
 
 describe('noReply handler unit tests', () => {
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
+
   describe('handle', () => {
     it('with noReply', () => {
       const node = {
@@ -53,6 +59,7 @@ describe('noReply handler unit tests', () => {
               message: 'the counter is 5.23',
               type: 'message',
             },
+            time: mockTime,
           },
         ],
         [
@@ -68,6 +75,7 @@ describe('noReply handler unit tests', () => {
               },
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);
@@ -339,6 +347,7 @@ describe('noReply handler unit tests', () => {
               message: 'the counter is 5.23',
               type: 'message',
             },
+            time: mockTime,
           },
         ],
         [
@@ -354,6 +363,7 @@ describe('noReply handler unit tests', () => {
               },
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);

--- a/tests/lib/services/runtime/handlers/speak.unit.ts
+++ b/tests/lib/services/runtime/handlers/speak.unit.ts
@@ -9,12 +9,16 @@ import { addOutputTrace, speakOutputTrace } from '@/lib/services/runtime/utils';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
+import { mockTime } from '../../dialog/fixture';
+
 describe('speak handler unit tests', async () => {
   const speakHandler = SpeakHandler({
     _sample: sinon.stub().callsFake((arr: any[]) => arr[0]),
     addOutputTrace,
     speakOutputTrace,
   });
+
+  beforeEach(() => sinon.useFakeTimers(mockTime));
 
   afterEach(() => sinon.restore());
 
@@ -67,6 +71,7 @@ describe('speak handler unit tests', async () => {
               type: 'message',
             },
             type: 'speak',
+            time: mockTime,
           },
         ],
         [
@@ -82,6 +87,7 @@ describe('speak handler unit tests', async () => {
               timestamp: getISO8601Timestamp(),
             },
             type: 'log',
+            time: mockTime,
           },
         ],
       ]);
@@ -117,7 +123,7 @@ describe('speak handler unit tests', async () => {
       // output has vars replaced and numbers turned to 2digits floats
       expect(topFrame.storage.set.args).to.eql([[FrameType.OUTPUT, 'random 1.23 or here']]);
       expect(runtime.trace.addTrace.args).to.eql([
-        [{ type: 'speak', payload: { message: 'random 1.23 or here', type: 'message' } }],
+        [{ type: 'speak', payload: { message: 'random 1.23 or here', type: 'message' }, time: mockTime }],
         [
           {
             type: 'log',
@@ -131,6 +137,7 @@ describe('speak handler unit tests', async () => {
               },
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);

--- a/tests/lib/services/runtime/handlers/text.unit.ts
+++ b/tests/lib/services/runtime/handlers/text.unit.ts
@@ -7,7 +7,11 @@ import { addOutputTrace } from '@/lib/services/runtime/utils';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
+import { mockTime } from '../../dialog/fixture';
+
 describe('text handler unit tests', async () => {
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
   afterEach(() => sinon.restore());
 
   describe('canHandle', () => {
@@ -77,6 +81,7 @@ describe('text handler unit tests', async () => {
               },
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);

--- a/tests/lib/services/runtime/init.unit.ts
+++ b/tests/lib/services/runtime/init.unit.ts
@@ -8,10 +8,12 @@ import { EventType } from '@/runtime';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 
+import { mockTime } from '../dialog/fixture';
+
 describe('runtime init service unit tests', () => {
-  afterEach(() => {
-    sinon.restore();
-  });
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
 
   describe('EventType.stackDidChange', () => {
     it('no top frame', () => {
@@ -148,6 +150,7 @@ describe('runtime init service unit tests', () => {
             {
               type: BaseNode.Utils.TraceType.SPEAK,
               payload: { message: output, type: BaseNode.Speak.TraceSpeakType.MESSAGE },
+              time: mockTime,
             },
           ],
           [
@@ -163,6 +166,7 @@ describe('runtime init service unit tests', () => {
                 },
                 timestamp: getISO8601Timestamp(),
               },
+              time: mockTime,
             },
           ],
         ]);

--- a/tests/runtime/lib/Handlers/api.unit.ts
+++ b/tests/runtime/lib/Handlers/api.unit.ts
@@ -8,6 +8,7 @@ import APIHandler, { USER_AGENT, USER_AGENT_KEY } from '@/runtime/lib/Handlers/a
 import * as APIUtils from '@/runtime/lib/Handlers/api/utils';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
+import { mockTime } from '@/tests/lib/services/dialog/fixture';
 
 const ACTION_DATA = { foo: 'bar', url: 'http://test.com/test' };
 const AGENT_ACTION_DATA = {
@@ -22,6 +23,10 @@ const config = {
 };
 
 describe('API Handler unit tests', () => {
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
+
   describe('canHandle', () => {
     it('false', () => {
       const apiHandler = APIHandler(config);
@@ -286,6 +291,7 @@ describe('API Handler unit tests', () => {
                 },
                 timestamp: getISO8601Timestamp(),
               },
+              time: mockTime,
             },
           ],
         ]);
@@ -369,6 +375,7 @@ describe('API Handler unit tests', () => {
                 },
                 timestamp: getISO8601Timestamp(),
               },
+              time: mockTime,
             },
           ],
         ]);

--- a/tests/runtime/lib/Handlers/end.unit.ts
+++ b/tests/runtime/lib/Handlers/end.unit.ts
@@ -5,9 +5,14 @@ import sinon from 'sinon';
 import EndHandler from '@/runtime/lib/Handlers/end';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
+import { mockTime } from '@/tests/lib/services/dialog/fixture';
 
 describe('EndHandler unit tests', () => {
   const endHandler = EndHandler();
+
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
 
   describe('canHandle', () => {
     it('false', () => {
@@ -63,6 +68,7 @@ describe('EndHandler unit tests', () => {
               level: RuntimeLogs.LogLevel.VERBOSE,
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);

--- a/tests/runtime/lib/Handlers/flow.unit.ts
+++ b/tests/runtime/lib/Handlers/flow.unit.ts
@@ -8,9 +8,14 @@ import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 import * as Frame from '@/runtime/lib/Runtime/Stack/Frame';
 import * as Utils from '@/runtime/lib/Runtime/utils/variables';
+import { mockTime } from '@/tests/lib/services/dialog/fixture';
 
 describe('flowHandler unit tests', () => {
   const flowHandler = FlowHandler();
+
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
 
   describe('canHandle', () => {
     it('false', () => {
@@ -95,6 +100,7 @@ describe('flowHandler unit tests', () => {
               },
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);
@@ -181,6 +187,7 @@ describe('flowHandler unit tests', () => {
               },
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);

--- a/tests/runtime/lib/Handlers/if.unit.ts
+++ b/tests/runtime/lib/Handlers/if.unit.ts
@@ -7,9 +7,14 @@ import * as Utils from '@/runtime/lib/Handlers/utils/shuntingYard';
 import { EventType } from '@/runtime/lib/Lifecycle';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
+import { mockTime } from '@/tests/lib/services/dialog/fixture';
 
 describe('ifHandler unit tests', () => {
   const ifHandler = IfHandler();
+
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
 
   describe('canHandle', () => {
     it('false', () => {
@@ -89,6 +94,7 @@ describe('ifHandler unit tests', () => {
               },
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);
@@ -146,6 +152,7 @@ describe('ifHandler unit tests', () => {
               },
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);
@@ -201,6 +208,7 @@ describe('ifHandler unit tests', () => {
                 },
                 timestamp: getISO8601Timestamp(),
               },
+              time: mockTime,
             },
           ],
         ]);
@@ -240,6 +248,7 @@ describe('ifHandler unit tests', () => {
                 },
                 timestamp: getISO8601Timestamp(),
               },
+              time: mockTime,
             },
           ],
         ]);

--- a/tests/runtime/lib/Handlers/ifV2.unit.ts
+++ b/tests/runtime/lib/Handlers/ifV2.unit.ts
@@ -6,11 +6,12 @@ import * as CodeHandler from '@/runtime/lib/Handlers/code';
 import IfV2Handler from '@/runtime/lib/Handlers/ifV2';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
+import { mockTime } from '@/tests/lib/services/dialog/fixture';
 
 describe('ifV2 handler unit tests', () => {
-  afterEach(() => {
-    sinon.restore();
-  });
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
 
   describe('canHandle', () => {
     it('false', () => {
@@ -121,6 +122,7 @@ describe('ifV2 handler unit tests', () => {
                 },
                 timestamp: getISO8601Timestamp(),
               },
+              time: mockTime,
             },
           ],
         ]);
@@ -156,6 +158,7 @@ describe('ifV2 handler unit tests', () => {
                 },
                 timestamp: getISO8601Timestamp(),
               },
+              time: mockTime,
             },
           ],
         ]);
@@ -218,6 +221,7 @@ describe('ifV2 handler unit tests', () => {
                 },
                 timestamp: getISO8601Timestamp(),
               },
+              time: mockTime,
             },
           ],
         ]);

--- a/tests/runtime/lib/Handlers/random.unit.ts
+++ b/tests/runtime/lib/Handlers/random.unit.ts
@@ -7,9 +7,14 @@ import RandomHandler from '@/runtime/lib/Handlers/random';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 import Store from '@/runtime/lib/Runtime/Store';
+import { mockTime } from '@/tests/lib/services/dialog/fixture';
 
 describe('randomHandler unit tests', () => {
   const randomHandler = RandomHandler();
+
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
 
   describe('canHandle', () => {
     it('false', () => {
@@ -45,6 +50,7 @@ describe('randomHandler unit tests', () => {
               level: 'info',
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);
@@ -81,6 +87,7 @@ describe('randomHandler unit tests', () => {
               level: 'info',
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);
@@ -120,6 +127,7 @@ describe('randomHandler unit tests', () => {
                 level: 'info',
                 timestamp: getISO8601Timestamp(),
               },
+              time: mockTime,
             },
           ],
         ]);
@@ -161,6 +169,7 @@ describe('randomHandler unit tests', () => {
                   level: 'info',
                   timestamp: getISO8601Timestamp(),
                 },
+                time: mockTime,
               },
             ],
           ]);
@@ -202,6 +211,7 @@ describe('randomHandler unit tests', () => {
                   level: 'info',
                   timestamp: getISO8601Timestamp(),
                 },
+                time: mockTime,
               },
             ],
           ]);
@@ -243,6 +253,7 @@ describe('randomHandler unit tests', () => {
                   level: 'info',
                   timestamp: getISO8601Timestamp(),
                 },
+                time: mockTime,
               },
             ],
           ]);

--- a/tests/runtime/lib/Handlers/set.unit.ts
+++ b/tests/runtime/lib/Handlers/set.unit.ts
@@ -7,9 +7,14 @@ import * as Utils from '@/runtime/lib/Handlers/utils/shuntingYard';
 import { EventType } from '@/runtime/lib/Lifecycle';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
+import { mockTime } from '@/tests/lib/services/dialog/fixture';
 
 describe('setHandler unit tests', () => {
   const setHandler = SetHandler();
+
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
 
   describe('canHandle', () => {
     it('false', () => {
@@ -105,6 +110,7 @@ describe('setHandler unit tests', () => {
               level: RuntimeLogs.LogLevel.INFO,
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);
@@ -142,6 +148,7 @@ describe('setHandler unit tests', () => {
               level: RuntimeLogs.LogLevel.INFO,
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);

--- a/tests/runtime/lib/Handlers/setV2.unit.ts
+++ b/tests/runtime/lib/Handlers/setV2.unit.ts
@@ -7,11 +7,12 @@ import SetV2Handler from '@/runtime/lib/Handlers/setV2';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
 import Store from '@/runtime/lib/Runtime/Store';
+import { mockTime } from '@/tests/lib/services/dialog/fixture';
 
 describe('setV2 handler unit tests', () => {
-  afterEach(() => {
-    sinon.restore();
-  });
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
 
   describe('canHandle', () => {
     it('false', () => {
@@ -112,6 +113,7 @@ describe('setV2 handler unit tests', () => {
               level: RuntimeLogs.LogLevel.INFO,
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);
@@ -168,6 +170,7 @@ describe('setV2 handler unit tests', () => {
               level: RuntimeLogs.LogLevel.INFO,
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);

--- a/tests/runtime/lib/Handlers/start.unit.ts
+++ b/tests/runtime/lib/Handlers/start.unit.ts
@@ -6,8 +6,13 @@ import { Store } from '@/runtime';
 import StartHandler from '@/runtime/lib/Handlers/start';
 import DebugLogging from '@/runtime/lib/Runtime/DebugLogging';
 import { getISO8601Timestamp } from '@/runtime/lib/Runtime/DebugLogging/utils';
+import { mockTime } from '@/tests/lib/services/dialog/fixture';
 
 describe('startHandler unit tests', () => {
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
+
   const startHandler = StartHandler();
 
   describe('canHandle', () => {
@@ -51,6 +56,7 @@ describe('startHandler unit tests', () => {
               level: RuntimeLogs.LogLevel.INFO,
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
         [
@@ -65,6 +71,7 @@ describe('startHandler unit tests', () => {
               level: RuntimeLogs.LogLevel.INFO,
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);
@@ -95,6 +102,7 @@ describe('startHandler unit tests', () => {
               level: RuntimeLogs.LogLevel.INFO,
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
         [
@@ -109,6 +117,7 @@ describe('startHandler unit tests', () => {
               level: RuntimeLogs.LogLevel.INFO,
               timestamp: getISO8601Timestamp(),
             },
+            time: mockTime,
           },
         ],
       ]);

--- a/tests/runtime/lib/Runtime/Trace/index.unit.ts
+++ b/tests/runtime/lib/Runtime/Trace/index.unit.ts
@@ -5,14 +5,19 @@ import sinon from 'sinon';
 
 import { EventType } from '@/runtime/lib/Lifecycle';
 import Trace from '@/runtime/lib/Runtime/Trace';
+import { mockTime } from '@/tests/lib/services/dialog/fixture';
 
 describe('Runtime Trace unit tests', () => {
+  beforeEach(() => sinon.useFakeTimers(mockTime));
+
+  afterEach(() => sinon.restore());
+
   describe('addTrace', () => {
     it('adds frame', () => {
       const runtime = { callEvent: sinon.stub() };
 
       const trace = new Trace(runtime as any);
-      const frame = { foo: 'bar' };
+      const frame = { foo: 'bar', time: mockTime };
       trace.addTrace(frame as any);
 
       expect(_.get(trace, 'trace')).to.eql([frame]);


### PR DESCRIPTION
add a `time` property with `Date.now()` for all traces.

Right now the time property is optional in `BaseTraceFrame`,  however for the purpose of the PR I intentionally modified my local type to have `time` to be required and fixed all resulting type and build errors. This way we can remove the optional field and have it fully be required.

Reference my comments for more details. The majority of traces just use `runtime.trace.addTrace` so I made it automatically assign the time there, and have the time field optional so other places can be less verbose.