### PR TITLE
[Merged by Bors] - fix: increase header timeout (ENG-173)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -49,6 +49,7 @@ class Server {
 
     // nodeJS keepAliveTimeout has to be higher than downstream nginx keepAliveTimeout (default 75s)
     this.server.keepAliveTimeout = 76 * 1000;
+    this.server.headersTimeout = 77 * 1000;
 
     const { middlewares, controllers } = this.serviceManager;
 


### PR DESCRIPTION
Just to be safe.
extension of: https://github.com/voiceflow/general-runtime/pull/815


https://connectreport.com/blog/tuning-http-keep-alive-in-node-js/