### PR TITLE
[Merged by Bors] - feat: update error messages (COR-2871)

### DIFF
--- a/lib/services/runtime/handlers/message/lib/conditions/expression.condition.ts
+++ b/lib/services/runtime/handlers/message/lib/conditions/expression.condition.ts
@@ -105,23 +105,17 @@ export class ExpressionCondition extends BaseCondition<CompiledExpressionConditi
       //           executes before the evaluated condition is fully computed.
       return await (this.condition.data.matchAll ? this.every(isolate) : this.some(isolate));
     } catch (err) {
-      if (err instanceof Error) {
-        this.logError(
-          `an unknown error occurred executing an expression condition, msg = ${err.message.substring(0, 200)}`
-        );
-      } else {
-        this.logError(
-          `an unknown error occurred executing an expression condition, details = ${JSON.stringify(
-            err,
-            null,
-            2
-          ).substring(0, 200)}`
-        );
-      }
+      const errMessage =
+        err instanceof Error
+          ? `Expression condition encountered an error and automatically resolved to 'false'. Details: ${err.message}`
+          : `Expression condition encountered an unexpected error and automatically resolved to 'false'. Details: ${JSON.stringify(
+              err,
+              null,
+              2
+            ).substring(0, 300)}`;
 
-      this.emitTraceMessage(
-        `Expression condition encountered an unexpected error and automatically resolved to 'false'`
-      );
+      this.logError(errMessage);
+      this.emitTraceMessage(errMessage);
 
       return false;
     } finally {

--- a/lib/services/runtime/handlers/message/lib/conditions/expression.condition.ts
+++ b/lib/services/runtime/handlers/message/lib/conditions/expression.condition.ts
@@ -67,38 +67,30 @@ export class ExpressionCondition extends BaseCondition<CompiledExpressionConditi
   }
 
   private async every(isolate: ConditionIsolate): Promise<boolean> {
-    this.emitTraceMessage('--- evaluating expression, matchAll = true ---');
-
     const assertionResults = await Promise.all(
       this.condition.data.assertions.map((assert) => this.evaluateAssertion(isolate, assert))
     );
     const result = assertionResults.every(Boolean);
 
-    this.emitTraceMessage(`--- evaluated expression, result = ${result} ---`);
-
     if (!result) {
       const firstFalse = assertionResults.findIndex((val) => !val);
       const assertion = this.condition.data.assertions[firstFalse];
-      this.emitTraceMessage(`- assertion '${this.formatAssertion(assertion)}' was false`);
+      this.emitTraceMessage(`Expression was false because '${this.formatAssertion(assertion)}' was false`);
     }
 
     return result;
   }
 
   private async some(isolate: ConditionIsolate): Promise<boolean> {
-    this.emitTraceMessage('--- evaluating expression, matchAll = false ---');
-
     const assertionResults = await Promise.all(
       this.condition.data.assertions.map((assert) => this.evaluateAssertion(isolate, assert))
     );
     const result = assertionResults.some(Boolean);
 
-    this.emitTraceMessage(`--- evaluated expression, result = ${result}`);
-
     if (result) {
       const firstTrue = assertionResults.findIndex((val) => val);
       const assertion = this.condition.data.assertions[firstTrue];
-      this.emitTraceMessage(`- assertion '${this.formatAssertion(assertion)}' was true`);
+      this.emitTraceMessage(`Expression was true because '${this.formatAssertion(assertion)}' was true`);
     }
 
     return result;
@@ -128,7 +120,7 @@ export class ExpressionCondition extends BaseCondition<CompiledExpressionConditi
       }
 
       this.emitTraceMessage(
-        `expression condition encountered an unexpected error and automatically resolved to 'false'`
+        `Expression condition encountered an unexpected error and automatically resolved to 'false'`
       );
 
       return false;

