### PR TITLE
build(arm): build for ARM at every stage (PL-000)

### DIFF
--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -75,6 +75,7 @@ jobs:
           image_repo: << pipeline.parameters.container-image-url >>
           target: checks
           no_cache_filter: checks
+          platforms: linux/amd64,linux/arm64
           # OR output: ci-reports
           output: type=local,dest=ci-reports
           extra_build_args: &node_version_arg NODE_VERSION={{ .values.node_version }}
@@ -110,6 +111,7 @@ jobs:
           image_repo: << pipeline.parameters.container-image-url >>
           image_tag: build
           target: build
+          platforms: linux/amd64,linux/arm64
           enable_cache_to: true
           extra_build_args: *node_version_arg
       - vfcommon/docker_run_networked:
@@ -132,11 +134,13 @@ jobs:
       - vfcommon/staged_buildx:
           image_repo: << pipeline.parameters.container-image-url >>
           target: "deps"
+          platforms: linux/amd64,linux/arm64
           enable_cache_to: false
           extra_build_args: *node_version_arg
       - vfcommon/staged_buildx:
           image_repo: << pipeline.parameters.container-image-url >>
           target: "build"
+          platforms: linux/amd64,linux/arm64
           enable_cache_to: true
           extra_build_args: *node_version_arg
 
@@ -180,7 +184,7 @@ workflows:
           component: << pipeline.parameters.track-component >>
           remote_docker_version: default
           extra_build_args: *node_version_arg
-          enable_cache_to: {{ eq .values.branch "master" }}
+          enable_cache_to: true
           {{- if $isMasterProd }}
           platform: linux/amd64,linux/arm64
           {{- else }}

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -132,13 +132,13 @@ jobs:
           docker_layer_caching: true
       - vfcommon/docker_login
       - vfcommon/authenticate_npm
-      - vfcommon/staged_buildx:
-          image_repo: << pipeline.parameters.container-image-url >>
-          target: "deps"
-          platforms: linux/amd64,linux/arm64
-          enable_cache_to: false
-          extra_build_args: *node_version_arg
-          output: type=image,name=<< pipeline.parameters.container-image-url >>-deps
+      ## - vfcommon/staged_buildx:
+      ##     image_repo: << pipeline.parameters.container-image-url >>
+      ##     target: "deps"
+      ##     platforms: linux/amd64,linux/arm64
+      ##     enable_cache_to: false
+      ##     extra_build_args: *node_version_arg
+      ##     output: type=image,name=<< pipeline.parameters.container-image-url >>-deps
       - vfcommon/staged_buildx:
           image_repo: << pipeline.parameters.container-image-url >>
           target: "build"

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -115,12 +115,15 @@ jobs:
           output: type=image,name=<< pipeline.parameters.container-image-url >>
           enable_cache_to: true
           extra_build_args: *node_version_arg
-      - vfcommon/docker_run_networked:
+      - vfcommon/staged_buildx:
           image_repo: << pipeline.parameters.container-image-url >>
-          image_tag: build
-          command: yarn test:integration
-          ## pre_steps: setup volume
-          ## post_steps: copy out artifacts
+          target: integration
+          no_cache_filter: integration
+          platforms: linux/amd64
+          output: type=local,dest=./
+          extra_build_args: *node_version_arg
+      - vfcommon/integration_tests:
+          wait: true
       - sonarcloud/scan
 
   install_and_buildx:

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -112,6 +112,7 @@ jobs:
           image_tag: build
           target: build
           platforms: linux/amd64,linux/arm64
+          output: type=image,name=<< pipeline.parameters.container-image-url >>
           enable_cache_to: true
           extra_build_args: *node_version_arg
       - vfcommon/docker_run_networked:
@@ -137,12 +138,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           enable_cache_to: false
           extra_build_args: *node_version_arg
+          output: type=image,name=<< pipeline.parameters.container-image-url >>-deps
       - vfcommon/staged_buildx:
           image_repo: << pipeline.parameters.container-image-url >>
           target: "build"
           platforms: linux/amd64,linux/arm64
           enable_cache_to: true
           extra_build_args: *node_version_arg
+          output: type=image,name=<< pipeline.parameters.container-image-url >>-build
 
 workflows:
   {{- if has $masterProdBranches .values.branch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ COPY --link --from=unit-tests /var/log/unit-tests.log /
 FROM sourced AS build
 RUN yarn build
 
+FROM scratch AS integration
+COPY --link --from=build /src/node_modules/ ./node_modules/
+
 FROM base AS prod
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,27 @@
 ARG NODE_VERSION=20.10
 FROM node:${NODE_VERSION}-alpine AS base
 WORKDIR /src
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 RUN \
-  --mount=type=cache,id=apk,target=/var/cache/apk,sharing=locked \
+  --mount=type=cache,sharing=locked,id=apk-$TARGETARCH$TARGETVARIANT,target=/var/cache/apk \
   apk add --no-cache dumb-init python3 make g++
 
 
 ## STAGE: deps
 FROM base AS deps
+ARG NPM_TOKEN
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 COPY --link package.json yarn.lock .yarnrc.yml ./
 COPY --link .yarn/ ./.yarn/
 
 RUN \
   --mount=type=secret,id=NPM_TOKEN \
-  --mount=type=cache,id=yarn,target=/src/.yarn/cache \
-  --mount=type=cache,id=home-yarn,target=/root/.yarn/berry \
+  --mount=type=cache,sharing=locked,id=yarn-$TARGETARCH$TARGETVARIANT,target=/src/.yarn/cache \
+  --mount=type=cache,sharing=locked,id=yarn-home-$TARGETARCH$TARGETVARIANT,target=/root/.yarn/berry \
   yarn config set -H 'npmRegistries["https://registry.yarnpkg.com"].npmAuthToken' "$(cat /run/secrets/NPM_TOKEN)" && \
   yarn install --immutable
 
@@ -50,14 +55,6 @@ COPY --link --from=unit-tests /var/log/unit-tests.log /
 FROM sourced AS build
 RUN yarn build
 
-## STAGE: prune
-FROM build AS prune
-RUN \
-  --mount=type=cache,id=yarn,target=/src/.yarn/cache \
-  yarn config unset -H npmRegistries && \
-  yarn cache clean
-
-
 FROM base AS prod
 WORKDIR /usr/src/app
 
@@ -71,8 +68,8 @@ ENV BUILD_NUM=${build_BUILD_NUM}
 ENV GIT_SHA=${build_GIT_SHA}
 ENV BUILD_URL=${build_BUILD_URL}
 
-COPY --link --from=prune /src/build/ ./
-COPY --link --from=prune /src/node_modules ./node_modules/
+COPY --link --from=build /src/build/ ./
+COPY --link --from=build /src/node_modules ./node_modules/
 
 ENTRYPOINT [ "dumb-init" ]
 CMD ["node", "--no-node-snapshot", "start.js"]


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->
- Build multi-platform images for linux/amd64, linux/arm64
- integration tests through orb but pulling node_modules from amd64 docker build for use by executor

`update_track` should probably run after `test` job, otherwise we're duping the build really