### PR TITLE
[Merged by Bors] - feat: remove builtin intents in NLC (PL-1367)

### DIFF
--- a/lib/controllers/nlu.ts
+++ b/lib/controllers/nlu.ts
@@ -95,7 +95,6 @@ class NLUController extends AbstractController {
       },
       intentClassificationSettings,
       {
-        locale: (version.prototype?.data?.locales?.[0] as VoiceflowConstants.Locale) ?? VoiceflowConstants.Locale.EN_US,
         hasChannelIntents: project?.platformData?.hasChannelIntents,
         platform: version?.prototype?.platform as VoiceflowConstants.PlatformType,
       }

--- a/lib/controllers/test/index.ts
+++ b/lib/controllers/test/index.ts
@@ -178,7 +178,6 @@ class TestController extends AbstractController {
       },
       data.intentClassificationSettings,
       {
-        locale: (version.prototype?.data?.locales?.[0] as VoiceflowConstants.Locale) ?? VoiceflowConstants.Locale.EN_US,
         hasChannelIntents: project?.platformData?.hasChannelIntents,
         platform: version?.prototype?.platform as VoiceflowConstants.PlatformType,
         filteredIntents: Array.from(extraIntentNames),

--- a/lib/services/classification/interfaces/nlu.interface.ts
+++ b/lib/services/classification/interfaces/nlu.interface.ts
@@ -78,7 +78,6 @@ export interface PredictOptions {
   filteredEntities?: string[];
   // Legacy options for NLC
   hasChannelIntents?: boolean;
-  locale: VoiceflowConstants.Locale;
   platform: VoiceflowConstants.PlatformType;
 }
 

--- a/lib/services/classification/predictor.class.ts
+++ b/lib/services/classification/predictor.class.ts
@@ -99,7 +99,6 @@ export class Predictor extends EventEmitter {
         intents: this.props.intents,
         slots: this.props.slots ?? [],
       },
-      locale: this.options.locale,
       openSlot,
       dmRequest: this.props.dmRequest,
     });

--- a/lib/services/dialog/index.ts
+++ b/lib/services/dialog/index.ts
@@ -179,8 +179,6 @@ class DialogManagement extends AbstractManager<{ utils: typeof utils }> implemen
             },
             intentClassificationSettings,
             {
-              locale:
-                (version.prototype?.data?.locales?.[0] as VoiceflowConstants.Locale) ?? VoiceflowConstants.Locale.EN_US,
               hasChannelIntents: project?.platformData?.hasChannelIntents,
               platform: version.prototype.platform as VoiceflowConstants.PlatformType,
             }

--- a/lib/services/nlu/index.ts
+++ b/lib/services/nlu/index.ts
@@ -65,7 +65,6 @@ class NLU extends AbstractManager implements ContextHandler {
       },
       intentClassificationSettings,
       {
-        locale: (version.prototype?.data?.locales?.[0] as VoiceflowConstants.Locale) ?? VoiceflowConstants.Locale.EN_US,
         hasChannelIntents: project?.platformData?.hasChannelIntents,
         platform: version?.prototype?.platform as VoiceflowConstants.PlatformType,
       }

--- a/lib/services/nlu/nlc.ts
+++ b/lib/services/nlu/nlc.ts
@@ -1,7 +1,6 @@
 import { BaseModels, BaseRequest } from '@voiceflow/base-types';
 import { getUtterancesWithSlotNames } from '@voiceflow/common';
 import NLC, { IIntentFullfilment, IIntentSlot } from '@voiceflow/natural-language-commander';
-import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 
 import log from '@/logger';
 
@@ -95,29 +94,12 @@ export const registerIntents = (
   });
 };
 
