### PR TITLE
[Merged by Bors] - fix: fixing crash due to empty variants (COR-2571)

### DIFF
--- a/lib/services/runtime/handlers/message/message.handler.ts
+++ b/lib/services/runtime/handlers/message/message.handler.ts
@@ -74,7 +74,7 @@ export const MessageHandler: HandlerFactory<CompiledMessageNode> = () => ({
 
       const chosenVariant = await selectVariant(preprocessedVariants);
 
-      if (chosenVariant.data.text.trim()) {
+      if (chosenVariant.data.text.length) {
         outputVariant(chosenVariant, node, runtime, variables);
       }
 

--- a/lib/services/runtime/handlers/message/message.handler.ts
+++ b/lib/services/runtime/handlers/message/message.handler.ts
@@ -74,7 +74,9 @@ export const MessageHandler: HandlerFactory<CompiledMessageNode> = () => ({
 
       const chosenVariant = await selectVariant(preprocessedVariants);
 
-      outputVariant(chosenVariant, node, runtime, variables);
+      if (chosenVariant.data.text.trim()) {
+        outputVariant(chosenVariant, node, runtime, variables);
+      }
 
       return node.ports.default;
     } catch (err) {

--- a/tests/lib/services/runtime/handlers/message/message.handler.unit.ts
+++ b/tests/lib/services/runtime/handlers/message/message.handler.unit.ts
@@ -118,6 +118,37 @@ describe('Message handler', () => {
       );
     });
 
+    it('outputs nothing if an empty text variant is given', async () => {
+      version = mockVersion({
+        programResources: {
+          messages: {
+            [ID.messageID]: {
+              variants: {
+                'default:en-us': [
+                  {
+                    data: {
+                      text: [],
+                      delay: 100,
+                    },
+                    condition: null,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+      runtime = {
+        ...runtime,
+        version,
+      } as unknown as Runtime;
+
+      const result = await handler.handle(messageNode, runtime, variables, program, eventHandler);
+
+      await expect(result).to.eql(messageNode.ports.default);
+      await expect((runtime.trace.addTrace as sinon.SinonStub).callCount).to.eql(0);
+    });
+
     it('outputs text trace for each text variant', async () => {
       const result = await handler.handle(messageNode, runtime, variables, program, eventHandler);
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements COR-2571**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

The message step handler crashes when all of the unconditioned variants have no text.

This is because the compiler (the `realtime`?) is stripping out variants with empty text. The `general-runtime` assumed that at least one variant would exist on a message resource, because the UI ensures there is always an editor for the unconditioned variant resource, but this requirement become invalid due to the compiler's stripping. 

So when executing this incorrect message resource, we attempt to sample from the list of unconditioned variants (which is `[]`) and then access the `.variant` property, `unconditionedVariants[randomIndex].variant`, causing an exception. 

This PR and a PR on `general-service` fixes the issue. The compiler no longer strips variants with empty text and the `general-runtime` will not output a trace with empty text.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test