### PR TITLE
[Merged by Bors] - feat: treat unused intent predictions as None (PL-1294)

### DIFF
--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -187,6 +187,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
 
           const prediction = await predictor.predict(`${prefix} ${query}`);
 
+          // LATER: look into using the `filteredIntents` field in the Predictor class instead
           dmPrefixedResult =
             prediction && isUsedIntent(version.prototype?.surveyorContext.usedIntentsSet, prediction.predictedIntent)
               ? getIntentRequest(prediction)

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -21,7 +21,7 @@ import { Context, ContextHandler, VersionTag } from '@/types';
 import { Predictor } from '../classification';
 import { castToDTO } from '../classification/classification.utils';
 import { getIntentRequest } from '../nlu';
-import { getNoneIntentRequest, isUsedIntent } from '../nlu/utils';
+import { findIntent, getNoneIntentRequest, isUsedIntent } from '../nlu/utils';
 import { isIntentRequest, StorageType } from '../runtime/types';
 import { addOutputTrace, getOutputTrace } from '../runtime/utils';
 import { AbstractManager, injectServices } from '../utils';
@@ -187,9 +187,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
 
           const prediction = await predictor.predict(`${prefix} ${query}`);
 
-          const predictedIntent = prediction?.predictedIntent
-            ? intents?.find((intent) => intent.name === prediction?.predictedIntent)
-            : undefined;
+          const predictedIntent = findIntent(intents, prediction?.predictedIntent);
 
           // LATER: look into using the `filteredIntents` field in the Predictor class instead
           dmPrefixedResult =

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -195,7 +195,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
           dmPrefixedResult =
             prediction && isUsedIntent(version.prototype?.surveyorContext?.usedIntentsSet, predictedIntent)
               ? getIntentRequest(prediction)
-              : getNoneIntentRequest(prediction ?? { query });
+              : getNoneIntentRequest({ query });
         }
 
         // Remove the dmPrefix from entity values that it has accidentally been attached to

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -187,9 +187,13 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
 
           const prediction = await predictor.predict(`${prefix} ${query}`);
 
+          const predictedIntent = prediction?.predictedIntent
+            ? intents?.find((intent) => intent.name === prediction?.predictedIntent)
+            : undefined;
+
           // LATER: look into using the `filteredIntents` field in the Predictor class instead
           dmPrefixedResult =
-            prediction && isUsedIntent(version.prototype?.surveyorContext?.usedIntentsSet, prediction.predictedIntent)
+            prediction && isUsedIntent(version.prototype?.surveyorContext?.usedIntentsSet, predictedIntent)
               ? getIntentRequest(prediction)
               : getNoneIntentRequest(prediction ?? { query });
         }

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -189,7 +189,7 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
 
           // LATER: look into using the `filteredIntents` field in the Predictor class instead
           dmPrefixedResult =
-            prediction && isUsedIntent(version.prototype?.surveyorContext.usedIntentsSet, prediction.predictedIntent)
+            prediction && isUsedIntent(version.prototype?.surveyorContext?.usedIntentsSet, prediction.predictedIntent)
               ? getIntentRequest(prediction)
               : getNoneIntentRequest(prediction ?? { query });
         }

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -13,13 +13,9 @@ import { DebugEvent, Predictor } from '../classification';
 import { castToDTO } from '../classification/classification.utils';
 import { Prediction } from '../classification/interfaces/nlu.interface';
 import { AbstractManager } from '../utils';
-import { getNoneIntentRequest } from './utils';
+import { getNoneIntentRequest, isUsedIntent } from './utils';
 
