### PR TITLE
fix: force steps to use strict vm (ENG-209)

### DIFF
--- a/runtime/lib/Handlers/code/index.ts
+++ b/runtime/lib/Handlers/code/index.ts
@@ -11,13 +11,18 @@ import * as utils from './utils';
 export interface CodeOptions {
   endpoint?: string | null;
   callbacks?: Record<string, (...args: any) => any>;
+  useStrictVM?: boolean;
 }
 
 export const GENERATED_CODE_NODE_ID = 'PROGRAMMATICALLY-GENERATED-CODE-NODE';
 
 const RESOLVED_PATH = '__RESOLVED_PATH__';
 
-const CodeHandler: HandlerFactory<BaseNode.Code.Node, CodeOptions | void> = ({ endpoint, callbacks } = {}) => ({
+const CodeHandler: HandlerFactory<BaseNode.Code.Node, CodeOptions | void> = ({
+  endpoint,
+  callbacks,
+  useStrictVM = false,
+} = {}) => ({
   canHandle: (node) => typeof node.code === 'string',
   handle: async (node, runtime, variables) => {
     try {
@@ -34,7 +39,9 @@ const CodeHandler: HandlerFactory<BaseNode.Code.Node, CodeOptions | void> = ({ e
       }
 
       let newVariableState: Record<string, any>;
-      if (endpoint) {
+      if (useStrictVM) {
+        newVariableState = await utils.ivmExecute(reqData, callbacks);
+      } else if (endpoint) {
         newVariableState = await utils.remoteVMExecute(endpoint, reqData);
       } else {
         newVariableState = await utils.ivmExecute(reqData, callbacks);
@@ -92,7 +99,6 @@ const CodeHandler: HandlerFactory<BaseNode.Code.Node, CodeOptions | void> = ({ e
       if (node.paths?.length && resolvedPath) {
         // eslint-disable-next-line no-restricted-syntax
         for (const path of node.paths) {
-          // eslint-disable-next-line max-depth
           if (path.label === resolvedPath) {
             return path.nextId ?? null;
           }

--- a/runtime/lib/Handlers/ifV2.ts
+++ b/runtime/lib/Handlers/ifV2.ts
@@ -34,7 +34,7 @@ const IfV2Handler: HandlerFactory<BaseNode.IfV2.Node, IfV2Options> = ({ _v1 }) =
       debugErrors.push(err);
     };
 
-    const codeHandler = CodeHandler({ callbacks: { setOutputPort, addDebugError } });
+    const codeHandler = CodeHandler({ callbacks: { setOutputPort, addDebugError }, useStrictVM: true });
 
     let code = '';
     for (let i = 0; i < node.payload.expressions.length; i++) {

--- a/runtime/lib/Handlers/setV2.ts
+++ b/runtime/lib/Handlers/setV2.ts
@@ -9,7 +9,7 @@ export type SetV2Options = Record<string, never>;
 const SetV2Handler: HandlerFactory<BaseNode.SetV2.Node, SetV2Options | void> = () => ({
   canHandle: (node) => node.type === BaseNode.NodeType.SET_V2,
   handle: async (node, runtime, variables, program, eventHandler) => {
-    const codeHandler = CodeHandler();
+    const codeHandler = CodeHandler({ useStrictVM: true });
 
     const beforeValues: Map<string, any> = new Map();
 


### PR DESCRIPTION
we introduced a bit of a regression with this:
https://github.com/voiceflow/general-runtime/pull/776

This was the standard state before that PR:
https://github.com/voiceflow/general-runtime/blob/48cba2d4ac54b3d5da745111587d592cb96b66a6/runtime/lib/Handlers/ifV2.ts#L38

Right now the IfV2 and setV2 steps are also going into the code execute lambda and using VM2, we want it to use isolated-vm on general-runtime itself.