### PR TITLE
[Merged by Bors] - build(fix): docker mocha compilation failure (PL-1263)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,13 +29,14 @@ COPY --link . ./
 FROM sourced AS testing
 
 FROM testing AS linter
-RUN yarn lint:report 2>&1 | tee /var/log/eslint.log
+RUN yarn lint:report >/var/log/eslint.log 2>&1
 
 FROM testing AS dep-check
-RUN yarn test:dependencies 2>&1 | tee /var/log/dep-check.log
+RUN yarn test:dependencies >/var/log/dep-check.log 2>&1
 
 FROM testing AS unit-tests
-RUN yarn test:unit:ci 2>&1 | tee /var/log/unit-tests.log
+RUN yarn test:unit:ci >/var/log/unit-tests.log 2>&1 \
+  || mkdir -p ./reports/mocha/ && touch ./reports/mocha/unit-tests.xml
 
 FROM scratch AS checks
 COPY --link --from=linter /src/reports/eslint.xml /


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-1263**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->
Docker "checks" build step expects the mocha unit-test.xml file to exist, which is not created when there is a compilation error. Use `touch` to make sure the file exists on failure

Tested on https://github.com/voiceflow/general-runtime/pull/868