-export const getIntentRequest = (prediction: Prediction | null): BaseRequest.IntentRequest => {
-  if (!prediction) {
-    return getNoneIntentRequest();
-  }
-
+export const getIntentRequest = (prediction: Prediction): BaseRequest.IntentRequest => {
   return {
     type: BaseRequest.RequestType.INTENT,
     payload: {
@@ -84,9 +80,13 @@ class NLU extends AbstractManager implements ContextHandler {
       predictor.on('debug', addDebug);
     }
 
-    const prediction = await predictor.predict(context.request.payload);
+    const query = context.request.payload;
+    const prediction = await predictor.predict(query);
 
-    const request = getIntentRequest(prediction);
+    const request =
+      prediction && isUsedIntent(version.prototype?.surveyorContext.usedIntentsSet, prediction.predictedIntent)
+        ? getIntentRequest(prediction)
+        : getNoneIntentRequest(prediction ?? { query });
 
     predictor.removeListener('debug', addDebug);
 

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -85,7 +85,7 @@ class NLU extends AbstractManager implements ContextHandler {
 
     // LATER: look into using the `filteredIntents` field in the Predictor class instead
     const request =
-      prediction && isUsedIntent(version.prototype?.surveyorContext.usedIntentsSet, prediction.predictedIntent)
+      prediction && isUsedIntent(version.prototype?.surveyorContext?.usedIntentsSet, prediction.predictedIntent)
         ? getIntentRequest(prediction)
         : getNoneIntentRequest(prediction ?? { query });
 

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -83,9 +83,13 @@ class NLU extends AbstractManager implements ContextHandler {
     const query = context.request.payload;
     const prediction = await predictor.predict(query);
 
+    const predictedIntent = prediction?.predictedIntent
+      ? intents?.find((intent) => intent.name === prediction?.predictedIntent)
+      : undefined;
+
     // LATER: look into using the `filteredIntents` field in the Predictor class instead
     const request =
-      prediction && isUsedIntent(version.prototype?.surveyorContext?.usedIntentsSet, prediction.predictedIntent)
+      prediction && isUsedIntent(version.prototype?.surveyorContext?.usedIntentsSet, predictedIntent)
         ? getIntentRequest(prediction)
         : getNoneIntentRequest(prediction ?? { query });
 

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -83,6 +83,7 @@ class NLU extends AbstractManager implements ContextHandler {
     const query = context.request.payload;
     const prediction = await predictor.predict(query);
 
+    // LATER: look into using the `filteredIntents` field in the Predictor class instead
     const request =
       prediction && isUsedIntent(version.prototype?.surveyorContext.usedIntentsSet, prediction.predictedIntent)
         ? getIntentRequest(prediction)

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -13,7 +13,7 @@ import { DebugEvent, Predictor } from '../classification';
 import { castToDTO } from '../classification/classification.utils';
 import { Prediction } from '../classification/interfaces/nlu.interface';
 import { AbstractManager } from '../utils';
-import { getNoneIntentRequest, isUsedIntent } from './utils';
+import { findIntent, getNoneIntentRequest, isUsedIntent } from './utils';
 
 export const getIntentRequest = (prediction: Prediction): BaseRequest.IntentRequest => {
   return {
@@ -83,9 +83,7 @@ class NLU extends AbstractManager implements ContextHandler {
     const query = context.request.payload;
     const prediction = await predictor.predict(query);
 
-    const predictedIntent = prediction?.predictedIntent
-      ? intents?.find((intent) => intent.name === prediction?.predictedIntent)
-      : undefined;
+    const predictedIntent = findIntent(intents, prediction?.predictedIntent);
 
     // LATER: look into using the `filteredIntents` field in the Predictor class instead
     const request =

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -91,7 +91,7 @@ class NLU extends AbstractManager implements ContextHandler {
     const request =
       prediction && isUsedIntent(version.prototype?.surveyorContext?.usedIntentsSet, predictedIntent)
         ? getIntentRequest(prediction)
-        : getNoneIntentRequest(prediction ?? { query });
+        : getNoneIntentRequest({ query });
 
     predictor.removeListener('debug', addDebug);
 

--- a/lib/services/nlu/utils.ts
+++ b/lib/services/nlu/utils.ts
@@ -89,8 +89,8 @@ export const mapChannelData = (data: any, platform?: VoiceflowConstants.Platform
 };
 
 export const isUsedIntent = (usedIntents: string[] | undefined, intent: string | undefined) =>
-  /* If we don't have any used intents, consider it "used" for compatibility */
-  !Array.isArray(usedIntents) || (intent && usedIntents.includes(intent));
+  /* If we don't have a used intents array, consider it "used" for compatibility */
+  !Array.isArray(usedIntents) || (!!intent && usedIntents.includes(intent));
 
 export const isHybridLLMStrategy = (nluSettings?: BaseModels.Project.NLUSettings) =>
   nluSettings?.classifyStrategy === BaseModels.Project.ClassifyStrategy.VF_NLU_LLM_HYBRID;

--- a/lib/services/nlu/utils.ts
+++ b/lib/services/nlu/utils.ts
@@ -1,14 +1,8 @@
 import { AlexaConstants } from '@voiceflow/alexa-types';
-import { BaseModels, BaseNode, BaseRequest } from '@voiceflow/base-types';
-import { CommandType, EventType } from '@voiceflow/base-types/build/cjs/node/utils';
-import { VoiceflowConstants, VoiceflowUtils } from '@voiceflow/voiceflow-types';
+import { BaseModels, BaseRequest } from '@voiceflow/base-types';
+import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import { match } from 'ts-pattern';
 
-import { Stack } from '@/runtime';
-import { Context } from '@/types';
-
-import { isIntentInInteraction, isIntentScopeInNode, isInteractionsInNode } from '../dialog/utils';
-import RuntimeManager from '../runtime';
 import { isConfidenceScoreAbove } from '../runtime/utils';
 import { NLUGatewayPredictResponse, PredictProps } from './types';
 
@@ -94,107 +88,9 @@ export const mapChannelData = (data: any, platform?: VoiceflowConstants.Platform
   };
 };
 
-const setIntersect = (set1: Set<any>, set2: Set<any>) => new Set([...set1].filter((i) => set2.has(i)));
-
-const getCommandLevelIntentsAndEntities = (
-  stack: Stack
-): { commandIntentNames: Set<string>; commandEntityNames: Set<string> } => {
-  const intentCommands = stack
-    .getFrames()
-    .flatMap((frame) => frame.getCommands<BaseNode.Utils.AnyCommand<BaseNode.Utils.IntentEvent>>())
-    .filter((command) => command.type === CommandType.JUMP && command.event.type === EventType.INTENT);
-
-  const commandIntentNames = new Set(intentCommands.map((command) => command.event.intent));
-
-  const commandEntityNames = new Set(
-    intentCommands.flatMap((command) => command.event?.mappings ?? []).flatMap((mapping) => mapping.slot ?? [])
-  );
-
-  return { commandIntentNames, commandEntityNames };
-};
-
-const getNodeLevelIntentsAndEntities = (
-  node: BaseNode.Utils.BaseNode | null
-): {
-  nodeInteractionIntentNames: Set<string>;
-  nodeInteractionEntityNames: Set<string>;
-} => {
-  const nodeInteractionIntentNames: Set<string> = new Set();
-  const nodeInteractionEntityNames: Set<string> = new Set();
-  if (node && isInteractionsInNode(node)) {
-    const intentInteractions = node.interactions.filter(isIntentInInteraction);
-
-    intentInteractions
-      .flatMap((interaction) => interaction.event.intent)
-      .forEach((intent) => nodeInteractionIntentNames.add(intent));
-
-    intentInteractions
-      .flatMap((interaction) => interaction.event.mappings)
-      .flatMap((mapping) => mapping?.slot || [])
-      .forEach((entity) => nodeInteractionEntityNames.add(entity));
-  }
-
-  return { nodeInteractionIntentNames, nodeInteractionEntityNames };
-};
-
-export const getAvailableIntentsAndEntities = async (
-  runtimeManager: RuntimeManager,
-  context: Context
-): Promise<{
-  availableIntents: Set<string>;
-  availableEntities: Set<string>;
-  bypass?: boolean;
-}> => {
-  const runtime = runtimeManager
-    .createClient(context.data.api, () => undefined)
-    .createRuntime({
-      versionID: context.versionID,
-      state: context.state,
-      request: context.request,
-      version: context.version,
-      project: context.project,
-      timeout: 0,
-    });
-
-  // get command-level scope
-  const { commandIntentNames, commandEntityNames } = getCommandLevelIntentsAndEntities(runtime.stack);
-
-  const currentFrame = runtime.stack.top();
-  const program = await runtime.getProgram(runtime.getVersionID(), currentFrame.getDiagramID());
-  const node = program.getNode(currentFrame.getNodeID());
-
-  // TODO: temporary bypass for locally scoped capture step
-  // please remove this and properly fix the getAvailableIntentsAndEntities function/intent scoping
-  if (
-    node &&
-    VoiceflowUtils.node.isCaptureV2(node) &&
-    !node.intent?.name &&
-    node.variable &&
-    node.intentScope === BaseNode.Utils.IntentScope.NODE
-  ) {
-    return {
-      availableIntents: new Set(),
-      availableEntities: new Set(),
-      bypass: true,
-    };
-  }
-
-  // get node-level scope
-  const { nodeInteractionIntentNames, nodeInteractionEntityNames } = getNodeLevelIntentsAndEntities(node);
-
-  // intersect scopes if necessary
-  if (node && isIntentScopeInNode(node) && node.intentScope === BaseNode.Utils.IntentScope.NODE) {
-    return {
-      availableIntents: setIntersect(commandIntentNames, nodeInteractionIntentNames),
-      availableEntities: setIntersect(commandEntityNames, nodeInteractionEntityNames),
-    };
-  }
-
-  return {
-    availableIntents: commandIntentNames,
-    availableEntities: commandEntityNames,
-  };
-};
+export const isUsedIntent = (usedIntents: string[] | undefined, intent: string | undefined) =>
+  /* If we don't have any used intents, consider it "used" for compatibility */
+  !Array.isArray(usedIntents) || (intent && usedIntents.includes(intent));
 
 export const isHybridLLMStrategy = (nluSettings?: BaseModels.Project.NLUSettings) =>
   nluSettings?.classifyStrategy === BaseModels.Project.ClassifyStrategy.VF_NLU_LLM_HYBRID;

--- a/lib/services/nlu/utils.ts
+++ b/lib/services/nlu/utils.ts
@@ -88,9 +88,12 @@ export const mapChannelData = (data: any, platform?: VoiceflowConstants.Platform
   };
 };
 
-export const isUsedIntent = (usedIntents: string[] | undefined, intent: string | undefined) =>
+export const isUsedIntent = (usedIntents: string[] | undefined, intent: { key: string; name: string } | undefined) =>
   /* If we don't have a used intents array, consider it "used" for compatibility */
-  !Array.isArray(usedIntents) || (!!intent && usedIntents.includes(intent));
+  !Array.isArray(usedIntents) ||
+  (!!intent &&
+    /* The used intent set contains both keys and names :confused: */
+    usedIntents.findIndex((used) => used === intent.key || used === intent.name) >= 0);
 
 export const isHybridLLMStrategy = (nluSettings?: BaseModels.Project.NLUSettings) =>
   nluSettings?.classifyStrategy === BaseModels.Project.ClassifyStrategy.VF_NLU_LLM_HYBRID;

--- a/tests/lib/services/nlu/utils.unit.ts
+++ b/tests/lib/services/nlu/utils.unit.ts
@@ -41,7 +41,7 @@ describe('nlu manager utils unit tests', () => {
 
   describe('isUsedIntent', () => {
     it('returns true if intent array is undefined', () => {
-      expect(isUsedIntent(undefined, 'intent')).to.eql(true);
+      expect(isUsedIntent(undefined, { key: 'abc', name: 'test' })).to.eql(true);
     });
 
     it('returns false if intent name is undefined', () => {
@@ -49,11 +49,15 @@ describe('nlu manager utils unit tests', () => {
     });
 
     it('returns true if intent name is in array', () => {
-      expect(isUsedIntent(['test'], 'test')).to.eql(true);
+      expect(isUsedIntent(['test'], { key: 'abc', name: 'test' })).to.eql(true);
     });
 
-    it('returns false if intent name is not in array', () => {
-      expect(isUsedIntent(['test'], 'nope')).to.eql(false);
+    it('returns true if intent key is in array', () => {
+      expect(isUsedIntent(['abc'], { key: 'abc', name: 'test' })).to.eql(true);
+    });
+
+    it('returns false if intent name and key are not in array', () => {
+      expect(isUsedIntent(['nope'], { key: 'abc', name: 'test' })).to.eql(false);
     });
   });
 });

--- a/tests/lib/services/nlu/utils.unit.ts
+++ b/tests/lib/services/nlu/utils.unit.ts
@@ -1,13 +1,9 @@
 import { AlexaConstants } from '@voiceflow/alexa-types';
-import { BaseNode } from '@voiceflow/base-types';
-import { CommandType, EventType } from '@voiceflow/base-types/build/cjs/node/utils';
 import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import chai from 'chai';
 import sinon from 'sinon';
 
-import { getAvailableIntentsAndEntities, mapChannelData } from '@/lib/services/nlu/utils';
-
-import { getMockRuntime } from './fixture';
+import { isUsedIntent, mapChannelData } from '@/lib/services/nlu/utils';
 
 const { expect } = chai;
 
@@ -43,100 +39,21 @@ describe('nlu manager utils unit tests', () => {
     });
   });
 
-  describe('getAvailableIntentsAndEntities', () => {
-    const mockContext = { data: { api: sinon.stub() } };
-    const mockPizzaIntent = { type: EventType.INTENT, intent: 'Pizza', mappings: [{ slot: 'foo' }, { slot: 'bar' }] };
-    const mockYesIntent = { type: EventType.INTENT, intent: 'VF.YES', mappings: [{ slot: 'baz' }] };
-    const mockNoIntent = { type: EventType.INTENT, intent: 'VF.NO', mappings: [{ slot: 'qux' }] };
-
-    it('takes intersection when node is scoped', async () => {
-      const mockNodeInteractions = [{ event: mockPizzaIntent }, { event: mockYesIntent }, { event: mockNoIntent }];
-
-      const mockNode = {
-        interactions: mockNodeInteractions,
-        intentScope: BaseNode.Utils.IntentScope.NODE,
-      };
-
-      const mockCommands = [
-        {
-          type: CommandType.JUMP,
-          event: mockYesIntent,
-        },
-        {
-          type: CommandType.JUMP,
-          event: mockPizzaIntent,
-        },
-      ];
-
-      const runtimeClient = {
-        createRuntime: sinon.stub().returns(getMockRuntime(mockCommands, mockNode)),
-      };
-
-      const mockRuntimeManager = {
-        createClient: sinon.stub().returns(runtimeClient),
-      };
-
-      const { availableIntents, availableEntities } = await getAvailableIntentsAndEntities(
-        mockRuntimeManager as any,
-        mockContext as any
-      );
-
-      expect(availableIntents).to.eql(new Set(['VF.YES', 'Pizza']));
-      expect(availableEntities).to.eql(new Set(['baz', 'foo', 'bar']));
+  describe('isUsedIntent', () => {
+    it('returns true if intent array is undefined', () => {
+      expect(isUsedIntent(undefined, 'intent')).to.eql(true);
     });
 
-    it('ignores node level when intentScope is global', async () => {
-      const mockNodeInteractions = [
-        {
-          event: mockYesIntent,
-        },
-      ];
-
-      const mockNode = {
-        interactions: mockNodeInteractions,
-        intentScope: BaseNode.Utils.IntentScope.GLOBAL,
-      };
-
-      const mockCommands = [
-        {
-          type: CommandType.JUMP,
-          event: mockNoIntent,
-        },
-      ];
-
-      const runtimeClient = {
-        createRuntime: sinon.stub().returns(getMockRuntime(mockCommands, mockNode)),
-      };
-
-      const mockRuntimeManager = {
-        createClient: sinon.stub().returns(runtimeClient),
-      };
-
-      const { availableIntents, availableEntities } = await getAvailableIntentsAndEntities(
-        mockRuntimeManager as any,
-        mockContext as any
-      );
-
-      expect(availableIntents).to.eql(new Set(['VF.NO']));
-      expect(availableEntities).to.eql(new Set(['qux']));
+    it('returns false if intent name is undefined', () => {
+      expect(isUsedIntent(['test'], undefined)).to.eql(false);
     });
 
-    it('works with empty params', async () => {
-      const runtimeClient = {
-        createRuntime: sinon.stub().returns(getMockRuntime()),
-      };
+    it('returns true if intent name is in array', () => {
+      expect(isUsedIntent(['test'], 'test')).to.eql(true);
+    });
 
-      const mockRuntimeManager = {
-        createClient: sinon.stub().returns(runtimeClient),
-      };
-
-      const { availableIntents, availableEntities } = await getAvailableIntentsAndEntities(
-        mockRuntimeManager as any,
-        mockContext as any
-      );
-
-      expect(availableIntents).to.eql(new Set([]));
-      expect(availableEntities).to.eql(new Set([]));
+    it('returns false if intent name is not in array', () => {
+      expect(isUsedIntent(['test'], 'nope')).to.eql(false);
     });
   });
 });


### PR DESCRIPTION
With the introduction of the Intent CMS, we changed so every intent is trained. This means we can trigger an intent, but it won't do anything. It also means if they have a `None` intent trigger, it won't be triggered.

We still keep track of used intents in the survey context, so if we have it, we use it to treat unused intents as `None`.