### PR TITLE
fix(build): catch and fail on unit test compilation errors (IN-1386)

### DIFF
--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -104,6 +104,7 @@ jobs:
                 command: |
                   set +o pipefail
                   cat ./ci-reports/unit-tests.log
+                  cat ./ci-reports/unit-tests.log | ( ! grep -qE "(Error: Cannot find module|Require stack:)" )
                   cat ./ci-reports/unit-tests.xml | grep 'failures="' | ( ! grep -qE 'failures="[1-9]+' )
                   set -o pipefail
       - vfcommon/staged_buildx:

--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -81,6 +81,8 @@ jobs:
           post_steps:
             - store_test_results:
                 path: ci-reports
+            - store_artifacts:
+                path: ci-reports
             - run:
                 name: ESLint
                 when: always


### PR DESCRIPTION
We were only checking the unit test results for test failures but not compilation failures in the test files.

- Add a check for "Error: Cannot find module" or "Require stack:" in the logs
- store test logs files as artifacts