### PR TITLE
feat: Switch execution engine for Code Node (ENG-204)

### DIFF
--- a/runtime/lib/Handlers/code/index.ts
+++ b/runtime/lib/Handlers/code/index.ts
@@ -38,8 +38,8 @@ const CodeHandler: HandlerFactory<BaseNode.Code.Node, CodeOptions | void> = ({ e
         reqData.variables = { ...reqData.variables, [RESOLVED_PATH]: null };
         reqData.code = `${RESOLVED_PATH} = (function(){\n${reqData.code}\n})()`;
       }
-      let remoteVMVariableState = null;
-      let ivmExecuteVariableState = null;
+      let remoteVMVariableState: Record<string, any> | null = null;
+      let ivmExecuteVariableState: Record<string, any> | null = null;
       let remoteVMError = null;
       let ivmExecuteError = null;
       const useIvm = date > CUTOFF_DATE;
@@ -87,7 +87,7 @@ const CodeHandler: HandlerFactory<BaseNode.Code.Node, CodeOptions | void> = ({ e
       // both execution methods succeeded
       if (remoteVMVariableState && ivmExecuteVariableState) {
         const allEqual = Object.keys(remoteVMVariableState).every((key) =>
-          isDeepStrictEqual(remoteVMVariableState[key], ivmExecuteVariableState[key])
+          isDeepStrictEqual(remoteVMVariableState![key], ivmExecuteVariableState![key])
         );
         if (!allEqual) {
           // eslint-disable-next-line no-console

--- a/runtime/lib/Handlers/code/index.ts
+++ b/runtime/lib/Handlers/code/index.ts
@@ -2,7 +2,7 @@
 import { BaseNode, RuntimeLogs } from '@voiceflow/base-types';
 import safeJSONStringify from 'json-stringify-safe';
 import _ from 'lodash';
-import ObjectId from 'mongodb';
+import { ObjectId } from 'mongodb';
 import { isDeepStrictEqual } from 'util';
 
 import { HandlerFactory } from '@/runtime/lib/Handler';
@@ -40,7 +40,7 @@ const CodeHandler: HandlerFactory<BaseNode.Code.Node, CodeOptions | void> = ({ e
       }
 
       let newVariableState: Record<string, any>;
-      if (endpoint && date < CUTOFF_DATE.getTime()) {
+      if (endpoint && date < CUTOFF_DATE) {
         newVariableState = await utils.remoteVMExecute(endpoint, reqData);
       } else {
         newVariableState = await utils.ivmExecute(reqData, callbacks);

--- a/tests/runtime/lib/Runtime/JsExecute/index.unit.ts
+++ b/tests/runtime/lib/Runtime/JsExecute/index.unit.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+
+import * as utils from '../../../../../runtime/lib/Handlers/code/utils';
+
+const ENDPOINT = 'https://cjpsnfbb56.execute-api.us-east-1.amazonaws.com/dev/code/execute';
+describe('JsExecute unit tests', () => {
+  describe('remoteVMExecute', () => {
+    it('works', async () => {
+      const code = 'a = 5 * 3';
+      const variableState: Record<string, any> = { a: 0 };
+      const remoteVMVariableState = await utils.remoteVMExecute(ENDPOINT!, { code, variables: variableState });
+      expect(remoteVMVariableState).to.eql({ a: 15 });
+    });
+  });
+  describe('ivmExecute', () => {
+    it('works', async () => {
+      const code = 'a = 5 * 3';
+      const variableState: Record<string, any> = { a: 0 };
+      const remoteVMVariableState = await utils.ivmExecute({ code, variables: variableState });
+      expect(remoteVMVariableState).to.eql({ a: 15 });
+    });
+  });
+  describe('remoteVMExecute result comparison with ivmExecute', () => {
+    it('should be the same', async () => {
+      const code = 'a = 5 * 3';
+      const variableState: Record<string, any> = { a: 0 };
+      const remoteVMVariableState = await utils.remoteVMExecute(ENDPOINT!, { code, variables: variableState });
+      const ivmExecuteVariableState = await utils.ivmExecute({ code, variables: variableState });
+      expect(remoteVMVariableState).to.eql(ivmExecuteVariableState);
+    });
+  });
+});


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes ENG-204**

### Brief description. What is this change?

We want to switch the execution engine for Code Node from the old AWS lambda to use the new IVM isolate

### Implementation details. How do you make this change?

Added a cutoff date where all Code Node created after will use the new IVM isolate



### Checklist

- [x] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [x] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [x] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test