-export const registerBuiltInIntents = (nlc: NLC, locale = VoiceflowConstants.Locale.EN_US) => {
-  const lang = locale.slice(0, 2);
-  const builtInIntents = VoiceflowConstants.DEFAULT_INTENTS_MAP[lang] || VoiceflowConstants.DEFAULT_INTENTS_MAP.en;
-
-  builtInIntents.forEach((intent) => {
-    const { name, samples } = intent;
-
-    try {
-      nlc.registerIntent({ intent: name, utterances: samples });
-    } catch (error) {
-      log.debug(`[app] [runtime] [nlc] unable to register built-in intent ${log.vars({ intent: name, error })}`);
-    }
-  });
-};
-
 export const createNLC = ({
   model,
-  locale,
   openSlot,
   dmRequest,
 }: {
   model: BaseModels.PrototypeModel;
-  locale: VoiceflowConstants.Locale;
   openSlot: boolean;
   dmRequest?: BaseRequest.IntentRequestPayload;
 }) => {
@@ -125,7 +107,6 @@ export const createNLC = ({
 
   registerSlots(nlc, model, openSlot);
   registerIntents(nlc, model, dmRequest);
-  registerBuiltInIntents(nlc, locale);
 
   return nlc;
 };
@@ -149,17 +130,15 @@ export const nlcToIntent = (intent: IIntentFullfilment | null, query = '', confi
 export const handleNLCCommand = ({
   query,
   model,
-  locale,
   openSlot = true,
   dmRequest,
 }: {
   query: string;
   model: BaseModels.PrototypeModel;
-  locale: VoiceflowConstants.Locale;
   openSlot: boolean;
   dmRequest?: BaseRequest.IntentRequestPayload;
 }): (IIntentFullfilment & { confidence: number }) | null => {
-  const nlc = createNLC({ model, locale, openSlot, dmRequest });
+  const nlc = createNLC({ model, openSlot, dmRequest });
 
   // ensure open slot is lower than the capture step threshold
   const confidence = openSlot ? 0.5 : 1;

--- a/tests/lib/services/classification/predictor.class.unit.ts
+++ b/tests/lib/services/classification/predictor.class.unit.ts
@@ -120,7 +120,6 @@ describe('predictor unit tests', () => {
     },
   };
   const defaultOptions: PredictOptions = {
-    locale: VoiceflowConstants.Locale.EN_US,
     hasChannelIntents: false,
     platform: VoiceflowConstants.PlatformType.VOICEFLOW,
   };

--- a/tests/lib/services/nlu/nlc.unit.ts
+++ b/tests/lib/services/nlu/nlc.unit.ts
@@ -1,18 +1,10 @@
 import { BaseRequest } from '@voiceflow/base-types';
 import * as NLC from '@voiceflow/natural-language-commander';
-import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
 import * as nlc from '@/lib/services/nlu/nlc';
-import {
-  createNLC,
-  handleNLCCommand,
-  nlcToIntent,
-  registerBuiltInIntents,
-  registerIntents,
-  registerSlots,
-} from '@/lib/services/nlu/nlc';
+import { createNLC, handleNLCCommand, nlcToIntent, registerIntents, registerSlots } from '@/lib/services/nlu/nlc';
 import * as utils from '@/lib/services/nlu/utils';
 
 import { customTypeSlots, regexMatcherSlots } from './fixture';
@@ -28,18 +20,15 @@ describe('nlu nlc service unit tests', () => {
       const NLCStub = sinon.stub(NLC, 'default').returns(nlcObj);
       const registerSlotsStub = sinon.stub(nlc, 'registerSlots');
       const registerIntentsStub = sinon.stub(nlc, 'registerIntents');
-      const registerBuiltInIntentsStub = sinon.stub(nlc, 'registerBuiltInIntents');
 
       const model = 'model';
-      const locale = 'locale';
       const openSlot = 'openSlot';
       const dmRequest = 'dmRequest';
 
-      expect(createNLC({ model, locale, openSlot, dmRequest } as any)).to.eql(nlcObj);
+      expect(createNLC({ model, openSlot, dmRequest } as any)).to.eql(nlcObj);
       expect(NLCStub.callCount).to.eql(1);
       expect(registerSlotsStub.args).to.eql([[nlcObj, model, openSlot]]);
       expect(registerIntentsStub.args).to.eql([[nlcObj, model, dmRequest]]);
-      expect(registerBuiltInIntentsStub.args).to.eql([[nlcObj, locale]]);
     });
   });
 
@@ -51,16 +40,14 @@ describe('nlu nlc service unit tests', () => {
 
       const query = 'query';
       const model = 'model';
-      const locale = 'locale';
       const dmRequest = 'dmRequest';
       const output = { ...commandRes, confidence: 0.5 };
 
-      expect(handleNLCCommand({ query, model, locale, dmRequest } as any)).to.eql(output);
+      expect(handleNLCCommand({ query, model, dmRequest } as any)).to.eql(output);
       expect(createNLCStub.args).to.eql([
         [
           {
             model,
-            locale,
             openSlot: true,
             dmRequest,
           },
@@ -76,17 +63,15 @@ describe('nlu nlc service unit tests', () => {
 
       const query = 'query';
       const model = 'model';
-      const locale = 'locale';
       const dmRequest = 'dmRequest';
 
       const output = { ...commandRes, confidence: 1 };
 
-      expect(handleNLCCommand({ query, model, locale, openSlot: false, dmRequest } as any)).to.eql(output);
+      expect(handleNLCCommand({ query, model, openSlot: false, dmRequest } as any)).to.eql(output);
       expect(createNLCStub.args).to.eql([
         [
           {
             model,
-            locale,
             openSlot: false,
             dmRequest,
           },
@@ -122,48 +107,6 @@ describe('nlu nlc service unit tests', () => {
           confidence,
         },
       });
-    });
-  });
-
-  describe('registerBuiltInIntents', () => {
-    it('language not supported', () => {
-      const locale = '00xx';
-      const nlcObj = {
-        registerIntent: sinon.stub().onFirstCall().throws('first call error'),
-      };
-
-      registerBuiltInIntents(nlcObj as any, locale as any);
-      const registerIntentArgs = VoiceflowConstants.DEFAULT_INTENTS_MAP.en.map(({ name, samples }) => [
-        { intent: name, utterances: samples },
-      ]);
-      expect(nlcObj.registerIntent.args).to.eql(registerIntentArgs);
-    });
-
-    it('no language', () => {
-      const nlcObj = {
-        registerIntent: sinon.stub().onFirstCall().throws('first call error'),
-      };
-
-      registerBuiltInIntents(nlcObj as any);
-      // eslint-disable-next-line sonarjs/no-identical-functions
-      const registerIntentArgs = VoiceflowConstants.DEFAULT_INTENTS_MAP.en.map(({ name, samples }) => [
-        { intent: name, utterances: samples },
-      ]);
-      expect(nlcObj.registerIntent.args).to.eql(registerIntentArgs);
-    });
-
-    it('language supported', () => {
-      const locale = 'español';
-      const nlcObj = {
-        registerIntent: sinon.stub().onFirstCall().throws('first call error'),
-      };
-
-      registerBuiltInIntents(nlcObj as any, locale as any);
-      // eslint-disable-next-line sonarjs/no-identical-functions
-      const registerIntentArgs = VoiceflowConstants.DEFAULT_INTENTS_MAP.es.map(({ name, samples }) => [
-        { intent: name, utterances: samples },
-      ]);
-      expect(nlcObj.registerIntent.args).to.eql(registerIntentArgs);
     });
   });
 


### PR DESCRIPTION
Built-in intents are a pretty old concept. With the introduction of the intent CMS, these are no longer needed. Only intents that exist in your project should be triggerable.