### PR TITLE
[Merged by Bors] - fix: add additional chaining to locales lookup (PL-1347)

### DIFF
--- a/lib/controllers/nlu.ts
+++ b/lib/controllers/nlu.ts
@@ -95,7 +95,7 @@ class NLUController extends AbstractController {
       },
       intentClassificationSettings,
       {
-        locale: version.prototype?.data.locales[0] as VoiceflowConstants.Locale,
+        locale: (version.prototype?.data?.locales?.[0] as VoiceflowConstants.Locale) ?? VoiceflowConstants.Locale.EN_US,
         hasChannelIntents: project?.platformData?.hasChannelIntents,
         platform: version?.prototype?.platform as VoiceflowConstants.PlatformType,
       }

--- a/lib/controllers/test/index.ts
+++ b/lib/controllers/test/index.ts
@@ -178,7 +178,7 @@ class TestController extends AbstractController {
       },
       data.intentClassificationSettings,
       {
-        locale: version.prototype?.data.locales[0] as VoiceflowConstants.Locale,
+        locale: (version.prototype?.data?.locales?.[0] as VoiceflowConstants.Locale) ?? VoiceflowConstants.Locale.EN_US,
         hasChannelIntents: project?.platformData?.hasChannelIntents,
         platform: version?.prototype?.platform as VoiceflowConstants.PlatformType,
         filteredIntents: Array.from(extraIntentNames),

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -179,7 +179,8 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
             },
             intentClassificationSettings,
             {
-              locale: version.prototype?.data.locales[0] as VoiceflowConstants.Locale,
+              locale:
+                (version.prototype?.data?.locales?.[0] as VoiceflowConstants.Locale) ?? VoiceflowConstants.Locale.EN_US,
               hasChannelIntents: project?.platformData?.hasChannelIntents,
               platform: version.prototype.platform as VoiceflowConstants.PlatformType,
             }

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -65,7 +65,7 @@ class NLU extends AbstractManager implements ContextHandler {
       },
       intentClassificationSettings,
       {
-        locale: version.prototype?.data.locales[0] as VoiceflowConstants.Locale,
+        locale: (version.prototype?.data?.locales?.[0] as VoiceflowConstants.Locale) ?? VoiceflowConstants.Locale.EN_US,
         hasChannelIntents: project?.platformData?.hasChannelIntents,
         platform: version?.prototype?.platform as VoiceflowConstants.PlatformType,
       }


### PR DESCRIPTION
Seeing some weird errors around accessing this `locales` property, even though it exists on the project data. Adding these optional chaining as a stop-gap while we investigate.