--- a/lib/services/runtime/handlers/message/lib/conditions/script.condition.ts
+++ b/lib/services/runtime/handlers/message/lib/conditions/script.condition.ts
@@ -6,20 +6,17 @@ import { ConditionIsolate } from './conditionIsolate';
 export class ScriptCondition extends BaseCondition<CompiledScriptCondition> {
   private async evaluateCode(isolate: ConditionIsolate, code: string): Promise<boolean> {
     const result = await isolate.executeFunction(code);
+
+    this.emitTraceMessage(`Script for condition returned value '${JSON.stringify(result)}'`);
+
     return !!result;
   }
 
   public async evaluate(): Promise<boolean> {
-    this.emitTraceMessage('--- evaluating script ---');
-
     const isolate = new ConditionIsolate(this.variables);
     try {
       await isolate.initialize();
-      const result = await this.evaluateCode(isolate, this.condition.data.code);
-
-      this.emitTraceMessage(`--- script evaluated to ${result} ---`);
-
-      return result;
+      return await this.evaluateCode(isolate, this.condition.data.code);
     } catch (err) {
       if (err instanceof Error) {
         this.logError(`an error occurred executing a script condition, msg = ${err.message}`);
@@ -32,7 +29,7 @@ export class ScriptCondition extends BaseCondition<CompiledScriptCondition> {
         );
       }
 
-      this.emitTraceMessage(`script condition encountered an unexpected error and automatically resolved to 'false'`);
+      this.emitTraceMessage(`Script condition encountered an unexpected error and automatically resolved to 'false'`);
 
       return false;
     } finally {

--- a/lib/services/runtime/handlers/message/lib/conditions/script.condition.ts
+++ b/lib/services/runtime/handlers/message/lib/conditions/script.condition.ts
@@ -7,9 +7,7 @@ export class ScriptCondition extends BaseCondition<CompiledScriptCondition> {
   private async evaluateCode(isolate: ConditionIsolate, code: string): Promise<boolean> {
     const result = await isolate.executeFunctionOrScript(code);
 
-    if (result !== true && result !== false) {
-      this.emitTraceMessage(`Script for condition returned value '${JSON.stringify(result)}'`);
-    }
+    this.emitTraceMessage(`Script for condition returned value '${JSON.stringify(result)}'`);
 
     return !!result;
   }

--- a/lib/services/runtime/handlers/message/lib/selectVariant.ts
+++ b/lib/services/runtime/handlers/message/lib/selectVariant.ts
@@ -1,5 +1,7 @@
 import { CompiledResponseMessage } from '@voiceflow/dtos';
+import { noop } from 'lodash';
 
+import { slateToPlaintext } from '../../../utils';
 import { BaseCondition } from './conditions/base.condition';
 
 interface VariantConditionPair {
@@ -7,7 +9,12 @@ interface VariantConditionPair {
   condition: BaseCondition | null;
 }
 
-export async function selectVariant(variants: VariantConditionPair[]): Promise<CompiledResponseMessage> {
+type Log = (message: string) => void;
+
+export async function selectVariant(
+  variants: VariantConditionPair[],
+  log: Log = noop
+): Promise<CompiledResponseMessage> {
   const [conditionedVariants, unconditionedVariants]: [VariantConditionPair[], VariantConditionPair[]] =
     variants.reduce(
       ([conditioned, unconditioned], pair) => {
@@ -26,11 +33,15 @@ export async function selectVariant(variants: VariantConditionPair[]): Promise<C
   for (const pair of conditionedVariants) {
     const isMatching = await pair.condition!.evaluate();
 
+    log(`Condition for variant '${slateToPlaintext(pair.variant.data.text)}' evaluated to '${isMatching}'`);
+
     if (isMatching) {
       return pair.variant;
     }
   }
   /* eslint-enable no-await-in-loop */
+
+  log(`All conditioned variants evaluated to false, selecting a random unconditioned variant`);
 
   const randomIndex = Math.floor(Math.random() * unconditionedVariants.length);
   return unconditionedVariants[randomIndex].variant;

--- a/lib/services/runtime/handlers/message/lib/selectVariant.ts
+++ b/lib/services/runtime/handlers/message/lib/selectVariant.ts
@@ -33,7 +33,12 @@ export async function selectVariant(
   for (const pair of conditionedVariants) {
     const isMatching = await pair.condition!.evaluate();
 
-    log(`Condition for variant with text '${slateToPlaintext(pair.variant.data.text)}' evaluated to '${isMatching}'`);
+    const notToken = isMatching ? '' : ' not';
+    log(
+      `Variant '${slateToPlaintext(pair.variant.data.text)}' was${notToken} used because its '${
+        pair.variant.condition?.type
+      }' condition evaluated to '${isMatching}'`
+    );
 
     if (isMatching) {
       return pair.variant;

--- a/lib/services/runtime/handlers/message/lib/selectVariant.ts
+++ b/lib/services/runtime/handlers/message/lib/selectVariant.ts
@@ -33,7 +33,7 @@ export async function selectVariant(
   for (const pair of conditionedVariants) {
     const isMatching = await pair.condition!.evaluate();
 
-    log(`Condition for variant '${slateToPlaintext(pair.variant.data.text)}' evaluated to '${isMatching}'`);
+    log(`Condition for variant with text '${slateToPlaintext(pair.variant.data.text)}' evaluated to '${isMatching}'`);
 
     if (isMatching) {
       return pair.variant;

--- a/lib/services/runtime/handlers/message/message.handler.ts
+++ b/lib/services/runtime/handlers/message/message.handler.ts
@@ -1,4 +1,3 @@
-import { Utils } from '@voiceflow/common';
 import {
   Channel,
   CompiledMessageNode,
@@ -68,10 +67,8 @@ export const MessageHandler: HandlerFactory<CompiledMessageNode> = () => ({
         );
       }
 
-      const executionId = Utils.id.cuid();
-      const composeMessage = (message: string) => `[${executionId}]: ${message}`;
-      const logToPrototype = (message: string) => runtime.trace.debug(composeMessage(message));
-      const logToObservability = (message: string) => log.error(composeMessage(message));
+      const logToPrototype = (message: string) => runtime.trace.debug(message);
+      const logToObservability = (message: string) => log.error(message);
       const preprocessedVariants = chosenDiscriminator.map((variant) => ({
         variant,
         condition: variant.condition
@@ -79,7 +76,7 @@ export const MessageHandler: HandlerFactory<CompiledMessageNode> = () => ({
           : null,
       }));
 
-      const chosenVariant = await selectVariant(preprocessedVariants);
+      const chosenVariant = await selectVariant(preprocessedVariants, logToPrototype);
 
       if (chosenVariant.data.text.length) {
         outputVariant(chosenVariant, node, runtime, variables);

--- a/tests/lib/services/runtime/handlers/message/lib/conditions/conditionIsolate.unit.ts
+++ b/tests/lib/services/runtime/handlers/message/lib/conditions/conditionIsolate.unit.ts
@@ -36,7 +36,7 @@ describe('ConditionIsolate', () => {
       const isolate = new ConditionIsolate(variables);
       await isolate.initialize();
 
-      const result = await isolate.executeFunction('return propA + propB + propC');
+      const result = await isolate.executeFunctionOrScript('return propA + propB + propC');
       await isolate.cleanup();
 
       expect(result).to.eql('1hellotrue');

--- a/tests/lib/services/runtime/handlers/message/lib/selectVariant.unit.ts
+++ b/tests/lib/services/runtime/handlers/message/lib/selectVariant.unit.ts
@@ -20,18 +20,15 @@ describe('selectVariant', () => {
       {
         variant: {
           data: {
-            text: {
-              id: 'su9b3lcm',
-              content: [
-                {
-                  children: [
-                    {
-                      text: 'Unconditioned variant A',
-                    },
-                  ],
-                },
-              ],
-            },
+            text: [
+              {
+                children: [
+                  {
+                    text: 'Unconditioned variant A',
+                  },
+                ],
+              },
+            ],
             delay: 137,
           },
           condition: null,
@@ -41,18 +38,15 @@ describe('selectVariant', () => {
       {
         variant: {
           data: {
-            text: {
-              id: 'su9b3lcm',
-              content: [
-                {
-                  children: [
-                    {
-                      text: 'Unconditioned variant B',
-                    },
-                  ],
-                },
-              ],
-            },
+            text: [
+              {
+                children: [
+                  {
+                    text: 'Unconditioned variant B',
+                  },
+                ],
+              },
+            ],
             delay: 137,
           },
           condition: null,
@@ -62,18 +56,15 @@ describe('selectVariant', () => {
       {
         variant: {
           data: {
-            text: {
-              id: 'su9b3lcm',
-              content: [
-                {
-                  children: [
-                    {
-                      text: 'Unconditioned variant C',
-                    },
-                  ],
-                },
-              ],
-            },
+            text: [
+              {
+                children: [
+                  {
+                    text: 'Unconditioned variant C',
+                  },
+                ],
+              },
+            ],
             delay: 137,
           },
           condition: null,
@@ -84,7 +75,7 @@ describe('selectVariant', () => {
 
     const selectedVariant = await selectVariant(variants);
 
-    expect(selectedVariant.data.text.content[0].children[0].text).to.oneOf([
+    expect(selectedVariant.data.text[0].children[0].text).to.oneOf([
       'Unconditioned variant A',
       'Unconditioned variant B',
       'Unconditioned variant C',
@@ -138,18 +129,15 @@ describe('selectVariant', () => {
       {
         variant: {
           data: {
-            text: {
-              id: 'su9b3lcm',
-              content: [
-                {
-                  children: [
-                    {
-                      text: 'Conditioned variant A',
-                    },
-                  ],
-                },
-              ],
-            },
+            text: [
+              {
+                children: [
+                  {
+                    text: 'Conditioned variant A',
+                  },
+                ],
+              },
+            ],
             delay: 137,
           },
           condition: falseCondition,
@@ -159,18 +147,15 @@ describe('selectVariant', () => {
       {
         variant: {
           data: {
-            text: {
-              id: 'su9b3lcm',
-              content: [
-                {
-                  children: [
-                    {
-                      text: 'Unconditioned variant A',
-                    },
-                  ],
-                },
-              ],
-            },
+            text: [
+              {
+                children: [
+                  {
+                    text: 'Unconditioned variant A',
+                  },
+                ],
+              },
+            ],
             delay: 137,
           },
           condition: null,
@@ -180,18 +165,15 @@ describe('selectVariant', () => {
       {
         variant: {
           data: {
-            text: {
-              id: 'su9b3lcm',
-              content: [
-                {
-                  children: [
-                    {
-                      text: 'Conditioned variant B',
-                    },
-                  ],
-                },
-              ],
-            },
+            text: [
+              {
+                children: [
+                  {
+                    text: 'Conditioned variant B',
+                  },
+                ],
+              },
+            ],
             delay: 137,
           },
           condition: trueConditionA,
@@ -201,18 +183,15 @@ describe('selectVariant', () => {
       {
         variant: {
           data: {
-            text: {
-              id: 'su9b3lcm',
-              content: [
-                {
-                  children: [
-                    {
-                      text: 'Unconditioned variant B',
-                    },
-                  ],
-                },
-              ],
-            },
+            text: [
+              {
+                children: [
+                  {
+                    text: 'Unconditioned variant B',
+                  },
+                ],
+              },
+            ],
             delay: 137,
           },
           condition: null,
@@ -222,18 +201,15 @@ describe('selectVariant', () => {
       {
         variant: {
           data: {
-            text: {
-              id: 'su9b3lcm',
-              content: [
-                {
-                  children: [
-                    {
-                      text: 'Conditioned variant C',
-                    },
-                  ],
-                },
-              ],
-            },
+            text: [
+              {
+                children: [
+                  {
+                    text: 'Conditioned variant C',
+                  },
+                ],
+              },
+            ],
             delay: 137,
           },
           condition: trueConditionB,
@@ -244,6 +220,6 @@ describe('selectVariant', () => {
 
     const selectedVariant = await selectVariant(variants);
 
-    expect(selectedVariant.data.text.content[0].children[0].text).to.eq('Conditioned variant B');
+    expect(selectedVariant.data.text[0].children[0].text).to.eq('Conditioned variant B');
   });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements COR-2871**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

Rework the error messaging for the Message step. 

Additionally, this PR reworks the Script Condition execution to fit with product's new requirements that the script condition shouldn't require the user to include a `return` statement, that is, all of these are valid and equivalent script condition code:
```js
const hello = 1;
1 + 2 == 3 + hello;
```
```js
const hello = 1;
return 1 + 2 == 3 + hello;
```

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

See notes

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->

N/A

### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

N/A

### Related PRs

<!-- List related PRs against other branches -->

- https://github.com/voiceflow/XXXXXXXXX/pull/123

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test