### PR TITLE
fix: allow production instances no unleash config (ENG-208)

### DIFF
--- a/lib/clients/unleash/index.ts
+++ b/lib/clients/unleash/index.ts
@@ -74,7 +74,7 @@ export class UnleashClient extends AbstractClient {
     try {
       await awaitInstanceReady(this.instance!);
     } catch (e) {
-      if (process.env.NODE_ENV !== 'local') {
+      if (this.instance) {
         throw new Error();
       }
 


### PR DESCRIPTION
If no env vars are set:
https://github.com/voiceflow/general-runtime/blob/5aa2cef79f5c519014b376f29d17f048655e9d6b/lib/clients/unleash/index.ts#L54-L58

instance never gets initialized, so we should not throw an error.